### PR TITLE
Phase E — Settings editor + alert persistence

### DIFF
--- a/docs/phases/phase-e.md
+++ b/docs/phases/phase-e.md
@@ -1,0 +1,21 @@
+# Phase E — Settings Editor + Alert Persistence
+
+## Scope
+
+- In-launcher settings editor screen (edit Phase A config values without hand-editing JSON)
+- Alert persistence SQLite table + "new since last view" markers in dashboard alert strip
+
+## Out of scope
+
+- Cloud-based settings sync
+- Alert filtering / snooze
+- Notification channels (email, Slack, etc.)
+
+## Dependencies
+
+Phase A (settings framework)
+Phase B (dashboard view)
+
+## Linked task
+
+TCMVP-5

--- a/main.py
+++ b/main.py
@@ -67,6 +67,7 @@ def setup_argument_parser() -> argparse.ArgumentParser:
         help="Account number to use (e.g. 5WW46136). Alternatively set TASTY_ACCOUNT_NUMBER in .env",
     )
     parser.add_argument("--home", action="store_true", help="Unified account dashboard (portfolio, performance, risk).")
+    parser.add_argument("--alerts", nargs="?", const=50, type=int, default=None, metavar="N", help="Print last N persisted alerts (default 50) for the resolved account.")
     parser.add_argument("--timeline", action="store_true", help="Event timeline (assignments, exercises, opens/closes, rolls) for the active account.")
     parser.add_argument("--timeline-days", type=int, default=30, help="Lookback window for --timeline (default 30).")
     parser.add_argument("--timeline-symbol", type=str, default=None, help="Optional underlying filter for --timeline.")
@@ -259,6 +260,29 @@ async def async_main() -> int:
                 return 1
             from utils.dashboard_ui import run_account_dashboard
             return await run_account_dashboard(session, account_number=account_number)
+
+        if args.alerts is not None:
+            account_number = args.account or client.config.account_number
+            accounts = await client.get_accounts()
+            if not accounts:
+                print("❌ No linked accounts found for this session.")
+                return 1
+            if len(accounts) > 1 and not account_number:
+                print("❌ Multiple accounts found. Please set TASTY_ACCOUNT_NUMBER in .env or pass --account.")
+                return 1
+            if not account_number:
+                account_number = getattr(accounts[0], "account_number", None)
+            if not account_number:
+                print("❌ Could not resolve an account number for --alerts.")
+                return 1
+            from utils.alert_store import AlertStore, print_alert_history
+            from utils.db import TradeDB
+            db = TradeDB()
+            try:
+                print_alert_history(AlertStore(db), account_number, limit=args.alerts)
+            finally:
+                db.close()
+            return 0
 
         if args.timeline:
             account_number = args.account or client.config.account_number

--- a/tests/test_alert_store.py
+++ b/tests/test_alert_store.py
@@ -1,0 +1,143 @@
+"""Tests for utils.alert_store (Phase E)."""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+
+from agents.alerts import Alert
+from utils.alert_store import AlertStore, print_alert_history
+from utils.db import TradeDB
+
+
+def _a(category, message, severity="warn", context=None):
+    return Alert(severity=severity, category=category, message=message,
+                 context=context or {})
+
+
+class TestAlertStore(unittest.TestCase):
+    def setUp(self):
+        self.db = TradeDB(db_path=Path(":memory:"))
+        self.store = AlertStore(self.db)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_record_alerts_inserts_rows(self):
+        alerts = [_a("bp", "m1"), _a("theta", "m2"), _a("market", "m3")]
+        n = self.store.record_alerts("ACCT", alerts)
+        self.assertEqual(n, 3)
+        self.assertEqual(len(self.store.get_history("ACCT")), 3)
+
+    def test_record_alerts_dedupes_same_day(self):
+        alerts = [_a("bp", "dup")]
+        when = datetime(2026, 4, 24, 10, tzinfo=timezone.utc)
+        self.store.record_alerts("ACCT", alerts, now=when)
+        self.store.record_alerts("ACCT", alerts, now=when)
+        self.assertEqual(len(self.store.get_history("ACCT")), 1)
+
+    def test_record_alerts_redup_next_day(self):
+        alerts = [_a("bp", "dup")]
+        d1 = datetime(2026, 4, 24, 10, tzinfo=timezone.utc)
+        d2 = datetime(2026, 4, 25, 10, tzinfo=timezone.utc)
+        self.store.record_alerts("ACCT", alerts, now=d1)
+        self.store.record_alerts("ACCT", alerts, now=d2)
+        self.assertEqual(len(self.store.get_history("ACCT")), 2)
+
+    def test_record_alerts_account_scoped(self):
+        alerts = [_a("bp", "same")]
+        self.store.record_alerts("A1", alerts)
+        self.store.record_alerts("A2", alerts)
+        self.assertEqual(len(self.store.get_history("A1")), 1)
+        self.assertEqual(len(self.store.get_history("A2")), 1)
+
+    def test_record_alerts_empty_iterable_is_noop(self):
+        self.assertEqual(self.store.record_alerts("ACCT", []), 0)
+
+    def test_record_alerts_handles_non_json_context(self):
+        # Decimal isn't JSON-native — default=str handles it.
+        alerts = [_a("bp", "with ctx", context={"value": Decimal("1.5")})]
+        n = self.store.record_alerts("ACCT", alerts)
+        self.assertEqual(n, 1)
+        hist = self.store.get_history("ACCT")
+        self.assertEqual(len(hist), 1)
+
+    def test_get_last_viewed_returns_none_initially(self):
+        self.assertIsNone(self.store.get_last_viewed("ACCT"))
+
+    def test_mark_viewed_then_get_last_viewed_roundtrip(self):
+        when = datetime(2026, 4, 24, 10, tzinfo=timezone.utc)
+        self.store.mark_viewed("ACCT", when)
+        got = self.store.get_last_viewed("ACCT")
+        self.assertEqual(got, when)
+
+    def test_mark_viewed_upserts(self):
+        d1 = datetime(2026, 4, 24, 10, tzinfo=timezone.utc)
+        d2 = datetime(2026, 4, 25, 10, tzinfo=timezone.utc)
+        self.store.mark_viewed("ACCT", d1)
+        self.store.mark_viewed("ACCT", d2)
+        self.assertEqual(self.store.get_last_viewed("ACCT"), d2)
+        rows = self.db.conn.execute(
+            "SELECT COUNT(*) FROM alert_views WHERE account_number = ?",
+            ("ACCT",),
+        ).fetchone()
+        self.assertEqual(rows[0], 1)
+
+    def test_new_alert_keys_since_returns_only_after_timestamp(self):
+        d1 = datetime(2026, 4, 24, 10, tzinfo=timezone.utc)
+        d2 = datetime(2026, 4, 24, 11, tzinfo=timezone.utc)
+        self.store.record_alerts("ACCT", [_a("bp", "old")], now=d1)
+        self.store.record_alerts("ACCT", [_a("theta", "new")], now=d2)
+        keys = self.store.new_alert_keys_since(
+            "ACCT", d1 + timedelta(minutes=1)
+        )
+        self.assertEqual(keys, {("theta", "new")})
+
+    def test_new_alert_keys_since_returns_empty_when_since_is_none(self):
+        self.store.record_alerts("ACCT", [_a("bp", "m")])
+        self.assertEqual(self.store.new_alert_keys_since("ACCT", None), set())
+
+    def test_get_history_orders_desc_and_respects_limit(self):
+        now = datetime(2026, 4, 24, 10, tzinfo=timezone.utc)
+        for i in range(5):
+            self.store.record_alerts(
+                "ACCT", [_a("bp", f"m{i}")],
+                now=now + timedelta(days=i),
+            )
+        hist = self.store.get_history("ACCT", limit=3)
+        self.assertEqual(len(hist), 3)
+        # Newest first: m4, m3, m2
+        self.assertEqual(hist[0]["message"], "m4")
+        self.assertEqual(hist[-1]["message"], "m2")
+
+    def test_first_seen_alert_is_marked_new_after_persist(self):
+        # Regression: the dashboard flow records alerts BEFORE computing
+        # new_alert_keys_since(), so a brand-new alert must appear as "new"
+        # on this refresh. Simulate that order here.
+        d0 = datetime(2026, 4, 24, 10, tzinfo=timezone.utc)
+        d1 = datetime(2026, 4, 24, 11, tzinfo=timezone.utc)
+        self.store.mark_viewed("ACCT", d0)
+        last = self.store.get_last_viewed("ACCT")
+        self.store.record_alerts(
+            "ACCT", [_a("bp", "brand new")], now=d1,
+        )
+        keys = self.store.new_alert_keys_since("ACCT", last)
+        self.assertIn(("bp", "brand new"), keys)
+
+    def test_schema_version_advances_to_2(self):
+        row = self.db.conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()
+        self.assertEqual(row[0], 2)
+
+    def test_print_alert_history_empty(self):
+        from io import StringIO
+        from rich.console import Console
+        buf = StringIO()
+        console = Console(file=buf, width=120, force_terminal=False)
+        print_alert_history(self.store, "ACCT", console=console)
+        self.assertIn("No alerts recorded", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -318,6 +318,21 @@ class TestRenderPanels(unittest.TestCase):
         rendered = _render_to_str(render_alerts_panel(data))
         self.assertIn("Market closed", rendered)
 
+    def test_render_alerts_panel_marks_new_with_dot(self):
+        alert = {"severity": "warn", "category": "bp", "message": "BP high"}
+        data = DashboardData(
+            risk={"alerts": [alert]},
+            new_alert_keys={("bp", "BP high")},
+        )
+        rendered = _render_to_str(render_alerts_panel(data))
+        self.assertIn("●", rendered)
+
+    def test_render_alerts_panel_no_dot_when_not_new(self):
+        alert = {"severity": "warn", "category": "bp", "message": "BP high"}
+        data = DashboardData(risk={"alerts": [alert]}, new_alert_keys=set())
+        rendered = _render_to_str(render_alerts_panel(data))
+        self.assertNotIn("●", rendered)
+
     def test_render_alerts_panel_truncation_title(self):
         alerts = [{"severity": "info", "category": f"cat{i}", "message": f"msg{i}"}
                   for i in range(10)]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -124,6 +124,93 @@ class TestSettings(unittest.TestCase):
         self.assertIsInstance(settings, Settings)
 
 
+class TestSettingsSet(unittest.TestCase):
+    def test_set_updates_numeric_key(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "config.json"
+            s = Settings(config_path=p)
+            s.set("position_pct_nlv_warn", 0.10)
+            self.assertEqual(s.get("position_pct_nlv_warn"), 0.10)
+            reloaded = Settings(config_path=p)
+            self.assertEqual(reloaded.get("position_pct_nlv_warn"), 0.10)
+
+    def test_set_rejects_unknown_key(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "config.json"
+            s = Settings(config_path=p)
+            s.get("bp_usage_warn")  # force load
+            before = p.read_text()
+            with self.assertRaises(ValueError):
+                s.set("nope", 1)
+            self.assertEqual(p.read_text(), before)
+
+    def test_set_rejects_negative_numeric(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            with self.assertRaises(ValueError):
+                s.set("bp_usage_warn", -0.1)
+
+    def test_set_coerces_string_numeric(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("concentration_pct_nlv_warn", "0.33")
+            self.assertEqual(s.get("concentration_pct_nlv_warn"), 0.33)
+
+    def test_set_nested_alert_toggle(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "config.json"
+            s = Settings(config_path=p)
+            s.set("alert_toggles.bp", False)
+            toggles = s.get("alert_toggles")
+            self.assertFalse(toggles["bp"])
+            self.assertTrue(toggles["position_size"])
+            self.assertTrue(toggles["theta"])
+
+    def test_set_many_atomic_on_validation_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "config.json"
+            s = Settings(config_path=p)
+            s.get("bp_usage_warn")
+            before = p.read_text()
+            with self.assertRaises(ValueError):
+                s.set_many({"bp_usage_warn": 0.40, "bogus_key": 1})
+            self.assertEqual(p.read_text(), before)
+            self.assertEqual(s.get("bp_usage_warn"), DEFAULTS["bp_usage_warn"])
+
+    def test_set_preserves_unknown_user_keys(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "config.json"
+            p.write_text(json.dumps({
+                "position_pct_nlv_warn": 0.05,
+                "custom_key": 42,
+            }))
+            s = Settings(config_path=p)
+            s.set("position_pct_nlv_warn", 0.08)
+            saved = json.loads(p.read_text())
+            self.assertEqual(saved["custom_key"], 42)
+
+    def test_set_alert_toggles_full_replace_preserves_other_categories(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("alert_toggles", {"bp": False})
+            toggles = s.get("alert_toggles")
+            self.assertFalse(toggles["bp"])
+            # All other default categories must still be present
+            for cat in ("position_size", "theta", "market", "concentration", "assignment"):
+                self.assertIn(cat, toggles)
+                self.assertTrue(toggles[cat])
+
+    def test_set_theta_target_accepts_none_and_numeric(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("theta_target", None)
+            self.assertIsNone(s.get("theta_target"))
+            s.set("theta_target", 0.002)
+            self.assertEqual(s.get("theta_target"), 0.002)
+            s.set("theta_target", "")
+            self.assertIsNone(s.get("theta_target"))
+
+
 class TestDecimalSettingFallback(unittest.TestCase):
     """Covers agents.manager._decimal_setting / _coerce_decimal safety net."""
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -189,6 +189,30 @@ class TestSettingsSet(unittest.TestCase):
             saved = json.loads(p.read_text())
             self.assertEqual(saved["custom_key"], 42)
 
+    def test_set_rejects_nan(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            with self.assertRaises(ValueError):
+                s.set("bp_usage_warn", float("nan"))
+            with self.assertRaises(ValueError):
+                s.set("bp_usage_warn", "nan")
+
+    def test_set_rejects_infinity(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            with self.assertRaises(ValueError):
+                s.set("position_pct_nlv_warn", float("inf"))
+            with self.assertRaises(ValueError):
+                s.set("position_pct_nlv_warn", "-inf")
+
+    def test_set_theta_target_rejects_nan_and_inf(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            with self.assertRaises(ValueError):
+                s.set("theta_target", float("nan"))
+            with self.assertRaises(ValueError):
+                s.set("theta_target", "inf")
+
     def test_set_alert_toggles_full_replace_preserves_other_categories(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             s = Settings(config_path=Path(tmpdir) / "config.json")

--- a/utils/alert_store.py
+++ b/utils/alert_store.py
@@ -1,0 +1,196 @@
+"""SQLite-backed alert history + view tracking for Phase E.
+
+Wraps a TradeDB (or raw sqlite3.Connection for testing). Never raises on
+caller-visible paths — on sqlite3.Error we log a warning and return a safe
+default so the dashboard / risk report can degrade gracefully.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional
+
+from agents.alerts import Alert
+
+
+logger = logging.getLogger(__name__)
+
+
+def _conn(db) -> sqlite3.Connection:
+    return getattr(db, "conn", db)
+
+
+def _as_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+class AlertStore:
+    """Persistence layer for alerts and last-viewed markers."""
+
+    def __init__(self, db) -> None:
+        self._conn = _conn(db)
+
+    def record_alerts(
+        self,
+        account_number: str,
+        alerts: Iterable[Alert],
+        *,
+        now: Optional[datetime] = None,
+    ) -> int:
+        """Insert alerts with per-day dedup on (account, category, message).
+
+        Same alert on the same day is a no-op (INSERT OR IGNORE). Returns the
+        number of rows actually inserted.
+        """
+        when = _as_utc(now) or datetime.now(timezone.utc)
+        recorded_at = when.isoformat()
+        recorded_day = when.date().isoformat()
+        inserted = 0
+        try:
+            with self._conn:
+                for a in alerts:
+                    ctx: Optional[str] = None
+                    ctx_val = getattr(a, "context", None)
+                    if ctx_val:
+                        try:
+                            ctx = json.dumps(ctx_val, default=str)
+                        except (TypeError, ValueError):
+                            ctx = None
+                    cur = self._conn.execute(
+                        "INSERT OR IGNORE INTO alert_history "
+                        "(account_number, severity, category, message, context, "
+                        "recorded_at, recorded_day) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        (account_number, a.severity, a.category, a.message,
+                         ctx, recorded_at, recorded_day),
+                    )
+                    inserted += cur.rowcount if cur.rowcount > 0 else 0
+        except sqlite3.Error as e:
+            logger.warning("record_alerts failed: %s", e)
+            return 0
+        return inserted
+
+    def get_last_viewed(self, account_number: str) -> Optional[datetime]:
+        """Return UTC-aware last_viewed_at or None."""
+        try:
+            row = self._conn.execute(
+                "SELECT last_viewed_at FROM alert_views WHERE account_number = ?",
+                (account_number,),
+            ).fetchone()
+        except sqlite3.Error as e:
+            logger.warning("get_last_viewed failed: %s", e)
+            return None
+        if not row:
+            return None
+        try:
+            return datetime.fromisoformat(row[0])
+        except (TypeError, ValueError):
+            return None
+
+    def mark_viewed(
+        self,
+        account_number: str,
+        when: Optional[datetime] = None,
+    ) -> None:
+        ts = (_as_utc(when) or datetime.now(timezone.utc)).isoformat()
+        try:
+            with self._conn:
+                self._conn.execute(
+                    "INSERT INTO alert_views (account_number, last_viewed_at) "
+                    "VALUES (?, ?) ON CONFLICT(account_number) DO UPDATE "
+                    "SET last_viewed_at = excluded.last_viewed_at",
+                    (account_number, ts),
+                )
+        except sqlite3.Error as e:
+            logger.warning("mark_viewed failed: %s", e)
+
+    def get_history(self, account_number: str, limit: int = 50) -> list[dict]:
+        """Most-recent-first list of dicts. Empty list on error."""
+        try:
+            rows = self._conn.execute(
+                "SELECT id, severity, category, message, context, recorded_at "
+                "FROM alert_history WHERE account_number = ? "
+                "ORDER BY recorded_at DESC LIMIT ?",
+                (account_number, limit),
+            ).fetchall()
+        except sqlite3.Error as e:
+            logger.warning("get_history failed: %s", e)
+            return []
+        out: list[dict] = []
+        for r in rows:
+            ctx: Any = None
+            if r["context"]:
+                try:
+                    ctx = json.loads(r["context"])
+                except (TypeError, ValueError):
+                    ctx = None
+            try:
+                recorded = datetime.fromisoformat(r["recorded_at"])
+            except (TypeError, ValueError):
+                recorded = None
+            out.append({
+                "id": r["id"],
+                "severity": r["severity"],
+                "category": r["category"],
+                "message": r["message"],
+                "context": ctx,
+                "recorded_at": recorded,
+            })
+        return out
+
+    def new_alert_keys_since(
+        self,
+        account_number: str,
+        since: Optional[datetime],
+    ) -> set:
+        """Return {(category, message), ...} for alerts recorded after `since`.
+
+        Returns an empty set if `since` is None (first ever view — avoid a
+        wall of dots on every alert).
+        """
+        if since is None:
+            return set()
+        since_iso = _as_utc(since).isoformat()
+        try:
+            rows = self._conn.execute(
+                "SELECT category, message FROM alert_history "
+                "WHERE account_number = ? AND recorded_at > ?",
+                (account_number, since_iso),
+            ).fetchall()
+        except sqlite3.Error as e:
+            logger.warning("new_alert_keys_since failed: %s", e)
+            return set()
+        return {(r["category"], r["message"]) for r in rows}
+
+
+def print_alert_history(
+    store: AlertStore,
+    account_number: str,
+    limit: int = 50,
+    *,
+    console=None,
+) -> None:
+    """Render a Rich Table of recent alerts. Prints to stdout via Console."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = console or Console()
+    rows = store.get_history(account_number, limit=limit)
+    if not rows:
+        console.print(f"No alerts recorded for {account_number}.")
+        return
+    table = Table(title=f"Alert history — {account_number}")
+    table.add_column("Recorded")
+    table.add_column("Severity")
+    table.add_column("Category")
+    table.add_column("Message", overflow="fold")
+    for r in rows:
+        ts = r["recorded_at"].isoformat() if r["recorded_at"] else "—"
+        table.add_row(ts, r["severity"], r["category"], r["message"])
+    console.print(table)

--- a/utils/dashboard_ui.py
+++ b/utils/dashboard_ui.py
@@ -192,7 +192,8 @@ async def gather_dashboard_data(session, account_number=None) -> DashboardData:
             pa = await PortfolioAgent(session, account_number=account_number).init()
             status = await pa.get_account_status()
             positions = await pa.get_positions()
-            return {"status": status, "positions": positions}
+            resolved = getattr(getattr(pa, "account", None), "account_number", None)
+            return {"status": status, "positions": positions, "resolved_account": resolved}
         except Exception as e:
             logger.error(f"Error fetching portfolio data: {e}")
             data.errors["portfolio"] = str(e)
@@ -233,9 +234,13 @@ async def gather_dashboard_data(session, account_number=None) -> DashboardData:
         data.errors["risk"] = str(risk_result)
 
     # Unpack portfolio
+    resolved_account_number = account_number
     if isinstance(portfolio_result, dict):
         data.account_status = portfolio_result.get("status")
         data.positions = portfolio_result.get("positions")
+        resolved_account_number = (
+            portfolio_result.get("resolved_account") or account_number
+        )
     elif isinstance(portfolio_result, Exception):
         data.errors["portfolio"] = str(portfolio_result)
 
@@ -263,16 +268,21 @@ async def gather_dashboard_data(session, account_number=None) -> DashboardData:
     # Persist alerts + compute "new since last view" markers. Ordering:
     # read last_viewed → persist current batch → compute new_keys from the
     # persisted rows (so first-seen alerts appear as new) → advance watermark.
-    if account_number and data.risk and data.risk.get("alerts"):
+    # Use the resolved account number (the one PortfolioAgent actually
+    # talked to) so single-account users without --account/env still get
+    # persistence.
+    if resolved_account_number and data.risk and data.risk.get("alerts"):
         try:
             from utils.alert_store import AlertStore
             from utils.db import TradeDB
             db = TradeDB()
             store = AlertStore(db)
-            last_viewed = store.get_last_viewed(account_number)
-            store.record_alerts(account_number, data.risk["alerts"])
-            data.new_alert_keys = store.new_alert_keys_since(account_number, last_viewed)
-            store.mark_viewed(account_number)
+            last_viewed = store.get_last_viewed(resolved_account_number)
+            store.record_alerts(resolved_account_number, data.risk["alerts"])
+            data.new_alert_keys = store.new_alert_keys_since(
+                resolved_account_number, last_viewed
+            )
+            store.mark_viewed(resolved_account_number)
             db.close()
         except Exception as e:
             logger.warning("alert persistence/markers failed: %s", e)

--- a/utils/dashboard_ui.py
+++ b/utils/dashboard_ui.py
@@ -55,6 +55,7 @@ class DashboardData:
     nlv: Optional[Decimal] = None
     position_pct_nlv_warn: float = DEFAULT_POSITION_PCT_NLV_WARN
     errors: dict[str, str] = field(default_factory=dict)
+    new_alert_keys: set = field(default_factory=set)
 
 
 # --- Formatting Helpers ---
@@ -258,6 +259,24 @@ async def gather_dashboard_data(session, account_number=None) -> DashboardData:
             data.nlv = Decimal(str(data.account_status["net_liquidating_value"]))
     except (InvalidOperation, ValueError, TypeError):
         pass
+
+    # Persist alerts + compute "new since last view" markers. Ordering:
+    # read last_viewed → persist current batch → compute new_keys from the
+    # persisted rows (so first-seen alerts appear as new) → advance watermark.
+    if account_number and data.risk and data.risk.get("alerts"):
+        try:
+            from utils.alert_store import AlertStore
+            from utils.db import TradeDB
+            db = TradeDB()
+            store = AlertStore(db)
+            last_viewed = store.get_last_viewed(account_number)
+            store.record_alerts(account_number, data.risk["alerts"])
+            data.new_alert_keys = store.new_alert_keys_since(account_number, last_viewed)
+            store.mark_viewed(account_number)
+            db.close()
+        except Exception as e:
+            logger.warning("alert persistence/markers failed: %s", e)
+            data.new_alert_keys = set()
 
     return data
 
@@ -559,6 +578,8 @@ def render_alerts_panel(data: DashboardData) -> Panel:
         "info": "bold blue",
     }
 
+    new_keys = data.new_alert_keys or set()
+
     for alert in alerts:
         severity = str(_g(alert, "severity", "info")).lower()
         category = _g(alert, "category", "")
@@ -568,6 +589,8 @@ def render_alerts_panel(data: DashboardData) -> Panel:
         severity_upper = severity.upper()
 
         row = Text()
+        if (category, message) in new_keys:
+            row.append("● ", style="bold magenta")
         row.append(severity_upper, style=color)
         row.append(f"  {category}  {message}")
         table.add_row(row)

--- a/utils/db.py
+++ b/utils/db.py
@@ -11,7 +11,7 @@ DB_PATH = Path.home() / ".tasty-coach" / "history.db"
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 MIGRATIONS = [
     # Version 1: Initial schema
@@ -114,6 +114,30 @@ MIGRATIONS = [
         version INTEGER PRIMARY KEY
     );
     INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+    """,
+    # Version 2: Phase E alert persistence
+    """
+    CREATE TABLE IF NOT EXISTS alert_history (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        account_number TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        category TEXT NOT NULL,
+        message TEXT NOT NULL,
+        context TEXT,
+        recorded_at TEXT NOT NULL,
+        recorded_day TEXT NOT NULL,
+        UNIQUE(account_number, category, message, recorded_day)
+    );
+
+    CREATE TABLE IF NOT EXISTS alert_views (
+        account_number TEXT PRIMARY KEY,
+        last_viewed_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_alert_history_account_time
+        ON alert_history(account_number, recorded_at DESC);
+
+    INSERT OR IGNORE INTO schema_version (version) VALUES (2);
     """,
 ]
 

--- a/utils/launcher_ui.py
+++ b/utils/launcher_ui.py
@@ -225,6 +225,7 @@ class LauncherUI:
             LauncherAction("t", "Event timeline", "Recent fills, assignments, exercises, and rolls", self._run_event_timeline),
             LauncherAction("9", "Dashboard", "Open the market quality dashboard", self._run_dashboard),
             LauncherAction("a", "Switch account", "Pick a different linked account", self._switch_account),
+            LauncherAction("s", "Settings", "Edit thresholds and alert toggles", self._run_settings_editor),
             LauncherAction("q", "Quit", "Exit the launcher", self._quit, exit_on_run=True, shortcut="F10"),
         ]
 
@@ -558,6 +559,78 @@ class LauncherUI:
             self.context.account_number if self.context else self.account_number
         )
         await run_account_dashboard(self.session, account_number=account_number)
+
+    async def _run_settings_editor(self) -> None:
+        """Launcher handler: interactive editor for Phase A settings."""
+        from rich.prompt import Confirm, Prompt
+        from rich.table import Table
+        from utils.settings import (
+            NUMERIC_KEYS,
+            OPTIONAL_NUMERIC_KEYS,
+            settings as settings_obj,
+        )
+
+        console = self.console
+        numeric_keys = sorted(NUMERIC_KEYS) + sorted(OPTIONAL_NUMERIC_KEYS)
+        toggle_keys = sorted((settings_obj.get("alert_toggles") or {}).keys())
+
+        pending: dict[str, Any] = {}
+
+        try:
+            console.print("[bold]Settings — numeric thresholds[/bold]")
+            console.print("[dim]  Enter a number to change. For optional keys, type 'none' to clear.[/dim]")
+            for key in numeric_keys:
+                current = settings_obj.get(key)
+                shown = "" if current is None else str(current)
+                answer = Prompt.ask(
+                    f"  {key}",
+                    default=shown,
+                    console=console,
+                )
+                if answer == shown:
+                    continue
+                if key in OPTIONAL_NUMERIC_KEYS and answer.strip().lower() in ("none", "null", ""):
+                    pending[key] = None
+                else:
+                    pending[key] = answer
+
+            console.print("\n[bold]Settings — alert toggles[/bold]")
+            toggles = settings_obj.get("alert_toggles") or {}
+            for cat in toggle_keys:
+                current_bool = bool(toggles.get(cat, True))
+                new_bool = Confirm.ask(
+                    f"  Enable alerts for {cat}?",
+                    default=current_bool,
+                    console=console,
+                )
+                if new_bool != current_bool:
+                    pending[f"alert_toggles.{cat}"] = new_bool
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Cancelled — no changes written.[/yellow]")
+            return
+
+        if not pending:
+            console.print("\n[dim]No changes.[/dim]")
+            return
+
+        preview = Table(title="Pending changes", show_header=True)
+        preview.add_column("Key")
+        preview.add_column("New value")
+        for k, v in pending.items():
+            preview.add_row(k, repr(v))
+        console.print(preview)
+
+        if not Confirm.ask("Save changes?", default=True, console=console):
+            console.print("[yellow]Discarded.[/yellow]")
+            return
+
+        try:
+            settings_obj.set_many(pending)
+            console.print("[green]Settings saved to {}[/green]".format(settings_obj.config_path))
+        except ValueError as e:
+            console.print(f"[red]Invalid value: {e}[/red]")
+        except OSError as e:
+            console.print(f"[red]Could not write config: {e}[/red]")
 
     async def _run_event_timeline(self) -> None:
         """Launcher handler: render event timeline for the active account."""

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import math
 import copy
 import os
 from pathlib import Path
@@ -145,6 +146,8 @@ class Settings:
             f = float(value)
         except (TypeError, ValueError) as e:
             raise ValueError(f"{key}: not a number ({value!r})") from e
+        if not math.isfinite(f):
+            raise ValueError(f"{key}: must be finite (got {f})")
         if f < 0:
             raise ValueError(f"{key}: must be >= 0 (got {f})")
         return f

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -3,8 +3,19 @@
 import json
 import logging
 import copy
+import os
 from pathlib import Path
 from typing import Any
+
+NUMERIC_KEYS: frozenset[str] = frozenset({
+    "position_pct_nlv_warn",
+    "bp_usage_warn",
+    "bp_usage_block",
+    "concentration_pct_nlv_warn",
+})
+OPTIONAL_NUMERIC_KEYS: frozenset[str] = frozenset({
+    "theta_target",  # may be None
+})
 
 DEFAULTS: dict[str, Any] = {
     "position_pct_nlv_warn": 0.05,
@@ -76,6 +87,94 @@ class Settings:
     def reload(self) -> None:
         """Force reload from disk."""
         self._data = None
+
+    def set(self, key: str, value: Any) -> None:
+        """Validate and persist a single setting. See set_many for details."""
+        self.set_many({key: value})
+
+    def set_many(self, updates: dict[str, Any]) -> None:
+        """Validate all updates, then write once atomically.
+
+        Supports dotted keys under `alert_toggles.*`. Raises ValueError on
+        any invalid entry and writes nothing; on success the new values are
+        persisted to disk and reflected in-memory.
+        """
+        if self._data is None:
+            self._data = self._load()
+        merged = copy.deepcopy(self._data)
+        for key, raw in updates.items():
+            coerced = self._validate_value(key, raw)
+            self._apply_dotted(merged, key, coerced)
+        self._atomic_write(merged)
+        self._data = merged
+
+    def _validate_value(self, key: str, value: Any) -> Any:
+        """Coerce and validate a single key's value."""
+        if key.startswith("alert_toggles."):
+            return self._coerce_bool(key, value)
+        if key == "alert_toggles":
+            if not isinstance(value, dict):
+                raise ValueError("alert_toggles must be a dict of bools")
+            coerced = {k: self._coerce_bool(f"alert_toggles.{k}", v) for k, v in value.items()}
+            existing = (self._data or {}).get("alert_toggles") or {}
+            return {**DEFAULTS["alert_toggles"], **existing, **coerced}
+        if key in OPTIONAL_NUMERIC_KEYS:
+            if value is None or (isinstance(value, str) and value.strip() == ""):
+                return None
+            return self._coerce_nonneg_float(key, value)
+        if key in NUMERIC_KEYS:
+            return self._coerce_nonneg_float(key, value)
+        if key in DEFAULTS:
+            # Unknown behavior for non-numeric keys in DEFAULTS — pass through
+            return value
+        raise ValueError(f"unknown setting: {key!r}")
+
+    @staticmethod
+    def _coerce_bool(key: str, value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)) and value in (0, 1):
+            return bool(value)
+        if isinstance(value, str) and value.lower() in ("true", "false", "1", "0", "yes", "no"):
+            return value.lower() in ("true", "1", "yes")
+        raise ValueError(f"{key}: expected a boolean, got {value!r}")
+
+    @staticmethod
+    def _coerce_nonneg_float(key: str, value: Any) -> float:
+        try:
+            f = float(value)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"{key}: not a number ({value!r})") from e
+        if f < 0:
+            raise ValueError(f"{key}: must be >= 0 (got {f})")
+        return f
+
+    @staticmethod
+    def _apply_dotted(d: dict, dotted_key: str, value: Any) -> None:
+        if "." not in dotted_key:
+            d[dotted_key] = value
+            return
+        head, _, tail = dotted_key.partition(".")
+        sub = d.get(head)
+        if not isinstance(sub, dict):
+            sub = {}
+            d[head] = sub
+        Settings._apply_dotted(sub, tail, value)
+
+    def _atomic_write(self, merged: dict[str, Any]) -> None:
+        """Write merged dict to <path>.tmp then os.rename to config_path."""
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.config_path.with_suffix(self.config_path.suffix + ".tmp")
+        try:
+            tmp.write_text(json.dumps(merged, indent=2))
+            os.replace(tmp, self.config_path)
+        except OSError:
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except OSError:
+                pass
+            raise
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
Provide in-launcher settings editor and persist alerts with "new" markers in dashboard.

## Scope
- In-launcher settings editor screen (edit Phase A config values without hand-editing JSON)
- Alert persistence SQLite table + "new since last view" markers in dashboard alert strip

## Out of scope
- Cloud-based settings sync
- Alert filtering / snooze
- Notification channels (email, Slack, etc.)

## Dependencies
Phase A (settings framework)
Phase B (dashboard view)

## Linked task
TCMVP-5

## Test plan
- [ ] Implementation TBD
- [ ] Manual verification against scope acceptance criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)