### PR TITLE
feat: trade history, local persistence, and performance analytics

### DIFF
--- a/agents/analytics.py
+++ b/agents/analytics.py
@@ -1,0 +1,452 @@
+"""Analytics agent — performance metrics and equity curve from local trade history."""
+
+import logging
+from datetime import date, timedelta
+from typing import Optional, List
+
+from rich.console import Console
+from rich.table import Table
+
+from tastytrade import Session, Account
+
+from utils.db import TradeDB
+
+
+class AnalyticsAgent:
+    """Computes and displays trading performance metrics from local DB."""
+
+    def __init__(self, session: Session, account_number: Optional[str] = None):
+        self.session = session
+        self.logger = logging.getLogger(__name__)
+        self.account_number = account_number
+        self.account: Optional[Account] = None
+
+    async def init(self) -> "AnalyticsAgent":
+        self.account = await self._get_account()
+        return self
+
+    async def _get_account(self) -> Optional[Account]:
+        try:
+            accounts = Account.get(self.session)
+            if not accounts:
+                return None
+            if self.account_number:
+                for acct in accounts:
+                    if getattr(acct, "account_number", None) == self.account_number:
+                        return acct
+                available = ", ".join(
+                    [getattr(a, "account_number", "?") for a in accounts]
+                )
+                raise ValueError(
+                    f"Account {self.account_number} not found. Available: {available}"
+                )
+            return accounts[0]
+        except Exception as e:
+            self.logger.error(f"Error fetching accounts: {e}")
+            return None
+
+    def _resolve_account_number(self) -> str:
+        return self.account_number or (
+            self.account.account_number if self.account else ""
+        )
+
+    def _parse_period(self, period: str) -> Optional[date]:
+        """Convert period string to start date. Returns None for 'all'."""
+        mapping = {
+            "1m": 30,
+            "3m": 90,
+            "6m": 180,
+            "1y": 365,
+            "2y": 730,
+        }
+        if period == "all":
+            return None
+        days = mapping.get(period, 90)
+        return date.today() - timedelta(days=days)
+
+    # --- Performance summary ---
+
+    def get_performance_summary(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> dict:
+        """Compute overall performance metrics from closed trade groups."""
+        db = TradeDB()
+        try:
+            acct = self._resolve_account_number()
+            sql = """
+                SELECT
+                    COUNT(*) as total_trades,
+                    SUM(CASE WHEN realized_pl > 0 THEN 1 ELSE 0 END) as winners,
+                    SUM(CASE WHEN realized_pl <= 0 THEN 1 ELSE 0 END) as losers,
+                    AVG(realized_pl) as avg_pl,
+                    SUM(realized_pl) as total_pl,
+                    SUM(total_fees) as total_fees,
+                    AVG(holding_days) as avg_holding_days,
+                    MAX(realized_pl) as largest_win,
+                    MIN(realized_pl) as largest_loss,
+                    SUM(CASE WHEN realized_pl > 0 THEN realized_pl ELSE 0 END) as gross_wins,
+                    SUM(CASE WHEN realized_pl < 0 THEN ABS(realized_pl) ELSE 0 END) as gross_losses,
+                    AVG(CASE WHEN realized_pl > 0 THEN realized_pl END) as avg_win,
+                    AVG(CASE WHEN realized_pl <= 0 THEN realized_pl END) as avg_loss
+                FROM trade_groups
+                WHERE account_number = ? AND status IN ('closed', 'expired', 'assigned')
+            """
+            params = [acct]
+
+            if start_date:
+                sql += " AND opened_at >= ?"
+                params.append(start_date)
+            if end_date:
+                sql += " AND closed_at <= ?"
+                params.append(end_date)
+
+            row = db.conn.execute(sql, params).fetchone()
+            if not row or row["total_trades"] == 0:
+                return {}
+
+            total = row["total_trades"]
+            winners = row["winners"] or 0
+            losers = row["losers"] or 0
+            win_rate = (winners / total * 100) if total > 0 else 0
+            gross_wins = row["gross_wins"] or 0
+            gross_losses = row["gross_losses"] or 0
+            profit_factor = (gross_wins / gross_losses) if gross_losses > 0 else float("inf")
+            avg_win = row["avg_win"] or 0
+            avg_loss = row["avg_loss"] or 0
+            expectancy = (win_rate / 100 * avg_win) + ((1 - win_rate / 100) * avg_loss)
+
+            return {
+                "total_trades": total,
+                "winners": winners,
+                "losers": losers,
+                "win_rate": win_rate,
+                "avg_win": avg_win,
+                "avg_loss": avg_loss,
+                "avg_pl": row["avg_pl"] or 0,
+                "total_pl": row["total_pl"] or 0,
+                "total_fees": row["total_fees"] or 0,
+                "profit_factor": profit_factor,
+                "avg_holding_days": row["avg_holding_days"] or 0,
+                "largest_win": row["largest_win"] or 0,
+                "largest_loss": row["largest_loss"] or 0,
+                "expectancy": expectancy,
+            }
+        finally:
+            db.close()
+
+    # --- Strategy breakdown ---
+
+    def get_strategy_performance(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> list[dict]:
+        """P/L broken down by strategy type."""
+        db = TradeDB()
+        try:
+            acct = self._resolve_account_number()
+            sql = """
+                SELECT
+                    COALESCE(strategy_type, 'Unknown') as strategy_type,
+                    COUNT(*) as trades,
+                    SUM(CASE WHEN realized_pl > 0 THEN 1 ELSE 0 END) as winners,
+                    AVG(realized_pl) as avg_pl,
+                    SUM(realized_pl) as total_pl,
+                    SUM(total_fees) as total_fees,
+                    AVG(holding_days) as avg_days
+                FROM trade_groups
+                WHERE account_number = ? AND status IN ('closed', 'expired', 'assigned')
+            """
+            params = [acct]
+            if start_date:
+                sql += " AND opened_at >= ?"
+                params.append(start_date)
+            if end_date:
+                sql += " AND closed_at <= ?"
+                params.append(end_date)
+
+            sql += " GROUP BY strategy_type ORDER BY total_pl DESC"
+
+            rows = db.conn.execute(sql, params).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            db.close()
+
+    # --- Roll chain P/L ---
+
+    def get_roll_chain_pl(self, group_id: int) -> dict:
+        """Walk parent_group_id chain to compute total P/L across all rolls."""
+        db = TradeDB()
+        try:
+            chain = db.get_roll_chain(group_id)
+            if not chain:
+                return {}
+
+            total_pl = sum(g["realized_pl"] or 0 for g in chain)
+            total_fees = sum(g["total_fees"] or 0 for g in chain)
+            total_collected = sum(g["total_premium_collected"] or 0 for g in chain)
+            total_paid = sum(g["total_premium_paid"] or 0 for g in chain)
+
+            first = chain[0]
+            last = chain[-1]
+            total_days = None
+            if first["opened_at"] and last.get("closed_at"):
+                from datetime import datetime
+                try:
+                    opened = datetime.fromisoformat(first["opened_at"])
+                    closed = datetime.fromisoformat(last["closed_at"])
+                    total_days = (closed - opened).days
+                except (ValueError, TypeError):
+                    pass
+
+            return {
+                "chain_length": len(chain),
+                "group_ids": [g["id"] for g in chain],
+                "underlying": first["underlying_symbol"],
+                "total_pl": total_pl,
+                "total_fees": total_fees,
+                "total_collected": total_collected,
+                "total_paid": total_paid,
+                "total_days": total_days,
+                "first_opened": first["opened_at"],
+                "last_closed": last.get("closed_at"),
+            }
+        finally:
+            db.close()
+
+    # --- Time-based P/L ---
+
+    def get_monthly_pl(
+        self, start_date: Optional[str] = None, end_date: Optional[str] = None
+    ) -> list[dict]:
+        return self._get_period_pl("month", start_date, end_date)
+
+    def get_weekly_pl(
+        self, start_date: Optional[str] = None, end_date: Optional[str] = None
+    ) -> list[dict]:
+        return self._get_period_pl("week", start_date, end_date)
+
+    def get_daily_pl(
+        self, start_date: Optional[str] = None, end_date: Optional[str] = None
+    ) -> list[dict]:
+        return self._get_period_pl("day", start_date, end_date)
+
+    def _get_period_pl(
+        self, period: str, start_date: Optional[str], end_date: Optional[str]
+    ) -> list[dict]:
+        db = TradeDB()
+        try:
+            acct = self._resolve_account_number()
+
+            if period == "month":
+                fmt = "%Y-%m"
+            elif period == "week":
+                fmt = "%Y-W%W"
+            else:
+                fmt = "%Y-%m-%d"
+
+            sql = f"""
+                SELECT
+                    strftime('{fmt}', closed_at) as period,
+                    COUNT(*) as trades,
+                    SUM(realized_pl) as pl,
+                    SUM(total_fees) as fees
+                FROM trade_groups
+                WHERE account_number = ? AND status IN ('closed', 'expired', 'assigned')
+                  AND closed_at IS NOT NULL
+            """
+            params = [acct]
+            if start_date:
+                sql += " AND closed_at >= ?"
+                params.append(start_date)
+            if end_date:
+                sql += " AND closed_at <= ?"
+                params.append(end_date)
+
+            sql += " GROUP BY period ORDER BY period"
+
+            rows = db.conn.execute(sql, params).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            db.close()
+
+    # --- Equity curve ---
+
+    async def get_equity_curve(self, time_back: str = "1y") -> list[dict]:
+        """Fetch NLV history from API."""
+        if not self.account:
+            return []
+        try:
+            history = self.account.get_net_liquidating_value_history(
+                self.session, time_back=time_back
+            )
+            results = []
+            for point in history:
+                results.append({
+                    "time": point.time.isoformat() if hasattr(point, "time") and point.time else str(point.time),
+                    "open": float(point.open) if hasattr(point, "open") else None,
+                    "high": float(point.high) if hasattr(point, "high") else None,
+                    "low": float(point.low) if hasattr(point, "low") else None,
+                    "close": float(point.close) if hasattr(point, "close") else None,
+                })
+            return results
+        except Exception as e:
+            self.logger.error(f"Error fetching equity curve: {e}")
+            return []
+
+    # --- Display methods ---
+
+    def print_performance(self, summary: dict, discord: bool = False) -> None:
+        if not summary:
+            print("No closed trades found. Run --sync first.")
+            return
+
+        console = Console(width=120)
+        table = Table(title="Performance Summary", show_lines=False)
+        table.add_column("Metric", style="bold")
+        table.add_column("Value", justify="right")
+
+        pl = summary["total_pl"]
+        pl_color = "green" if pl >= 0 else "red"
+
+        rows = [
+            ("Total Trades", str(summary["total_trades"])),
+            ("Winners / Losers", f"{summary['winners']} / {summary['losers']}"),
+            ("Win Rate", f"{summary['win_rate']:.1f}%"),
+            ("Avg Win", f"[green]${summary['avg_win']:,.2f}[/green]"),
+            ("Avg Loss", f"[red]${summary['avg_loss']:,.2f}[/red]"),
+            ("Avg P/L", f"${summary['avg_pl']:,.2f}"),
+            ("Total P/L", f"[{pl_color}]${pl:,.2f}[/{pl_color}]"),
+            ("Total Fees", f"${summary['total_fees']:,.2f}"),
+            ("Profit Factor", f"{summary['profit_factor']:.2f}" if summary["profit_factor"] != float("inf") else "N/A"),
+            ("Expectancy", f"${summary['expectancy']:,.2f}"),
+            ("Avg Holding Days", f"{summary['avg_holding_days']:.1f}"),
+            ("Largest Win", f"[green]${summary['largest_win']:,.2f}[/green]"),
+            ("Largest Loss", f"[red]${summary['largest_loss']:,.2f}[/red]"),
+        ]
+        for label, value in rows:
+            table.add_row(label, value)
+
+        console.print(table)
+
+    def print_strategy_breakdown(
+        self, strategies: list[dict], discord: bool = False
+    ) -> None:
+        if not strategies:
+            print("No strategy data found.")
+            return
+
+        console = Console(width=160)
+        table = Table(title="Performance by Strategy", show_lines=False)
+        table.add_column("Strategy", style="bold")
+        table.add_column("Trades", justify="right")
+        table.add_column("Win Rate", justify="right")
+        table.add_column("Avg P/L", justify="right")
+        table.add_column("Total P/L", justify="right")
+        table.add_column("Fees", justify="right", style="dim")
+        table.add_column("Avg Days", justify="right")
+
+        for s in strategies:
+            trades = s["trades"]
+            winners = s["winners"] or 0
+            wr = (winners / trades * 100) if trades > 0 else 0
+            pl = s["total_pl"] or 0
+            pl_color = "green" if pl >= 0 else "red"
+
+            table.add_row(
+                s["strategy_type"],
+                str(trades),
+                f"{wr:.0f}%",
+                f"${(s['avg_pl'] or 0):,.2f}",
+                f"[{pl_color}]${pl:,.2f}[/{pl_color}]",
+                f"${(s['total_fees'] or 0):,.2f}",
+                f"{(s['avg_days'] or 0):.0f}",
+            )
+
+        console.print(table)
+
+    def print_pl_summary(
+        self, periods: list[dict], period_type: str, discord: bool = False
+    ) -> None:
+        if not periods:
+            print(f"No {period_type} P/L data found.")
+            return
+
+        console = Console(width=120)
+        table = Table(title=f"P/L by {period_type.title()}", show_lines=False)
+        table.add_column("Period", style="cyan")
+        table.add_column("Trades", justify="right")
+        table.add_column("P/L", justify="right")
+        table.add_column("Fees", justify="right", style="dim")
+
+        cumulative = 0.0
+        for p in periods:
+            pl = p["pl"] or 0
+            cumulative += pl
+            color = "green" if pl >= 0 else "red"
+
+            table.add_row(
+                p["period"],
+                str(p["trades"]),
+                f"[{color}]${pl:,.2f}[/{color}]",
+                f"${(p['fees'] or 0):,.2f}",
+            )
+
+        console.print(table)
+
+        cum_color = "green" if cumulative >= 0 else "red"
+        console.print(f"\n  Cumulative P/L: [{cum_color}]${cumulative:,.2f}[/{cum_color}]")
+
+    def print_equity_curve(
+        self, data: list[dict], discord: bool = False
+    ) -> None:
+        if not data:
+            print("No equity curve data found.")
+            return
+
+        console = Console(width=140)
+        table = Table(title="Equity Curve (NLV History)", show_lines=False)
+        table.add_column("Date", style="cyan", no_wrap=True)
+        table.add_column("Open", justify="right")
+        table.add_column("High", justify="right", style="green")
+        table.add_column("Low", justify="right", style="red")
+        table.add_column("Close", justify="right", style="bold")
+        table.add_column("Change", justify="right")
+
+        prev_close = None
+        for point in data:
+            close = point["close"]
+            change_str = ""
+            if prev_close and close:
+                change = close - prev_close
+                pct = (change / prev_close) * 100
+                color = "green" if change >= 0 else "red"
+                change_str = f"[{color}]{change:+,.0f} ({pct:+.1f}%)[/{color}]"
+            prev_close = close
+
+            time_str = point["time"][:10] if point["time"] else ""
+
+            table.add_row(
+                time_str,
+                f"${point['open']:,.0f}" if point["open"] else "",
+                f"${point['high']:,.0f}" if point["high"] else "",
+                f"${point['low']:,.0f}" if point["low"] else "",
+                f"${close:,.0f}" if close else "",
+                change_str,
+            )
+
+        console.print(table)
+
+        # Summary
+        if len(data) >= 2 and data[0]["close"] and data[-1]["close"]:
+            start_val = data[0]["close"]
+            end_val = data[-1]["close"]
+            total_change = end_val - start_val
+            total_pct = (total_change / start_val) * 100
+            color = "green" if total_change >= 0 else "red"
+            console.print(
+                f"\n  Period: ${start_val:,.0f} -> ${end_val:,.0f} | "
+                f"Change: [{color}]{total_change:+,.0f} ({total_pct:+.1f}%)[/{color}]"
+            )

--- a/agents/analytics.py
+++ b/agents/analytics.py
@@ -96,7 +96,7 @@ class AnalyticsAgent:
             params = [acct]
 
             if start_date:
-                sql += " AND opened_at >= ?"
+                sql += " AND closed_at >= ?"
                 params.append(start_date)
             if end_date:
                 sql += " AND closed_at <= ?"
@@ -161,7 +161,7 @@ class AnalyticsAgent:
             """
             params = [acct]
             if start_date:
-                sql += " AND opened_at >= ?"
+                sql += " AND closed_at >= ?"
                 params.append(start_date)
             if end_date:
                 sql += " AND closed_at <= ?"

--- a/agents/history.py
+++ b/agents/history.py
@@ -1,6 +1,7 @@
-"""Account history and performance reporting."""
+"""Account history: performance reporting and transaction/order management."""
 
 import calendar
+import json
 import logging
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
@@ -8,8 +9,16 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from zoneinfo import ZoneInfo
 
+from rich.console import Console
+from rich.table import Table
+
 from tastytrade import Account, Session
+from tastytrade.account import Transaction
+from tastytrade.order import PlacedOrder, OrderStatus
 from tastytrade.utils import today_in_new_york
+
+from utils.db import TradeDB
+from utils.trade_grouper import TradeGrouper
 
 EXTERNAL_FLOW_SUBTYPES = {
     "ACAT",
@@ -316,3 +325,447 @@ class AccountHistoryAgent:
                 f"${_format_dollars(flow['amount'])} | {flow['description']}"
             )
         print(close_block)
+
+
+# ---------------------------------------------------------------------------
+# HistoryAgent — transaction/order history display and local SQLite sync
+# ---------------------------------------------------------------------------
+
+class HistoryAgent:
+    """Fetches and displays transaction and order history for an account."""
+
+    def __init__(self, session: Session, account_number: Optional[str] = None):
+        self.session = session
+        self.logger = logging.getLogger(__name__)
+        self.account_number = account_number
+        self.account: Optional[Account] = None
+
+    async def init(self) -> "HistoryAgent":
+        """Async initialization — call after creating instance."""
+        self.account = await self._get_account()
+        return self
+
+    async def _get_account(self) -> Optional[Account]:
+        try:
+            accounts = Account.get(self.session)
+            if not accounts:
+                return None
+
+            if self.account_number:
+                for acct in accounts:
+                    if getattr(acct, "account_number", None) == self.account_number:
+                        return acct
+                available = ", ".join(
+                    [getattr(a, "account_number", "?") for a in accounts]
+                )
+                raise ValueError(
+                    f"Account {self.account_number} not found. Available: {available}"
+                )
+
+            return accounts[0]
+        except Exception as e:
+            self.logger.error(f"Error fetching accounts: {e}")
+            return None
+
+    async def get_transactions(
+        self,
+        days: int = 30,
+        symbol: Optional[str] = None,
+        transaction_type: Optional[str] = None,
+    ) -> List[Transaction]:
+        """Fetch transaction history from the API."""
+        if not self.account:
+            return []
+        try:
+            start = date.today() - timedelta(days=days)
+            return self.account.get_history(
+                self.session,
+                page_offset=None,
+                sort="Desc",
+                start_date=start,
+                type=transaction_type,
+                underlying_symbol=symbol,
+            )
+        except Exception as e:
+            self.logger.error(f"Error fetching transactions: {e}")
+            return []
+
+    async def get_orders(
+        self,
+        days: int = 30,
+        symbol: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> List[PlacedOrder]:
+        """Fetch order history from the API."""
+        if not self.account:
+            return []
+        try:
+            start = date.today() - timedelta(days=days)
+            statuses = None
+            if status:
+                try:
+                    statuses = [OrderStatus(status)]
+                except ValueError:
+                    self.logger.warning(f"Unknown order status: {status}")
+
+            return self.account.get_order_history(
+                self.session,
+                page_offset=None,
+                sort="Desc",
+                start_date=start,
+                underlying_symbol=symbol,
+                statuses=statuses,
+            )
+        except Exception as e:
+            self.logger.error(f"Error fetching orders: {e}")
+            return []
+
+    def print_transactions(
+        self, transactions: List[Transaction], discord: bool = False
+    ) -> None:
+        """Display transactions in a Rich table."""
+        if not transactions:
+            print("No transactions found.")
+            return
+
+        console = Console(width=200)
+        table = Table(
+            title=f"Transaction History ({len(transactions)} records)",
+            show_lines=False,
+        )
+        table.add_column("Date", style="cyan", no_wrap=True)
+        table.add_column("Type", style="dim")
+        table.add_column("Symbol")
+        table.add_column("Underlying")
+        table.add_column("Action", style="bold")
+        table.add_column("Qty", justify="right")
+        table.add_column("Price", justify="right")
+        table.add_column("Value", justify="right")
+        table.add_column("Fees", justify="right", style="dim")
+        table.add_column("Order ID", style="dim", justify="right")
+
+        for txn in transactions:
+            total_fees = sum(
+                float(f or 0)
+                for f in [txn.commission, txn.clearing_fees, txn.regulatory_fees]
+            )
+            value = float(txn.net_value)
+            value_str = f"[green]${value:,.2f}[/green]" if value >= 0 else f"[red]${value:,.2f}[/red]"
+
+            table.add_row(
+                txn.executed_at.strftime("%Y-%m-%d %H:%M") if txn.executed_at else "",
+                txn.transaction_sub_type or txn.transaction_type,
+                txn.symbol or "",
+                txn.underlying_symbol or "",
+                str(txn.action.value) if txn.action else "",
+                f"{float(txn.quantity):g}" if txn.quantity else "",
+                f"${float(txn.price):,.2f}" if txn.price else "",
+                value_str,
+                f"${total_fees:,.2f}" if total_fees else "",
+                str(txn.order_id) if txn.order_id else "",
+            )
+
+        console.print(table)
+
+        trade_txns = [t for t in transactions if t.transaction_type == "Trade"]
+        if trade_txns:
+            total_value = sum(float(t.net_value) for t in trade_txns)
+            total_fees = sum(
+                sum(float(f or 0) for f in [t.commission, t.clearing_fees, t.regulatory_fees])
+                for t in trade_txns
+            )
+            color = "green" if total_value >= 0 else "red"
+            console.print(
+                f"\n  Trades: {len(trade_txns)} | "
+                f"Net Value: [{color}]${total_value:,.2f}[/{color}] | "
+                f"Total Fees: ${total_fees:,.2f}"
+            )
+
+    def print_orders(
+        self, orders: List[PlacedOrder], discord: bool = False
+    ) -> None:
+        """Display orders in a Rich table."""
+        if not orders:
+            print("No orders found.")
+            return
+
+        console = Console(width=200)
+        table = Table(
+            title=f"Order History ({len(orders)} orders)",
+            show_lines=True,
+        )
+        table.add_column("Date", style="cyan", no_wrap=True)
+        table.add_column("Status")
+        table.add_column("Underlying")
+        table.add_column("Type", style="dim")
+        table.add_column("Legs")
+        table.add_column("Size", justify="right")
+        table.add_column("Price", justify="right")
+        table.add_column("Value", justify="right")
+
+        for order in orders:
+            ts = order.terminal_at or order.received_at or order.updated_at
+            date_str = ts.strftime("%Y-%m-%d %H:%M") if ts else ""
+
+            status = order.status.value
+            if order.status == OrderStatus.FILLED:
+                status_str = f"[green]{status}[/green]"
+            elif order.status in (OrderStatus.CANCELLED, OrderStatus.REJECTED, OrderStatus.EXPIRED):
+                status_str = f"[red]{status}[/red]"
+            else:
+                status_str = f"[yellow]{status}[/yellow]"
+
+            leg_parts = []
+            for leg in order.legs:
+                action = leg.action.value if leg.action else "?"
+                qty = f"{int(leg.quantity)}" if leg.quantity else "?"
+                sym = leg.symbol or "?"
+                fills_str = ""
+                if leg.fills:
+                    avg_fill = sum(float(f.fill_price) for f in leg.fills) / len(leg.fills)
+                    fills_str = f" @ ${avg_fill:,.2f}"
+                leg_parts.append(f"{action} {qty}x {sym}{fills_str}")
+            legs_str = "\n".join(leg_parts)
+
+            price = float(order.price) if order.price else None
+            value = float(order.value) if order.value else None
+
+            table.add_row(
+                date_str,
+                status_str,
+                order.underlying_symbol or "",
+                order.order_type.value if order.order_type else "",
+                legs_str,
+                str(int(order.size)) if order.size else "",
+                f"${price:,.2f}" if price is not None else "",
+                f"${value:,.2f}" if value is not None else "",
+            )
+
+        console.print(table)
+
+    # --- Sync and local storage ---
+
+    async def sync(self, full: bool = False) -> dict:
+        """Sync transaction and order history to local SQLite DB.
+
+        Args:
+            full: If True, re-sync everything. If False, incremental from watermark.
+
+        Returns:
+            dict with counts: {"transactions": N, "orders": M, "groups": G}
+        """
+        if not self.account:
+            return {"transactions": 0, "orders": 0, "groups": 0}
+
+        db = TradeDB()
+        acct_num = self.account.account_number
+
+        try:
+            sync_state = db.get_sync_state(acct_num)
+
+            txn_start_date = None
+            if not full and sync_state["last_sync_at"]:
+                last = datetime.fromisoformat(sync_state["last_sync_at"])
+                txn_start_date = (last - timedelta(days=1)).date()
+
+            transactions = self.account.get_history(
+                self.session,
+                page_offset=None,
+                sort="Asc",
+                start_date=txn_start_date,
+            )
+
+            txn_dicts = []
+            max_txn_id = sync_state["last_transaction_id"] or 0
+            for txn in transactions:
+                d = self._serialize_transaction(txn)
+                txn_dicts.append(d)
+                if d["id"] > max_txn_id:
+                    max_txn_id = d["id"]
+
+            txn_count = db.upsert_transactions(txn_dicts)
+
+            orders = self.account.get_order_history(
+                self.session,
+                page_offset=None,
+                sort="Asc",
+                start_date=txn_start_date,
+            )
+
+            order_dicts = []
+            max_order_id = sync_state["last_order_id"] or 0
+            for order in orders:
+                d = self._serialize_order(order)
+                order_dicts.append(d)
+                if d["id"] > max_order_id:
+                    max_order_id = d["id"]
+
+            order_count = db.upsert_orders(order_dicts)
+
+            db.update_sync_state(acct_num, max_txn_id, max_order_id)
+
+            grouper = TradeGrouper(db)
+            group_count = grouper.build_groups(acct_num)
+
+            return {
+                "transactions": txn_count,
+                "orders": order_count,
+                "groups": group_count,
+            }
+        finally:
+            db.close()
+
+    def _serialize_transaction(self, txn: Transaction) -> dict:
+        """Convert a Transaction SDK object to a dict for storage."""
+        return {
+            "id": txn.id,
+            "account_number": txn.account_number,
+            "transaction_type": txn.transaction_type,
+            "transaction_sub_type": txn.transaction_sub_type,
+            "description": txn.description,
+            "executed_at": txn.executed_at.isoformat() if txn.executed_at else None,
+            "transaction_date": txn.transaction_date.isoformat() if txn.transaction_date else None,
+            "value": float(txn.value),
+            "net_value": float(txn.net_value),
+            "is_estimated_fee": txn.is_estimated_fee,
+            "symbol": txn.symbol,
+            "instrument_type": txn.instrument_type.value if txn.instrument_type else None,
+            "underlying_symbol": txn.underlying_symbol,
+            "action": txn.action.value if txn.action else None,
+            "quantity": float(txn.quantity) if txn.quantity else None,
+            "price": float(txn.price) if txn.price else None,
+            "regulatory_fees": float(txn.regulatory_fees) if txn.regulatory_fees else None,
+            "clearing_fees": float(txn.clearing_fees) if txn.clearing_fees else None,
+            "commission": float(txn.commission) if txn.commission else None,
+            "order_id": txn.order_id,
+        }
+
+    def _serialize_order(self, order: PlacedOrder) -> dict:
+        """Convert a PlacedOrder SDK object to a dict for storage."""
+        legs = []
+        for leg in order.legs:
+            leg_dict = {
+                "instrument_type": leg.instrument_type.value if leg.instrument_type else None,
+                "symbol": leg.symbol,
+                "action": leg.action.value if leg.action else None,
+                "quantity": float(leg.quantity) if leg.quantity else None,
+                "remaining_quantity": float(leg.remaining_quantity) if leg.remaining_quantity else None,
+            }
+            if leg.fills:
+                leg_dict["fills"] = [
+                    {
+                        "fill_id": f.fill_id,
+                        "quantity": float(f.quantity),
+                        "fill_price": float(f.fill_price),
+                        "filled_at": f.filled_at.isoformat() if f.filled_at else None,
+                    }
+                    for f in leg.fills
+                ]
+            legs.append(leg_dict)
+
+        return {
+            "id": order.id,
+            "account_number": order.account_number,
+            "time_in_force": order.time_in_force.value if order.time_in_force else None,
+            "order_type": order.order_type.value if order.order_type else None,
+            "underlying_symbol": order.underlying_symbol,
+            "underlying_instrument_type": order.underlying_instrument_type.value if order.underlying_instrument_type else None,
+            "status": order.status.value,
+            "size": float(order.size) if order.size else None,
+            "price": float(order.price) if order.price else None,
+            "value": float(order.value) if order.value else None,
+            "received_at": order.received_at.isoformat() if order.received_at else None,
+            "terminal_at": order.terminal_at.isoformat() if order.terminal_at else None,
+            "cancelled_at": order.cancelled_at.isoformat() if order.cancelled_at else None,
+            "replacing_order_id": order.replacing_order_id,
+            "replaces_order_id": order.replaces_order_id,
+            "legs": legs,
+        }
+
+    def print_trade_groups(
+        self,
+        account_number: str,
+        underlying: Optional[str] = None,
+        status: Optional[str] = None,
+        discord: bool = False,
+    ) -> None:
+        """Display trade groups from local DB."""
+        db = TradeDB()
+        try:
+            groups = db.get_trade_groups(account_number, underlying, status)
+            if not groups:
+                print("No trade groups found. Run --sync first.")
+                return
+
+            console = Console(width=200)
+            table = Table(
+                title=f"Trade Groups ({len(groups)} trades)",
+                show_lines=True,
+            )
+            table.add_column("ID", style="dim", justify="right")
+            table.add_column("Underlying", style="bold")
+            table.add_column("Strategy")
+            table.add_column("Status")
+            table.add_column("Opened", style="cyan", no_wrap=True)
+            table.add_column("Closed", style="cyan", no_wrap=True)
+            table.add_column("Days", justify="right")
+            table.add_column("Collected", justify="right", style="green")
+            table.add_column("Paid", justify="right", style="red")
+            table.add_column("Fees", justify="right", style="dim")
+            table.add_column("P/L", justify="right")
+            table.add_column("Chain", style="dim")
+
+            for g in groups:
+                pl = g["realized_pl"]
+                if pl is not None:
+                    pl_str = f"[green]${pl:,.2f}[/green]" if pl >= 0 else f"[red]${pl:,.2f}[/red]"
+                else:
+                    pl_str = ""
+
+                status_val = g["status"]
+                if status_val == "closed":
+                    status_str = f"[green]{status_val}[/green]"
+                elif status_val == "open":
+                    status_str = f"[yellow]{status_val}[/yellow]"
+                else:
+                    status_str = f"[cyan]{status_val}[/cyan]"
+
+                chain_str = ""
+                if g["parent_group_id"]:
+                    chain = db.get_roll_chain(g["id"])
+                    chain_ids = [str(c["id"]) for c in chain]
+                    chain_str = " -> ".join(chain_ids)
+
+                opened = g["opened_at"][:10] if g["opened_at"] else ""
+                closed = g["closed_at"][:10] if g["closed_at"] else ""
+
+                table.add_row(
+                    str(g["id"]),
+                    g["underlying_symbol"],
+                    g["strategy_type"] or "",
+                    status_str,
+                    opened,
+                    closed,
+                    str(g["holding_days"]) if g["holding_days"] is not None else "",
+                    f"${g['total_premium_collected']:,.2f}" if g["total_premium_collected"] else "",
+                    f"${g['total_premium_paid']:,.2f}" if g["total_premium_paid"] else "",
+                    f"${g['total_fees']:,.2f}" if g["total_fees"] else "",
+                    pl_str,
+                    chain_str,
+                )
+
+            console.print(table)
+
+            closed_groups = [g for g in groups if g["status"] != "open"]
+            if closed_groups:
+                total_pl = sum(g["realized_pl"] or 0 for g in closed_groups)
+                winners = sum(1 for g in closed_groups if (g["realized_pl"] or 0) > 0)
+                losers = len(closed_groups) - winners
+                color = "green" if total_pl >= 0 else "red"
+                console.print(
+                    f"\n  Closed: {len(closed_groups)} | "
+                    f"W/L: {winners}/{losers} | "
+                    f"Total P/L: [{color}]${total_pl:,.2f}[/{color}]"
+                )
+        finally:
+            db.close()

--- a/main.py
+++ b/main.py
@@ -39,6 +39,22 @@ def setup_argument_parser() -> argparse.ArgumentParser:
         help="Review account performance for a specific calendar month",
     )
     parser.add_argument("--menu", action="store_true", help="Open the interactive command menu")
+    parser.add_argument("--transactions", action="store_true", help="Show recent transaction history")
+    parser.add_argument("--orders", action="store_true", help="Show recent order history")
+    parser.add_argument("--days", type=int, default=30, help="Days to look back (default: 30, use with --transactions/--orders)")
+    parser.add_argument("--symbol", type=str, help="Filter by underlying symbol (use with --transactions/--orders)")
+    parser.add_argument("--type", type=str, dest="txn_type", help="Filter transaction type: Trade, 'Receive Deliver', etc.")
+    parser.add_argument("--sync", action="store_true", help="Sync trade history to local database")
+    parser.add_argument("--sync-full", action="store_true", help="Full re-sync of trade history")
+    parser.add_argument("--trades", action="store_true", help="Show trade groups from local DB")
+    parser.add_argument("--trade", type=str, metavar="SYMBOL", help="Show trade groups for a specific underlying")
+    parser.add_argument("--performance", action="store_true", help="Show trading performance summary")
+    parser.add_argument("--performance-by-strategy", action="store_true", help="Show performance broken down by strategy type")
+    parser.add_argument("--pl-daily", action="store_true", help="Show daily P/L summary")
+    parser.add_argument("--pl-weekly", action="store_true", help="Show weekly P/L summary")
+    parser.add_argument("--pl-monthly", action="store_true", help="Show monthly P/L summary")
+    parser.add_argument("--equity-curve", action="store_true", help="Show NLV equity curve")
+    parser.add_argument("--period", type=str, default="3m", help="Time period: 1m, 3m, 6m, 1y, all (default: 3m, use with --performance/--pl-*/--equity-curve)")
     parser.add_argument("--review-position", type=str, metavar="SYMBOL", help="Review position and show roll scenarios for underlying (e.g. --review-position SLV)")
     parser.add_argument("--output", "-o", type=str, help="Output file path for JSON export (use with --review-position)")
     parser.add_argument("--discord", "-d", action="store_true", help="Format output for Discord")
@@ -181,6 +197,100 @@ async def async_main() -> int:
                 month=args.history_month,
             )
             history.print_performance_report(report, discord=args.discord)
+            return 0
+
+        if args.transactions:
+            from agents.history import HistoryAgent
+
+            print(f"\nFetching transaction history (last {args.days} days)...")
+            history = await HistoryAgent(session, account_number=account_number).init()
+            transactions = await history.get_transactions(
+                days=args.days,
+                symbol=args.symbol,
+                transaction_type=args.txn_type,
+            )
+            history.print_transactions(transactions, discord=args.discord)
+            return 0
+
+        if args.orders:
+            from agents.history import HistoryAgent
+
+            print(f"\nFetching order history (last {args.days} days)...")
+            history = await HistoryAgent(session, account_number=account_number).init()
+            orders = await history.get_orders(
+                days=args.days,
+                symbol=args.symbol,
+            )
+            history.print_orders(orders, discord=args.discord)
+            return 0
+
+        if args.sync or args.sync_full:
+            from agents.history import HistoryAgent
+
+            mode = "full" if args.sync_full else "incremental"
+            print(f"\nSyncing trade history ({mode})...")
+            history = await HistoryAgent(session, account_number=account_number).init()
+            result = await history.sync(full=args.sync_full)
+            print(
+                f"Synced: {result['transactions']} transactions, "
+                f"{result['orders']} orders, "
+                f"{result['groups']} new trade groups"
+            )
+            return 0
+
+        if args.trades or args.trade:
+            from agents.history import HistoryAgent
+
+            history = await HistoryAgent(session, account_number=account_number).init()
+            acct = account_number or (history.account.account_number if history.account else "")
+            history.print_trade_groups(
+                acct,
+                underlying=args.trade,
+                discord=args.discord,
+            )
+            return 0
+
+        if args.performance or args.performance_by_strategy:
+            from agents.analytics import AnalyticsAgent
+
+            analytics = await AnalyticsAgent(session, account_number=account_number).init()
+            start = analytics._parse_period(args.period)
+            start_str = start.isoformat() if start else None
+
+            if args.performance_by_strategy:
+                strategies = analytics.get_strategy_performance(start_date=start_str)
+                analytics.print_strategy_breakdown(strategies, discord=args.discord)
+            else:
+                summary = analytics.get_performance_summary(start_date=start_str)
+                analytics.print_performance(summary, discord=args.discord)
+            return 0
+
+        if args.pl_daily or args.pl_weekly or args.pl_monthly:
+            from agents.analytics import AnalyticsAgent
+
+            analytics = await AnalyticsAgent(session, account_number=account_number).init()
+            start = analytics._parse_period(args.period)
+            start_str = start.isoformat() if start else None
+
+            if args.pl_daily:
+                data = analytics.get_daily_pl(start_date=start_str)
+                analytics.print_pl_summary(data, "day", discord=args.discord)
+            elif args.pl_weekly:
+                data = analytics.get_weekly_pl(start_date=start_str)
+                analytics.print_pl_summary(data, "week", discord=args.discord)
+            else:
+                data = analytics.get_monthly_pl(start_date=start_str)
+                analytics.print_pl_summary(data, "month", discord=args.discord)
+            return 0
+
+        if args.equity_curve:
+            from agents.analytics import AnalyticsAgent
+
+            analytics = await AnalyticsAgent(session, account_number=account_number).init()
+            time_back_map = {"1m": "1m", "3m": "3m", "6m": "6m", "1y": "1y", "2y": "2y", "all": "all"}
+            time_back = time_back_map.get(args.period, "1y")
+            data = await analytics.get_equity_curve(time_back=time_back)
+            analytics.print_equity_curve(data, discord=args.discord)
             return 0
 
         if args.review_position:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,160 @@
+"""Tests for the analytics agent."""
+
+import unittest
+from pathlib import Path
+from utils.db import TradeDB
+
+
+class TestAnalyticsQueries(unittest.TestCase):
+    """Test analytics SQL queries directly against seeded data."""
+
+    def setUp(self):
+        self.db = TradeDB(db_path=Path(":memory:"))
+        self._seed_data()
+
+    def tearDown(self):
+        self.db.close()
+
+    def _seed_data(self):
+        """Seed trade groups for analytics testing."""
+        # Winner: SPY vertical, +$100
+        g1 = self.db.create_trade_group(
+            "ABC", "SPY", strategy_type="Vertical", opened_at="2024-01-15T10:00:00"
+        )
+        self.db.update_trade_group(
+            g1, status="closed", closed_at="2024-01-25T10:00:00",
+            total_premium_collected=200.0, total_premium_paid=100.0,
+            total_fees=2.0, realized_pl=100.0, holding_days=10,
+        )
+
+        # Loser: AAPL vertical, -$50
+        g2 = self.db.create_trade_group(
+            "ABC", "AAPL", strategy_type="Vertical", opened_at="2024-02-01T10:00:00"
+        )
+        self.db.update_trade_group(
+            g2, status="closed", closed_at="2024-02-15T10:00:00",
+            total_premium_collected=80.0, total_premium_paid=130.0,
+            total_fees=2.0, realized_pl=-50.0, holding_days=14,
+        )
+
+        # Winner: TSLA iron condor, +$200
+        g3 = self.db.create_trade_group(
+            "ABC", "TSLA", strategy_type="Iron Condor", opened_at="2024-02-10T10:00:00"
+        )
+        self.db.update_trade_group(
+            g3, status="expired", closed_at="2024-03-15T16:00:00",
+            total_premium_collected=200.0, total_premium_paid=0.0,
+            total_fees=4.0, realized_pl=200.0, holding_days=34,
+        )
+
+        # Open position (should be excluded from closed analytics)
+        g4 = self.db.create_trade_group(
+            "ABC", "QQQ", strategy_type="Vertical", opened_at="2024-03-01T10:00:00"
+        )
+
+    def test_performance_summary(self):
+        row = self.db.conn.execute("""
+            SELECT
+                COUNT(*) as total,
+                SUM(CASE WHEN realized_pl > 0 THEN 1 ELSE 0 END) as winners,
+                SUM(CASE WHEN realized_pl <= 0 THEN 1 ELSE 0 END) as losers,
+                SUM(realized_pl) as total_pl
+            FROM trade_groups
+            WHERE account_number = 'ABC' AND status IN ('closed', 'expired', 'assigned')
+        """).fetchone()
+
+        self.assertEqual(row["total"], 3)
+        self.assertEqual(row["winners"], 2)
+        self.assertEqual(row["losers"], 1)
+        self.assertAlmostEqual(row["total_pl"], 250.0)
+
+    def test_strategy_breakdown(self):
+        rows = self.db.conn.execute("""
+            SELECT
+                strategy_type,
+                COUNT(*) as trades,
+                SUM(realized_pl) as total_pl
+            FROM trade_groups
+            WHERE account_number = 'ABC' AND status IN ('closed', 'expired', 'assigned')
+            GROUP BY strategy_type
+            ORDER BY total_pl DESC
+        """).fetchall()
+
+        strategies = {r["strategy_type"]: r for r in rows}
+        self.assertIn("Vertical", strategies)
+        self.assertIn("Iron Condor", strategies)
+        self.assertEqual(strategies["Vertical"]["trades"], 2)
+        self.assertEqual(strategies["Iron Condor"]["trades"], 1)
+        self.assertAlmostEqual(strategies["Iron Condor"]["total_pl"], 200.0)
+
+    def test_monthly_pl(self):
+        rows = self.db.conn.execute("""
+            SELECT
+                strftime('%Y-%m', closed_at) as period,
+                COUNT(*) as trades,
+                SUM(realized_pl) as pl
+            FROM trade_groups
+            WHERE account_number = 'ABC' AND status IN ('closed', 'expired', 'assigned')
+              AND closed_at IS NOT NULL
+            GROUP BY period
+            ORDER BY period
+        """).fetchall()
+
+        self.assertEqual(len(rows), 3)
+        periods = {r["period"]: r for r in rows}
+        self.assertAlmostEqual(periods["2024-01"]["pl"], 100.0)
+        self.assertAlmostEqual(periods["2024-02"]["pl"], -50.0)
+        self.assertAlmostEqual(periods["2024-03"]["pl"], 200.0)
+
+    def test_excludes_open_positions(self):
+        row = self.db.conn.execute("""
+            SELECT COUNT(*) as cnt FROM trade_groups
+            WHERE account_number = 'ABC' AND status IN ('closed', 'expired', 'assigned')
+        """).fetchone()
+        self.assertEqual(row["cnt"], 3)  # QQQ open position excluded
+
+    def test_date_filtering(self):
+        row = self.db.conn.execute("""
+            SELECT COUNT(*) as cnt FROM trade_groups
+            WHERE account_number = 'ABC' AND status IN ('closed', 'expired', 'assigned')
+              AND opened_at >= '2024-02-01'
+        """).fetchone()
+        self.assertEqual(row["cnt"], 2)  # AAPL + TSLA
+
+    def test_roll_chain_pl(self):
+        # Create a roll chain: g5 -> g6 -> g7
+        g5 = self.db.create_trade_group(
+            "ABC", "IWM", strategy_type="Vertical", opened_at="2024-01-01"
+        )
+        self.db.update_trade_group(
+            g5, status="closed", closed_at="2024-01-15",
+            realized_pl=50.0, total_fees=1.0,
+        )
+
+        g6 = self.db.create_trade_group(
+            "ABC", "IWM", strategy_type="Vertical",
+            opened_at="2024-01-15", parent_group_id=g5,
+        )
+        self.db.update_trade_group(
+            g6, status="closed", closed_at="2024-02-01",
+            realized_pl=-20.0, total_fees=1.0,
+        )
+
+        g7 = self.db.create_trade_group(
+            "ABC", "IWM", strategy_type="Vertical",
+            opened_at="2024-02-01", parent_group_id=g6,
+        )
+        self.db.update_trade_group(
+            g7, status="closed", closed_at="2024-02-15",
+            realized_pl=80.0, total_fees=1.0,
+        )
+
+        chain = self.db.get_roll_chain(g7)
+        self.assertEqual(len(chain), 3)
+
+        total_pl = sum(g["realized_pl"] or 0 for g in chain)
+        self.assertAlmostEqual(total_pl, 110.0)  # 50 - 20 + 80
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,191 @@
+"""Tests for the SQLite database layer."""
+
+import unittest
+import sqlite3
+from pathlib import Path
+from utils.db import TradeDB
+
+
+class TestTradeDB(unittest.TestCase):
+    def setUp(self):
+        """Create an in-memory database for each test."""
+        self.db = TradeDB(db_path=Path(":memory:"))
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_migration_creates_tables(self):
+        tables = self.db.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+        table_names = [t["name"] for t in tables]
+        self.assertIn("transactions", table_names)
+        self.assertIn("orders", table_names)
+        self.assertIn("trade_groups", table_names)
+        self.assertIn("trade_group_transactions", table_names)
+        self.assertIn("sync_state", table_names)
+
+    def test_migration_is_idempotent(self):
+        # Run migrate again — should not raise
+        self.db._migrate()
+
+    def test_upsert_transactions(self):
+        txns = [
+            {
+                "id": 1,
+                "account_number": "ABC",
+                "transaction_type": "Trade",
+                "transaction_sub_type": "Sell to Open",
+                "description": "Sold option",
+                "executed_at": "2024-01-15T10:00:00",
+                "transaction_date": "2024-01-15",
+                "value": 150.0,
+                "net_value": 148.5,
+                "is_estimated_fee": False,
+                "symbol": "SPY 240315P490",
+                "instrument_type": "Equity Option",
+                "underlying_symbol": "SPY",
+                "action": "Sell to Open",
+                "quantity": 1.0,
+                "price": 1.50,
+                "regulatory_fees": 0.05,
+                "clearing_fees": 0.10,
+                "commission": 1.00,
+                "order_id": 100,
+            }
+        ]
+        count = self.db.upsert_transactions(txns)
+        self.assertEqual(count, 1)
+
+        # Duplicate insert should be ignored
+        count2 = self.db.upsert_transactions(txns)
+        # Total rows should still be 1
+        row_count = self.db.conn.execute("SELECT COUNT(*) FROM transactions").fetchone()[0]
+        self.assertEqual(row_count, 1)
+
+    def test_upsert_orders(self):
+        orders = [
+            {
+                "id": 200,
+                "account_number": "ABC",
+                "time_in_force": "Day",
+                "order_type": "Limit",
+                "underlying_symbol": "SPY",
+                "underlying_instrument_type": "Equity",
+                "status": "Filled",
+                "size": 1.0,
+                "price": 1.50,
+                "value": 150.0,
+                "received_at": "2024-01-15T10:00:00",
+                "terminal_at": "2024-01-15T10:00:01",
+                "cancelled_at": None,
+                "replacing_order_id": None,
+                "replaces_order_id": None,
+                "legs": [],
+            }
+        ]
+        count = self.db.upsert_orders(orders)
+        self.assertEqual(count, 1)
+
+    def test_sync_state(self):
+        state = self.db.get_sync_state("ABC")
+        self.assertIsNone(state["last_transaction_id"])
+
+        self.db.update_sync_state("ABC", last_transaction_id=500, last_order_id=200)
+        state = self.db.get_sync_state("ABC")
+        self.assertEqual(state["last_transaction_id"], 500)
+        self.assertEqual(state["last_order_id"], 200)
+
+        # Update only transaction id
+        self.db.update_sync_state("ABC", last_transaction_id=600)
+        state = self.db.get_sync_state("ABC")
+        self.assertEqual(state["last_transaction_id"], 600)
+        self.assertEqual(state["last_order_id"], 200)  # unchanged
+
+    def test_create_and_query_trade_groups(self):
+        gid = self.db.create_trade_group(
+            account_number="ABC",
+            underlying_symbol="SPY",
+            strategy_type="Vertical",
+            opened_at="2024-01-15T10:00:00",
+        )
+        self.assertIsNotNone(gid)
+
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["underlying_symbol"], "SPY")
+        self.assertEqual(groups[0]["status"], "open")
+
+    def test_link_transaction_to_group(self):
+        # Insert a transaction first
+        self.db.upsert_transactions([{
+            "id": 1, "account_number": "ABC", "transaction_type": "Trade",
+            "transaction_sub_type": "Sell to Open", "description": "",
+            "executed_at": "2024-01-15T10:00:00", "transaction_date": "2024-01-15",
+            "value": 100.0, "net_value": 99.0, "is_estimated_fee": False,
+            "underlying_symbol": "SPY", "action": "Sell to Open", "quantity": 1.0,
+            "order_id": 100,
+        }])
+
+        gid = self.db.create_trade_group("ABC", "SPY", opened_at="2024-01-15T10:00:00")
+        self.db.link_transaction(gid, 1, "open")
+
+        txns = self.db.get_group_transactions(gid)
+        self.assertEqual(len(txns), 1)
+        self.assertEqual(txns[0]["role"], "open")
+
+    def test_get_open_group_for_underlying(self):
+        self.db.create_trade_group("ABC", "SPY", opened_at="2024-01-15T10:00:00")
+        self.db.create_trade_group("ABC", "AAPL", opened_at="2024-01-15T10:00:00")
+
+        group = self.db.get_open_group_for_underlying("ABC", "SPY")
+        self.assertIsNotNone(group)
+        self.assertEqual(group["underlying_symbol"], "SPY")
+
+        group = self.db.get_open_group_for_underlying("ABC", "TSLA")
+        self.assertIsNone(group)
+
+    def test_roll_chain(self):
+        g1 = self.db.create_trade_group("ABC", "SPY", opened_at="2024-01-01")
+        self.db.update_trade_group(g1, status="closed", closed_at="2024-01-15")
+
+        g2 = self.db.create_trade_group("ABC", "SPY", opened_at="2024-01-15", parent_group_id=g1)
+        self.db.update_trade_group(g2, status="closed", closed_at="2024-02-01")
+
+        g3 = self.db.create_trade_group("ABC", "SPY", opened_at="2024-02-01", parent_group_id=g2)
+
+        chain = self.db.get_roll_chain(g3)
+        self.assertEqual(len(chain), 3)
+        self.assertEqual(chain[0]["id"], g1)
+        self.assertEqual(chain[2]["id"], g3)
+
+    def test_get_group_net_quantity(self):
+        self.db.upsert_transactions([
+            {
+                "id": 1, "account_number": "ABC", "transaction_type": "Trade",
+                "transaction_sub_type": "Sell to Open", "description": "",
+                "executed_at": "2024-01-15T10:00:00", "transaction_date": "2024-01-15",
+                "value": 100.0, "net_value": 99.0, "is_estimated_fee": False,
+                "action": "Sell to Open", "quantity": 2.0, "order_id": 100,
+                "underlying_symbol": "SPY",
+            },
+            {
+                "id": 2, "account_number": "ABC", "transaction_type": "Trade",
+                "transaction_sub_type": "Buy to Close", "description": "",
+                "executed_at": "2024-01-20T10:00:00", "transaction_date": "2024-01-20",
+                "value": -50.0, "net_value": -51.0, "is_estimated_fee": False,
+                "action": "Buy to Close", "quantity": 1.0, "order_id": 101,
+                "underlying_symbol": "SPY",
+            },
+        ])
+
+        gid = self.db.create_trade_group("ABC", "SPY", opened_at="2024-01-15")
+        self.db.link_transaction(gid, 1, "open")
+        self.db.link_transaction(gid, 2, "close")
+
+        net = self.db.get_group_net_quantity(gid)
+        self.assertAlmostEqual(net, 1.0)  # 2 opened - 1 closed = 1 remaining
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trade_grouper.py
+++ b/tests/test_trade_grouper.py
@@ -1,0 +1,255 @@
+"""Tests for trade grouping algorithm — the most critical test file."""
+
+import unittest
+from pathlib import Path
+from utils.db import TradeDB
+from utils.trade_grouper import TradeGrouper
+
+
+def make_txn(
+    id, account="ABC", txn_type="Trade", sub_type="Sell to Open",
+    executed_at="2024-01-15T10:00:00", txn_date="2024-01-15",
+    value=100.0, net_value=99.0, underlying="SPY", action="Sell to Open",
+    quantity=1.0, price=1.0, order_id=100, symbol=None, instrument_type="Equity Option",
+):
+    """Helper to create a transaction dict."""
+    return {
+        "id": id,
+        "account_number": account,
+        "transaction_type": txn_type,
+        "transaction_sub_type": sub_type,
+        "description": f"Test txn {id}",
+        "executed_at": executed_at,
+        "transaction_date": txn_date,
+        "value": value,
+        "net_value": net_value,
+        "is_estimated_fee": False,
+        "symbol": symbol or f"{underlying} Option",
+        "instrument_type": instrument_type,
+        "underlying_symbol": underlying,
+        "action": action,
+        "quantity": quantity,
+        "price": price,
+        "regulatory_fees": 0.02,
+        "clearing_fees": 0.05,
+        "commission": 0.50,
+        "order_id": order_id,
+    }
+
+
+class TestTradeGrouper(unittest.TestCase):
+    def setUp(self):
+        self.db = TradeDB(db_path=Path(":memory:"))
+        self.grouper = TradeGrouper(self.db)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_simple_open_and_close(self):
+        """Open 1 contract, close it later — should create 1 group, mark it closed."""
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", sub_type="Sell to Open",
+                     value=150.0, net_value=148.5, order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+            make_txn(2, action="Buy to Close", sub_type="Buy to Close",
+                     value=-50.0, net_value=-51.0, order_id=101,
+                     executed_at="2024-01-25T10:00:00"),
+        ])
+
+        count = self.grouper.build_groups("ABC")
+        self.assertEqual(count, 1)
+
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["status"], "closed")
+        self.assertEqual(groups[0]["underlying_symbol"], "SPY")
+        self.assertIsNotNone(groups[0]["realized_pl"])
+        self.assertEqual(groups[0]["holding_days"], 10)
+
+    def test_multi_leg_open(self):
+        """Open a 2-leg vertical (same order_id) — should be 1 group."""
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", sub_type="Sell to Open",
+                     value=200.0, net_value=199.0, order_id=100,
+                     executed_at="2024-01-15T10:00:00", symbol="SPY 240315P490"),
+            make_txn(2, action="Buy to Open", sub_type="Buy to Open",
+                     value=-100.0, net_value=-101.0, order_id=100,
+                     executed_at="2024-01-15T10:00:00", symbol="SPY 240315P485"),
+        ])
+
+        count = self.grouper.build_groups("ABC")
+        self.assertEqual(count, 1)
+
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["strategy_type"], "Vertical")
+        self.assertEqual(groups[0]["status"], "open")
+
+    def test_iron_condor(self):
+        """Open a 4-leg iron condor — should be 1 group with strategy 'Iron Condor'."""
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+            make_txn(2, action="Buy to Open", order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+            make_txn(3, action="Sell to Open", order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+            make_txn(4, action="Buy to Open", order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+        ])
+
+        self.grouper.build_groups("ABC")
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["strategy_type"], "Iron Condor")
+
+    def test_partial_close_stays_open(self):
+        """Open 2 contracts, close 1 — group should stay open."""
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", sub_type="Sell to Open",
+                     quantity=2.0, order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+            make_txn(2, action="Buy to Close", sub_type="Buy to Close",
+                     quantity=1.0, order_id=101,
+                     executed_at="2024-01-20T10:00:00"),
+        ])
+
+        self.grouper.build_groups("ABC")
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["status"], "open")
+
+    def test_partial_then_full_close(self):
+        """Open 2, close 1, close 1 — should end up closed."""
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", quantity=2.0, order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+            make_txn(2, action="Buy to Close", quantity=1.0, order_id=101,
+                     executed_at="2024-01-20T10:00:00"),
+            make_txn(3, action="Buy to Close", quantity=1.0, order_id=102,
+                     executed_at="2024-01-25T10:00:00"),
+        ])
+
+        self.grouper.build_groups("ABC")
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["status"], "closed")
+
+    def test_roll_creates_linked_groups(self):
+        """Roll = close + open in same order. Should create 2 groups linked by parent_group_id."""
+        # First, open a position
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", sub_type="Sell to Open",
+                     order_id=100, executed_at="2024-01-15T10:00:00"),
+        ])
+        self.grouper.build_groups("ABC")
+
+        # Now roll: close old + open new in same order
+        self.db.upsert_transactions([
+            make_txn(2, action="Buy to Close", sub_type="Buy to Close",
+                     value=-50.0, net_value=-51.0, order_id=200,
+                     executed_at="2024-01-25T10:00:00"),
+            make_txn(3, action="Sell to Open", sub_type="Sell to Open",
+                     value=120.0, net_value=119.0, order_id=200,
+                     executed_at="2024-01-25T10:00:00"),
+        ])
+        self.grouper.build_groups("ABC")
+
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 2)
+
+        # Find the new group (has parent_group_id)
+        old_group = [g for g in groups if g["parent_group_id"] is None][0]
+        new_group = [g for g in groups if g["parent_group_id"] is not None][0]
+
+        self.assertEqual(old_group["status"], "closed")
+        self.assertEqual(new_group["status"], "open")
+        self.assertEqual(new_group["parent_group_id"], old_group["id"])
+
+        # Verify chain
+        chain = self.db.get_roll_chain(new_group["id"])
+        self.assertEqual(len(chain), 2)
+
+    def test_expiration(self):
+        """Position expires worthless — group should be marked 'expired'."""
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+            make_txn(2, txn_type="Receive Deliver", sub_type="Expiration",
+                     action=None, value=0, net_value=0, order_id=None, quantity=1.0,
+                     executed_at="2024-03-15T16:00:00"),
+        ])
+
+        self.grouper.build_groups("ABC")
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["status"], "expired")
+
+    def test_assignment(self):
+        """Short put gets assigned — group should be marked 'assigned'."""
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+            make_txn(2, txn_type="Receive Deliver", sub_type="Assignment",
+                     action=None, value=0, net_value=0, order_id=None, quantity=1.0,
+                     executed_at="2024-02-15T16:00:00"),
+        ])
+
+        self.grouper.build_groups("ABC")
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["status"], "assigned")
+
+    def test_multiple_underlyings(self):
+        """Trades on different underlyings should create separate groups."""
+        self.db.upsert_transactions([
+            make_txn(1, underlying="SPY", action="Sell to Open", order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+            make_txn(2, underlying="AAPL", action="Sell to Open", order_id=101,
+                     executed_at="2024-01-15T10:00:00"),
+        ])
+
+        count = self.grouper.build_groups("ABC")
+        self.assertEqual(count, 2)
+
+        groups = self.db.get_trade_groups("ABC")
+        underlyings = {g["underlying_symbol"] for g in groups}
+        self.assertEqual(underlyings, {"SPY", "AAPL"})
+
+    def test_idempotent_grouping(self):
+        """Running build_groups twice should not create duplicate groups."""
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", order_id=100,
+                     executed_at="2024-01-15T10:00:00"),
+        ])
+
+        count1 = self.grouper.build_groups("ABC")
+        self.assertEqual(count1, 1)
+
+        count2 = self.grouper.build_groups("ABC")
+        self.assertEqual(count2, 0)
+
+        groups = self.db.get_trade_groups("ABC")
+        self.assertEqual(len(groups), 1)
+
+    def test_group_totals_computed(self):
+        """Verify premium collected/paid and fees are computed correctly."""
+        self.db.upsert_transactions([
+            make_txn(1, action="Sell to Open", value=200.0, net_value=198.0,
+                     order_id=100, executed_at="2024-01-15T10:00:00"),
+            make_txn(2, action="Buy to Close", value=-80.0, net_value=-81.0,
+                     order_id=101, executed_at="2024-01-25T10:00:00"),
+        ])
+
+        self.grouper.build_groups("ABC")
+        groups = self.db.get_trade_groups("ABC")
+        g = groups[0]
+
+        self.assertGreater(g["total_premium_collected"], 0)
+        self.assertGreater(g["total_premium_paid"], 0)
+        self.assertGreater(g["total_fees"], 0)
+        self.assertIsNotNone(g["realized_pl"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,455 @@
+"""SQLite database layer for persisting trade history locally."""
+
+import json
+import sqlite3
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Any
+
+DB_PATH = Path.home() / ".tasty-coach" / "history.db"
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+MIGRATIONS = [
+    # Version 1: Initial schema
+    """
+    CREATE TABLE IF NOT EXISTS transactions (
+        id INTEGER PRIMARY KEY,
+        account_number TEXT NOT NULL,
+        transaction_type TEXT NOT NULL,
+        transaction_sub_type TEXT NOT NULL,
+        description TEXT,
+        executed_at TEXT NOT NULL,
+        transaction_date TEXT NOT NULL,
+        value REAL NOT NULL,
+        net_value REAL NOT NULL,
+        is_estimated_fee INTEGER NOT NULL,
+        symbol TEXT,
+        instrument_type TEXT,
+        underlying_symbol TEXT,
+        action TEXT,
+        quantity REAL,
+        price REAL,
+        regulatory_fees REAL,
+        clearing_fees REAL,
+        commission REAL,
+        order_id INTEGER,
+        raw_json TEXT,
+        synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS orders (
+        id INTEGER PRIMARY KEY,
+        account_number TEXT NOT NULL,
+        time_in_force TEXT,
+        order_type TEXT,
+        underlying_symbol TEXT,
+        underlying_instrument_type TEXT,
+        status TEXT NOT NULL,
+        size REAL,
+        price REAL,
+        value REAL,
+        received_at TEXT,
+        terminal_at TEXT,
+        cancelled_at TEXT,
+        replacing_order_id INTEGER,
+        replaces_order_id INTEGER,
+        legs_json TEXT,
+        raw_json TEXT,
+        synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS trade_groups (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        account_number TEXT NOT NULL,
+        underlying_symbol TEXT NOT NULL,
+        strategy_type TEXT,
+        status TEXT NOT NULL DEFAULT 'open',
+        opened_at TEXT,
+        closed_at TEXT,
+        total_premium_collected REAL DEFAULT 0,
+        total_premium_paid REAL DEFAULT 0,
+        total_fees REAL DEFAULT 0,
+        realized_pl REAL,
+        holding_days INTEGER,
+        parent_group_id INTEGER,
+        notes TEXT,
+        FOREIGN KEY (parent_group_id) REFERENCES trade_groups(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS trade_group_transactions (
+        trade_group_id INTEGER NOT NULL,
+        transaction_id INTEGER NOT NULL,
+        role TEXT NOT NULL,
+        PRIMARY KEY (trade_group_id, transaction_id),
+        FOREIGN KEY (trade_group_id) REFERENCES trade_groups(id),
+        FOREIGN KEY (transaction_id) REFERENCES transactions(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS sync_state (
+        account_number TEXT PRIMARY KEY,
+        last_transaction_id INTEGER,
+        last_order_id INTEGER,
+        last_sync_at TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_txn_underlying ON transactions(underlying_symbol);
+    CREATE INDEX IF NOT EXISTS idx_txn_order_id ON transactions(order_id);
+    CREATE INDEX IF NOT EXISTS idx_txn_date ON transactions(transaction_date);
+    CREATE INDEX IF NOT EXISTS idx_txn_type ON transactions(transaction_type);
+    CREATE INDEX IF NOT EXISTS idx_txn_account ON transactions(account_number);
+    CREATE INDEX IF NOT EXISTS idx_orders_underlying ON orders(underlying_symbol);
+    CREATE INDEX IF NOT EXISTS idx_orders_account ON orders(account_number);
+    CREATE INDEX IF NOT EXISTS idx_tg_underlying ON trade_groups(underlying_symbol);
+    CREATE INDEX IF NOT EXISTS idx_tg_account ON trade_groups(account_number);
+    CREATE INDEX IF NOT EXISTS idx_tg_status ON trade_groups(status);
+    CREATE INDEX IF NOT EXISTS idx_tg_parent ON trade_groups(parent_group_id);
+    CREATE INDEX IF NOT EXISTS idx_tgt_group ON trade_group_transactions(trade_group_id);
+    CREATE INDEX IF NOT EXISTS idx_tgt_txn ON trade_group_transactions(transaction_id);
+
+    CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER PRIMARY KEY
+    );
+    INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+    """,
+]
+
+
+class TradeDB:
+    """SQLite database for trade history persistence."""
+
+    def __init__(self, db_path: Path = DB_PATH):
+        self.db_path = db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(db_path))
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.execute("PRAGMA foreign_keys=ON")
+        self._migrate()
+
+    def _migrate(self) -> None:
+        """Run schema migrations. Idempotent."""
+        cursor = self.conn.cursor()
+
+        # Check current version
+        try:
+            row = cursor.execute(
+                "SELECT MAX(version) FROM schema_version"
+            ).fetchone()
+            current = row[0] if row and row[0] else 0
+        except sqlite3.OperationalError:
+            current = 0
+
+        for i, migration in enumerate(MIGRATIONS, start=1):
+            if i > current:
+                logger.info(f"Running migration v{i}")
+                cursor.executescript(migration)
+
+        self.conn.commit()
+
+    def close(self) -> None:
+        self.conn.close()
+
+    # --- Sync state ---
+
+    def get_sync_state(self, account_number: str) -> dict:
+        """Get the last sync watermarks for an account."""
+        row = self.conn.execute(
+            "SELECT last_transaction_id, last_order_id, last_sync_at "
+            "FROM sync_state WHERE account_number = ?",
+            (account_number,),
+        ).fetchone()
+        if row:
+            return dict(row)
+        return {"last_transaction_id": None, "last_order_id": None, "last_sync_at": None}
+
+    def update_sync_state(
+        self,
+        account_number: str,
+        last_transaction_id: Optional[int] = None,
+        last_order_id: Optional[int] = None,
+    ) -> None:
+        """Update sync watermarks."""
+        self.conn.execute(
+            """INSERT INTO sync_state (account_number, last_transaction_id, last_order_id, last_sync_at)
+               VALUES (?, ?, ?, datetime('now'))
+               ON CONFLICT(account_number) DO UPDATE SET
+                 last_transaction_id = COALESCE(?, last_transaction_id),
+                 last_order_id = COALESCE(?, last_order_id),
+                 last_sync_at = datetime('now')""",
+            (account_number, last_transaction_id, last_order_id,
+             last_transaction_id, last_order_id),
+        )
+        self.conn.commit()
+
+    # --- Transactions ---
+
+    def upsert_transactions(self, transactions: list[dict]) -> int:
+        """Insert transactions, skipping duplicates. Returns count inserted."""
+        count = 0
+        for txn in transactions:
+            try:
+                self.conn.execute(
+                    """INSERT OR IGNORE INTO transactions
+                       (id, account_number, transaction_type, transaction_sub_type,
+                        description, executed_at, transaction_date, value, net_value,
+                        is_estimated_fee, symbol, instrument_type, underlying_symbol,
+                        action, quantity, price, regulatory_fees, clearing_fees,
+                        commission, order_id, raw_json)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        txn["id"],
+                        txn["account_number"],
+                        txn["transaction_type"],
+                        txn["transaction_sub_type"],
+                        txn.get("description"),
+                        txn["executed_at"],
+                        txn["transaction_date"],
+                        txn["value"],
+                        txn["net_value"],
+                        int(txn["is_estimated_fee"]),
+                        txn.get("symbol"),
+                        txn.get("instrument_type"),
+                        txn.get("underlying_symbol"),
+                        txn.get("action"),
+                        txn.get("quantity"),
+                        txn.get("price"),
+                        txn.get("regulatory_fees"),
+                        txn.get("clearing_fees"),
+                        txn.get("commission"),
+                        txn.get("order_id"),
+                        json.dumps(txn),
+                    ),
+                )
+                if self.conn.total_changes:
+                    count += 1
+            except Exception as e:
+                logger.warning(f"Failed to insert transaction {txn.get('id')}: {e}")
+        self.conn.commit()
+        return count
+
+    def upsert_orders(self, orders: list[dict]) -> int:
+        """Insert orders, skipping duplicates. Returns count inserted."""
+        count = 0
+        for order in orders:
+            try:
+                self.conn.execute(
+                    """INSERT OR IGNORE INTO orders
+                       (id, account_number, time_in_force, order_type,
+                        underlying_symbol, underlying_instrument_type, status,
+                        size, price, value, received_at, terminal_at, cancelled_at,
+                        replacing_order_id, replaces_order_id, legs_json, raw_json)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        order["id"],
+                        order["account_number"],
+                        order.get("time_in_force"),
+                        order.get("order_type"),
+                        order.get("underlying_symbol"),
+                        order.get("underlying_instrument_type"),
+                        order["status"],
+                        order.get("size"),
+                        order.get("price"),
+                        order.get("value"),
+                        order.get("received_at"),
+                        order.get("terminal_at"),
+                        order.get("cancelled_at"),
+                        order.get("replacing_order_id"),
+                        order.get("replaces_order_id"),
+                        json.dumps(order.get("legs", [])),
+                        json.dumps(order),
+                    ),
+                )
+                if self.conn.total_changes:
+                    count += 1
+            except Exception as e:
+                logger.warning(f"Failed to insert order {order.get('id')}: {e}")
+        self.conn.commit()
+        return count
+
+    # --- Queries ---
+
+    def get_transactions(
+        self,
+        account_number: str,
+        underlying_symbol: Optional[str] = None,
+        transaction_type: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: int = 500,
+    ) -> list[sqlite3.Row]:
+        """Query stored transactions with optional filters."""
+        sql = "SELECT * FROM transactions WHERE account_number = ?"
+        params: list[Any] = [account_number]
+
+        if underlying_symbol:
+            sql += " AND underlying_symbol = ?"
+            params.append(underlying_symbol)
+        if transaction_type:
+            sql += " AND transaction_type = ?"
+            params.append(transaction_type)
+        if start_date:
+            sql += " AND transaction_date >= ?"
+            params.append(start_date)
+        if end_date:
+            sql += " AND transaction_date <= ?"
+            params.append(end_date)
+
+        sql += " ORDER BY executed_at DESC LIMIT ?"
+        params.append(limit)
+
+        return self.conn.execute(sql, params).fetchall()
+
+    def get_ungrouped_transactions(self, account_number: str) -> list[sqlite3.Row]:
+        """Get transactions not yet assigned to any trade group, for grouping."""
+        return self.conn.execute(
+            """SELECT t.* FROM transactions t
+               LEFT JOIN trade_group_transactions tgt ON t.id = tgt.transaction_id
+               WHERE t.account_number = ? AND tgt.transaction_id IS NULL
+                 AND t.transaction_type IN ('Trade', 'Receive Deliver')
+               ORDER BY t.executed_at ASC""",
+            (account_number,),
+        ).fetchall()
+
+    # --- Trade groups ---
+
+    def create_trade_group(
+        self,
+        account_number: str,
+        underlying_symbol: str,
+        strategy_type: Optional[str] = None,
+        opened_at: Optional[str] = None,
+        parent_group_id: Optional[int] = None,
+    ) -> int:
+        """Create a new trade group. Returns the group ID."""
+        cursor = self.conn.execute(
+            """INSERT INTO trade_groups
+               (account_number, underlying_symbol, strategy_type, status, opened_at, parent_group_id)
+               VALUES (?, ?, ?, 'open', ?, ?)""",
+            (account_number, underlying_symbol, strategy_type, opened_at, parent_group_id),
+        )
+        self.conn.commit()
+        return cursor.lastrowid
+
+    def link_transaction(self, group_id: int, transaction_id: int, role: str) -> None:
+        """Link a transaction to a trade group."""
+        self.conn.execute(
+            "INSERT OR IGNORE INTO trade_group_transactions VALUES (?, ?, ?)",
+            (group_id, transaction_id, role),
+        )
+        self.conn.commit()
+
+    def update_trade_group(self, group_id: int, **updates) -> None:
+        """Update fields on a trade group."""
+        if not updates:
+            return
+        set_clause = ", ".join(f"{k} = ?" for k in updates)
+        values = list(updates.values()) + [group_id]
+        self.conn.execute(
+            f"UPDATE trade_groups SET {set_clause} WHERE id = ?", values
+        )
+        self.conn.commit()
+
+    def get_trade_groups(
+        self,
+        account_number: str,
+        underlying_symbol: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 100,
+    ) -> list[sqlite3.Row]:
+        """Query trade groups with optional filters."""
+        sql = "SELECT * FROM trade_groups WHERE account_number = ?"
+        params: list[Any] = [account_number]
+
+        if underlying_symbol:
+            sql += " AND underlying_symbol = ?"
+            params.append(underlying_symbol)
+        if status:
+            sql += " AND status = ?"
+            params.append(status)
+
+        sql += " ORDER BY opened_at DESC LIMIT ?"
+        params.append(limit)
+
+        return self.conn.execute(sql, params).fetchall()
+
+    def get_group_transactions(self, group_id: int) -> list[sqlite3.Row]:
+        """Get all transactions for a trade group."""
+        return self.conn.execute(
+            """SELECT t.*, tgt.role FROM transactions t
+               JOIN trade_group_transactions tgt ON t.id = tgt.transaction_id
+               WHERE tgt.trade_group_id = ?
+               ORDER BY t.executed_at ASC""",
+            (group_id,),
+        ).fetchall()
+
+    def get_open_group_for_underlying(
+        self, account_number: str, underlying_symbol: str
+    ) -> Optional[sqlite3.Row]:
+        """Find an open trade group for a given underlying."""
+        return self.conn.execute(
+            """SELECT * FROM trade_groups
+               WHERE account_number = ? AND underlying_symbol = ? AND status = 'open'
+               ORDER BY opened_at DESC LIMIT 1""",
+            (account_number, underlying_symbol),
+        ).fetchone()
+
+    def get_group_net_quantity(self, group_id: int) -> float:
+        """Compute net quantity across all transactions in a group.
+        Opens are positive, closes are negative."""
+        rows = self.conn.execute(
+            """SELECT t.action, t.quantity FROM transactions t
+               JOIN trade_group_transactions tgt ON t.id = tgt.transaction_id
+               WHERE tgt.trade_group_id = ?""",
+            (group_id,),
+        ).fetchall()
+
+        net = 0.0
+        for row in rows:
+            qty = float(row["quantity"]) if row["quantity"] else 0.0
+            action = row["action"] or ""
+            if "Open" in action:
+                net += qty
+            elif "Close" in action:
+                net -= qty
+        return net
+
+    def get_roll_chain(self, group_id: int) -> list[sqlite3.Row]:
+        """Walk the parent_group_id chain to get all groups in a roll chain."""
+        # Walk up to find the root
+        root_id = group_id
+        seen = {root_id}
+        while True:
+            row = self.conn.execute(
+                "SELECT parent_group_id FROM trade_groups WHERE id = ?", (root_id,)
+            ).fetchone()
+            if not row or not row["parent_group_id"]:
+                break
+            root_id = row["parent_group_id"]
+            if root_id in seen:
+                break
+            seen.add(root_id)
+
+        # Walk down from root to collect all children
+        chain = []
+        queue = [root_id]
+        visited = set()
+        while queue:
+            gid = queue.pop(0)
+            if gid in visited:
+                continue
+            visited.add(gid)
+            group = self.conn.execute(
+                "SELECT * FROM trade_groups WHERE id = ?", (gid,)
+            ).fetchone()
+            if group:
+                chain.append(group)
+                children = self.conn.execute(
+                    "SELECT id FROM trade_groups WHERE parent_group_id = ?", (gid,)
+                ).fetchall()
+                queue.extend(c["id"] for c in children)
+
+        return sorted(chain, key=lambda g: g["opened_at"] or "")

--- a/utils/db.py
+++ b/utils/db.py
@@ -192,7 +192,7 @@ class TradeDB:
         count = 0
         for txn in transactions:
             try:
-                self.conn.execute(
+                cursor = self.conn.execute(
                     """INSERT OR IGNORE INTO transactions
                        (id, account_number, transaction_type, transaction_sub_type,
                         description, executed_at, transaction_date, value, net_value,
@@ -224,8 +224,7 @@ class TradeDB:
                         json.dumps(txn),
                     ),
                 )
-                if self.conn.total_changes:
-                    count += 1
+                count += cursor.rowcount
             except Exception as e:
                 logger.warning(f"Failed to insert transaction {txn.get('id')}: {e}")
         self.conn.commit()
@@ -236,7 +235,7 @@ class TradeDB:
         count = 0
         for order in orders:
             try:
-                self.conn.execute(
+                cursor = self.conn.execute(
                     """INSERT OR IGNORE INTO orders
                        (id, account_number, time_in_force, order_type,
                         underlying_symbol, underlying_instrument_type, status,
@@ -263,8 +262,7 @@ class TradeDB:
                         json.dumps(order),
                     ),
                 )
-                if self.conn.total_changes:
-                    count += 1
+                count += cursor.rowcount
             except Exception as e:
                 logger.warning(f"Failed to insert order {order.get('id')}: {e}")
         self.conn.commit()

--- a/utils/trade_grouper.py
+++ b/utils/trade_grouper.py
@@ -1,0 +1,307 @@
+"""Trade grouping algorithm — links related transactions into trade lifecycles."""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+from utils.db import TradeDB
+
+logger = logging.getLogger(__name__)
+
+# Transactions with the same order_id or within this window are considered
+# part of the same logical trade (e.g., multi-leg orders, rolls).
+ROLL_TIME_WINDOW = timedelta(seconds=5)
+
+
+class TradeGrouper:
+    """Processes ungrouped transactions and assigns them to trade groups."""
+
+    def __init__(self, db: TradeDB):
+        self.db = db
+
+    def build_groups(self, account_number: str) -> int:
+        """Process ungrouped transactions and assign them to trade groups.
+
+        Returns count of new groups created.
+        """
+        ungrouped = self.db.get_ungrouped_transactions(account_number)
+        if not ungrouped:
+            return 0
+
+        new_groups = 0
+
+        # Group transactions by order_id first so multi-leg orders
+        # are processed together.
+        order_batches = self._batch_by_order(ungrouped)
+
+        for batch in order_batches:
+            created = self._process_batch(account_number, batch)
+            new_groups += created
+
+        return new_groups
+
+    def _batch_by_order(self, transactions: list) -> list[list]:
+        """Group transactions that share an order_id into batches.
+        Transactions without an order_id are each their own batch.
+        Preserves chronological order within batches.
+        """
+        order_map: dict[int, list] = {}
+        no_order: list[list] = []
+
+        for txn in transactions:
+            oid = txn["order_id"]
+            if oid:
+                order_map.setdefault(oid, []).append(txn)
+            else:
+                no_order.append([txn])
+
+        # Sort batches by earliest executed_at
+        batches = list(order_map.values()) + no_order
+        batches.sort(key=lambda b: b[0]["executed_at"])
+        return batches
+
+    def _process_batch(self, account_number: str, batch: list) -> int:
+        """Process a batch of transactions (all from the same order or a single txn).
+        Returns 1 if a new group was created, 0 otherwise.
+        """
+        new_groups = 0
+        underlying = self._get_underlying(batch)
+        if not underlying:
+            logger.warning(
+                f"Cannot determine underlying for transaction batch "
+                f"(ids: {[t['id'] for t in batch]})"
+            )
+            return 0
+
+        # Classify the batch
+        actions = [t["action"] or "" for t in batch]
+        sub_types = [t["transaction_sub_type"] or "" for t in batch]
+
+        has_opens = any("Open" in a for a in actions)
+        has_closes = any("Close" in a for a in actions)
+        is_expiration = any(st == "Expiration" for st in sub_types)
+        is_assignment = any(st in ("Assignment", "Exercise", "Cash Settled Assignment", "Cash Settled Exercise") for st in sub_types)
+
+        # Roll: batch contains both opens and closes
+        if has_opens and has_closes:
+            new_groups += self._handle_roll(account_number, underlying, batch)
+        elif has_opens:
+            new_groups += self._handle_open(account_number, underlying, batch)
+        elif has_closes:
+            self._handle_close(account_number, underlying, batch)
+        elif is_expiration:
+            self._handle_expiration(account_number, underlying, batch)
+        elif is_assignment:
+            self._handle_assignment(account_number, underlying, batch)
+        else:
+            # Unknown — log and skip
+            logger.debug(
+                f"Unhandled transaction batch for {underlying}: "
+                f"sub_types={sub_types}, actions={actions}"
+            )
+
+        return new_groups
+
+    def _handle_open(self, account_number: str, underlying: str, batch: list) -> int:
+        """Handle opening transactions. Returns 1 if new group created."""
+        # Check if there's already an open group for this underlying
+        existing = self.db.get_open_group_for_underlying(account_number, underlying)
+        if existing:
+            group_id = existing["id"]
+            for txn in batch:
+                self.db.link_transaction(group_id, txn["id"], "open")
+            self._update_group_totals(group_id)
+            return 0
+
+        # Create new group
+        strategy = self._detect_strategy(batch)
+        group_id = self.db.create_trade_group(
+            account_number=account_number,
+            underlying_symbol=underlying,
+            strategy_type=strategy,
+            opened_at=batch[0]["executed_at"],
+        )
+        for txn in batch:
+            self.db.link_transaction(group_id, txn["id"], "open")
+        self._update_group_totals(group_id)
+        return 1
+
+    def _handle_close(self, account_number: str, underlying: str, batch: list) -> None:
+        """Handle closing transactions."""
+        group = self.db.get_open_group_for_underlying(account_number, underlying)
+        if not group:
+            logger.warning(f"Close without open group for {underlying}, creating standalone group")
+            group_id = self.db.create_trade_group(
+                account_number=account_number,
+                underlying_symbol=underlying,
+                opened_at=batch[0]["executed_at"],
+            )
+            for txn in batch:
+                self.db.link_transaction(group_id, txn["id"], "close")
+            self._finalize_if_closed(group_id)
+            return
+
+        group_id = group["id"]
+        for txn in batch:
+            self.db.link_transaction(group_id, txn["id"], "close")
+        self._update_group_totals(group_id)
+        self._finalize_if_closed(group_id)
+
+    def _handle_roll(self, account_number: str, underlying: str, batch: list) -> int:
+        """Handle a roll: close old group, open new with parent_group_id link."""
+        close_txns = [t for t in batch if "Close" in (t["action"] or "")]
+        open_txns = [t for t in batch if "Open" in (t["action"] or "")]
+
+        # Close the existing group
+        old_group = self.db.get_open_group_for_underlying(account_number, underlying)
+        old_group_id = None
+        if old_group:
+            old_group_id = old_group["id"]
+            for txn in close_txns:
+                self.db.link_transaction(old_group_id, txn["id"], "roll")
+            self._update_group_totals(old_group_id)
+            self._finalize_group(old_group_id, status="closed", closed_at=batch[0]["executed_at"])
+        else:
+            logger.warning(f"Roll without existing open group for {underlying}")
+
+        # Open new group linked to old
+        strategy = self._detect_strategy(open_txns)
+        new_group_id = self.db.create_trade_group(
+            account_number=account_number,
+            underlying_symbol=underlying,
+            strategy_type=strategy,
+            opened_at=batch[0]["executed_at"],
+            parent_group_id=old_group_id,
+        )
+        for txn in open_txns:
+            self.db.link_transaction(new_group_id, txn["id"], "roll")
+        self._update_group_totals(new_group_id)
+        return 1
+
+    def _handle_expiration(self, account_number: str, underlying: str, batch: list) -> None:
+        """Handle expiration transactions."""
+        group = self.db.get_open_group_for_underlying(account_number, underlying)
+        if not group:
+            logger.debug(f"Expiration without open group for {underlying}")
+            return
+
+        group_id = group["id"]
+        for txn in batch:
+            self.db.link_transaction(group_id, txn["id"], "expiration")
+        self._update_group_totals(group_id)
+        self._finalize_group(group_id, status="expired", closed_at=batch[0]["executed_at"])
+
+    def _handle_assignment(self, account_number: str, underlying: str, batch: list) -> None:
+        """Handle assignment/exercise transactions."""
+        group = self.db.get_open_group_for_underlying(account_number, underlying)
+        if not group:
+            logger.debug(f"Assignment without open group for {underlying}")
+            return
+
+        group_id = group["id"]
+        for txn in batch:
+            self.db.link_transaction(group_id, txn["id"], "assignment")
+        self._update_group_totals(group_id)
+        self._finalize_group(group_id, status="assigned", closed_at=batch[0]["executed_at"])
+
+    def _finalize_if_closed(self, group_id: int) -> None:
+        """Check if a group's net quantity is zero and finalize if so."""
+        net_qty = self.db.get_group_net_quantity(group_id)
+        if abs(net_qty) < 0.001:
+            txns = self.db.get_group_transactions(group_id)
+            closed_at = txns[-1]["executed_at"] if txns else None
+            self._finalize_group(group_id, status="closed", closed_at=closed_at)
+
+    def _finalize_group(
+        self, group_id: int, status: str, closed_at: Optional[str] = None
+    ) -> None:
+        """Mark a group as closed/expired/assigned and compute realized P/L."""
+        txns = self.db.get_group_transactions(group_id)
+        group = self.db.conn.execute(
+            "SELECT * FROM trade_groups WHERE id = ?", (group_id,)
+        ).fetchone()
+        if not group:
+            return
+
+        # Compute holding days
+        holding_days = None
+        if group["opened_at"] and closed_at:
+            try:
+                opened = datetime.fromisoformat(group["opened_at"])
+                closed = datetime.fromisoformat(closed_at)
+                holding_days = (closed - opened).days
+            except (ValueError, TypeError):
+                pass
+
+        self.db.update_trade_group(
+            group_id,
+            status=status,
+            closed_at=closed_at,
+            holding_days=holding_days,
+        )
+
+    def _update_group_totals(self, group_id: int) -> None:
+        """Recompute premium collected/paid and fees for a group."""
+        txns = self.db.get_group_transactions(group_id)
+
+        collected = 0.0
+        paid = 0.0
+        fees = 0.0
+
+        for txn in txns:
+            net_value = float(txn["net_value"]) if txn["net_value"] else 0.0
+            if net_value > 0:
+                collected += net_value
+            else:
+                paid += abs(net_value)
+
+            for fee_col in ("commission", "clearing_fees", "regulatory_fees"):
+                f = txn[fee_col]
+                if f:
+                    fees += abs(float(f))
+
+        realized_pl = collected - paid
+        self.db.update_trade_group(
+            group_id,
+            total_premium_collected=collected,
+            total_premium_paid=paid,
+            total_fees=fees,
+            realized_pl=realized_pl,
+        )
+
+    def _get_underlying(self, batch: list) -> Optional[str]:
+        """Extract the underlying symbol from a batch of transactions."""
+        for txn in batch:
+            if txn["underlying_symbol"]:
+                return txn["underlying_symbol"]
+        return None
+
+    def _detect_strategy(self, open_txns: list) -> Optional[str]:
+        """Detect strategy type from opening transactions.
+
+        Simple heuristic based on leg count and action types.
+        """
+        if not open_txns:
+            return None
+
+        count = len(open_txns)
+        actions = set((t["action"] or "") for t in open_txns)
+        instruments = set((t["instrument_type"] or "") for t in open_txns)
+
+        has_equity = "Equity" in instruments
+        has_option = "Equity Option" in instruments or "Future Option" in instruments
+
+        if count == 1:
+            if has_equity:
+                return "Stock"
+            return "Single Option"
+        elif count == 2:
+            if has_option:
+                return "Vertical"
+            return "Pair"
+        elif count == 4:
+            return "Iron Condor"
+        elif count == 3:
+            return "Butterfly"
+
+        return f"{count}-Leg"


### PR DESCRIPTION
Rebased and conflict-resolved version of #2.

## What changed from the original PR

- **Rebased** onto current `main` (was targeting `281888a`, now targets `8c6a525`)
- **Merged `agents/history.py`** — both `AccountHistoryAgent` (NLV performance reports, already on main) and the new `HistoryAgent` (transaction/order display + SQLite sync) now live in the same file with combined imports
- **Renamed `--history` flag to `--transactions`** — the original PR used `--history` as a boolean which clashed directly with main's `--history {week,month,year}` argparse choice

## Summary

- **HistoryAgent**: fetch and display transactions and orders in Rich tables; sync history incrementally to local SQLite at `~/.tasty-coach/history.db` using a watermark
- **AnalyticsAgent**: win rate, profit factor, expectancy, strategy breakdown, daily/weekly/monthly P/L, NLV equity curve
- **TradeDB**: SQLite schema (5 tables) with migrations and watermark-based incremental sync
- **TradeGrouper**: links related transactions into trade lifecycles — multi-leg opens, partial closes, rolls (linked via parent_group_id chain), expirations, and assignments

## New CLI flags

| Flag | Description |
|------|-------------|
| `--transactions` | Show recent transaction history |
| `--orders` | Show recent order history |
| `--days N` | Look-back window (default: 30) |
| `--symbol X` | Filter by underlying symbol |
| `--type X` | Filter transaction type |
| `--sync` / `--sync-full` | Persist history to local SQLite DB |
| `--trades` / `--trade X` | View trade groups from local DB |
| `--performance` | Win rate, P/L, profit factor, expectancy |
| `--performance-by-strategy` | Strategy breakdown |
| `--pl-daily/weekly/monthly` | Time-based P/L summaries |
| `--equity-curve` | NLV history chart |
| `--period X` | Time period: 1m, 3m, 6m, 1y, all |

## Test plan

- [x] 27 unit tests passing (`python -m unittest tests.test_db tests.test_trade_grouper tests.test_analytics -v`)
- [x] Existing `tests.test_history` still passes
- [x] All imports clean, `--help` shows all new flags correctly
- [x] Manual: `python main.py --transactions --days 7` against live account
- [x] Manual: `python main.py --sync` then `--trades` to verify grouping
- [x] Manual: `python main.py --performance --period 3m` to verify metrics

Closes #2