### PR TITLE
TCBT-2: add --best-trades CLI entry point (stub)

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -1,0 +1,57 @@
+"""Watchlist-wide trade ranking orchestrator.
+
+Stub implementation for TCBT-2. Full pipeline is implemented across
+TCBT-3..11; this module currently returns a canonical empty result so the
+CLI and launcher entry points can be wired in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+from tastytrade import Session
+
+
+DEFAULT_WATCHLISTS: tuple[str, ...] = (
+    "Chris Historical Trades",
+    "High Options Volume",
+)
+
+STUB_MARKER: str = "stub — full logic in TCBT-8/3/9/10/4/5/6/7"
+
+
+async def run_best_trades(
+    session: Session,
+    *,
+    watchlists: Optional[Sequence[str]] = None,
+    top: int = 3,
+    output_format: str = "text",
+) -> dict[str, Any]:
+    """Rank trade ideas across watchlists; stub returns an empty canonical result."""
+    resolved = list(watchlists) if watchlists is not None else list(DEFAULT_WATCHLISTS)
+    return {
+        "top": [],
+        "rejected": [],
+        "warnings": [],
+        "watchlists": resolved,
+    }
+
+
+def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
+    """Print a best-trades result dict in human-readable form including the stub marker."""
+    print()
+    print("=" * 80)
+    print(f"Best Trades Today  ({STUB_MARKER})")
+    print("=" * 80)
+    watchlists = result["watchlists"]
+    print(f"Watchlists: {', '.join(watchlists) if watchlists else '(none)'}")
+    print(f"Top requested: {top}")
+    print(f"Ranked: {len(result['top'])}   Rejected: {len(result['rejected'])}   Warnings: {len(result['warnings'])}")
+    if not result["top"]:
+        print()
+        print("No trade ideas yet — orchestrator stub. Implementation lands in TCBT-3..11.")
+    if result["warnings"]:
+        print()
+        print("Warnings:")
+        for w in result["warnings"]:
+            print(f"  • {w}")

--- a/main.py
+++ b/main.py
@@ -79,6 +79,9 @@ def setup_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--min-credit-ratio", type=float, default=None, help="Minimum credit as fraction of spread width (default: 0.25)")
     parser.add_argument("--min-delta", type=float, default=None, help="Minimum absolute short delta (default: 0.15)")
     parser.add_argument("--max-delta", type=float, default=None, help="Maximum absolute short delta (default: 0.45)")
+    parser.add_argument("--best-trades", action="store_true", help="Rank best trade ideas across watchlists")
+    parser.add_argument("--top", type=int, default=3, help="Number of top ideas to surface (use with --best-trades, default: 3)")
+    parser.add_argument("--bt-watchlist", action="append", dest="bt_watchlist", metavar="NAME", help="Watchlist to include in --best-trades (repeatable; defaults: Chris Historical Trades, High Options Volume)")
     parser.add_argument("--force", action="store_true", help="Override Risk Manager blocks")
     parser.add_argument("--debug", "-D", action="store_true", help="Enable debug logging")
     return parser
@@ -246,6 +249,23 @@ async def async_main() -> int:
                 default_threshold=args.threshold or client.config.ivr_threshold,
             )
             return await launcher.run()
+
+        if args.best_trades:
+            from agents.trade_ranker import run_best_trades, _print_best_trades_text
+
+            result = await run_best_trades(
+                session,
+                watchlists=args.bt_watchlist,
+                top=args.top,
+                output_format=args.format,
+            )
+
+            if args.format == "json":
+                print(json.dumps(result, indent=2, default=str))
+            else:
+                _print_best_trades_text(result, args.top)
+
+            return 0
 
         if args.home:
             account_number = args.account or client.config.account_number

--- a/tests/test_best_trades_cli.py
+++ b/tests/test_best_trades_cli.py
@@ -1,0 +1,236 @@
+"""Tests for TCBT-2 best-trades CLI entry point and launcher integration."""
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestBestTradesArgparse(unittest.TestCase):
+    """Test argparse integration for best-trades flags."""
+
+    def setUp(self):
+        from main import setup_argument_parser
+        self.parser = setup_argument_parser()
+
+    def test_help_lists_best_trades_flag(self):
+        help_text = self.parser.format_help()
+        self.assertIn("--best-trades", help_text)
+
+    def test_help_lists_top_flag(self):
+        help_text = self.parser.format_help()
+        self.assertIn("--top", help_text)
+
+    def test_help_lists_bt_watchlist_flag(self):
+        help_text = self.parser.format_help()
+        self.assertIn("--bt-watchlist", help_text)
+
+    def test_best_trades_defaults(self):
+        args = self.parser.parse_args(["--best-trades"])
+        self.assertTrue(args.best_trades)
+        self.assertEqual(args.top, 3)
+        self.assertIsNone(args.bt_watchlist)
+        self.assertEqual(args.format, "text")
+
+    def test_bt_watchlist_appends(self):
+        args = self.parser.parse_args(["--best-trades", "--bt-watchlist", "A", "--bt-watchlist", "B"])
+        self.assertEqual(args.bt_watchlist, ["A", "B"])
+
+    def test_top_parses_int(self):
+        args = self.parser.parse_args(["--best-trades", "--top", "7"])
+        self.assertEqual(args.top, 7)
+
+    def test_format_choice_reused(self):
+        args = self.parser.parse_args(["--best-trades", "--format", "json"])
+        self.assertEqual(args.format, "json")
+
+    def test_existing_watchlist_flag_unaffected(self):
+        args = self.parser.parse_args(["-w", "Foo"])
+        self.assertEqual(args.watchlist, "Foo")
+        self.assertIsNone(args.bt_watchlist)
+
+
+class TestRunBestTradesStub(unittest.IsolatedAsyncioTestCase):
+    """Test the run_best_trades stub function."""
+
+    async def test_default_watchlists_used_when_none(self):
+        from agents.trade_ranker import run_best_trades, DEFAULT_WATCHLISTS
+        result = await run_best_trades(MagicMock())
+        self.assertEqual(result["watchlists"], list(DEFAULT_WATCHLISTS))
+
+    async def test_explicit_watchlists_honoured(self):
+        from agents.trade_ranker import run_best_trades
+        result = await run_best_trades(MagicMock(), watchlists=["X", "Y"])
+        self.assertEqual(result["watchlists"], ["X", "Y"])
+
+    async def test_explicit_empty_watchlists_honoured(self):
+        from agents.trade_ranker import run_best_trades
+        result = await run_best_trades(MagicMock(), watchlists=[])
+        self.assertEqual(result["watchlists"], [])
+
+    async def test_canonical_shape(self):
+        from agents.trade_ranker import run_best_trades
+        result = await run_best_trades(MagicMock())
+        self.assertEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
+        self.assertEqual(result["top"], [])
+        self.assertEqual(result["rejected"], [])
+        self.assertEqual(result["warnings"], [])
+
+    async def test_session_not_called(self):
+        from agents.trade_ranker import run_best_trades
+        session = MagicMock()
+        await run_best_trades(session)
+        self.assertEqual(session.method_calls, [])
+        self.assertEqual(session.mock_calls, [])
+
+    async def test_top_arg_accepted(self):
+        from agents.trade_ranker import run_best_trades
+        result = await run_best_trades(MagicMock(), top=10)
+        self.assertEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
+
+    async def test_output_format_arg_accepted(self):
+        from agents.trade_ranker import run_best_trades
+        result = await run_best_trades(MagicMock(), output_format="json")
+        self.assertEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
+
+
+class TestBestTradesCliOutput(unittest.IsolatedAsyncioTestCase):
+    """Test text and JSON output formats and CLI dispatch."""
+
+    def test_text_output_contains_stub_marker(self):
+        from agents.trade_ranker import _print_best_trades_text, STUB_MARKER
+        result = {"top": [], "rejected": [], "warnings": [], "watchlists": ["A"]}
+        f = io.StringIO()
+        with redirect_stdout(f):
+            _print_best_trades_text(result, 3)
+        self.assertIn(STUB_MARKER, f.getvalue())
+
+    def test_text_output_lists_watchlists(self):
+        from agents.trade_ranker import _print_best_trades_text
+        result = {"top": [], "rejected": [], "warnings": [], "watchlists": ["A"]}
+        f = io.StringIO()
+        with redirect_stdout(f):
+            _print_best_trades_text(result, 3)
+        self.assertIn("A", f.getvalue())
+
+    def _build_client_mock(self):
+        client_inst = MagicMock()
+        client_inst.authenticate.return_value = True
+        client_inst.get_session.return_value = MagicMock()
+        client_inst.config.log_level = "INFO"
+        client_inst.config.account_number = None
+        client_inst.config.ivr_threshold = 25.0
+        return client_inst
+
+    async def test_json_dispatch_emits_valid_json(self):
+        result_dict = {"top": [], "rejected": [], "warnings": [], "watchlists": ["X"]}
+        with patch("main._warn_if_not_in_venv"), \
+             patch("agents.trade_ranker.run_best_trades", new_callable=AsyncMock) as mock_run, \
+             patch("main.TastyClient") as mock_client:
+            mock_run.return_value = result_dict
+            mock_client.return_value = self._build_client_mock()
+            f = io.StringIO()
+            with redirect_stdout(f), patch.object(sys, "argv", ["main.py", "--best-trades", "--format", "json"]):
+                from main import async_main
+                rc = await async_main()
+            parsed = json.loads(f.getvalue().strip())
+            self.assertEqual(parsed, result_dict)
+            self.assertEqual(rc, 0)
+
+    async def test_text_dispatch_calls_printer(self):
+        result_dict = {"top": [], "rejected": [], "warnings": [], "watchlists": ["A"]}
+        with patch("main._warn_if_not_in_venv"), \
+             patch("agents.trade_ranker.run_best_trades", new_callable=AsyncMock) as mock_run, \
+             patch("agents.trade_ranker._print_best_trades_text") as mock_printer, \
+             patch("main.TastyClient") as mock_client:
+            mock_run.return_value = result_dict
+            mock_client.return_value = self._build_client_mock()
+            with patch.object(sys, "argv", ["main.py", "--best-trades", "--format", "text"]):
+                from main import async_main
+                await async_main()
+            mock_printer.assert_called_once_with(result_dict, 3)
+
+    async def test_dispatch_passes_bt_watchlist(self):
+        with patch("main._warn_if_not_in_venv"), \
+             patch("agents.trade_ranker.run_best_trades", new_callable=AsyncMock) as mock_run, \
+             patch("main.TastyClient") as mock_client:
+            mock_run.return_value = {"top": [], "rejected": [], "warnings": [], "watchlists": ["FOO", "BAR"]}
+            mock_client.return_value = self._build_client_mock()
+            with patch.object(sys, "argv", ["main.py", "--best-trades", "--bt-watchlist", "FOO", "--bt-watchlist", "BAR"]):
+                from main import async_main
+                await async_main()
+            self.assertEqual(mock_run.call_args[1]["watchlists"], ["FOO", "BAR"])
+
+    async def test_dispatch_passes_top(self):
+        with patch("main._warn_if_not_in_venv"), \
+             patch("agents.trade_ranker.run_best_trades", new_callable=AsyncMock) as mock_run, \
+             patch("main.TastyClient") as mock_client:
+            mock_run.return_value = {"top": [], "rejected": [], "warnings": [], "watchlists": []}
+            mock_client.return_value = self._build_client_mock()
+            with patch.object(sys, "argv", ["main.py", "--best-trades", "--top", "5"]):
+                from main import async_main
+                await async_main()
+            self.assertEqual(mock_run.call_args[1]["top"], 5)
+
+    async def test_dispatch_runs_without_account(self):
+        with patch("main._warn_if_not_in_venv"), \
+             patch("agents.trade_ranker.run_best_trades", new_callable=AsyncMock) as mock_run, \
+             patch("main.TastyClient") as mock_client:
+            mock_run.return_value = {"top": [], "rejected": [], "warnings": [], "watchlists": []}
+            client_inst = self._build_client_mock()
+            client_inst.get_accounts = AsyncMock(side_effect=AssertionError("get_accounts must not be called for --best-trades"))
+            mock_client.return_value = client_inst
+            with patch.object(sys, "argv", ["main.py", "--best-trades"]):
+                from main import async_main
+                rc = await async_main()
+            self.assertEqual(rc, 0)
+
+
+class TestBestTradesLauncher(unittest.IsolatedAsyncioTestCase):
+    """Test launcher integration."""
+
+    def _build_ui(self):
+        from utils.launcher_ui import LauncherUI
+        ui = LauncherUI(MagicMock(), MagicMock())
+        ui.context = MagicMock()
+        return ui
+
+    def test_action_present(self):
+        ui = self._build_ui()
+        b_actions = [a for a in ui._actions() if a.key == "b"]
+        self.assertEqual(len(b_actions), 1)
+        self.assertEqual(b_actions[0].title, "Best trades today")
+
+    def test_action_handler_is_method(self):
+        ui = self._build_ui()
+        b_action = next(a for a in ui._actions() if a.key == "b")
+        self.assertEqual(b_action.handler, ui._run_best_trades)
+
+    def test_action_does_not_exit(self):
+        ui = self._build_ui()
+        b_action = next(a for a in ui._actions() if a.key == "b")
+        self.assertFalse(b_action.exit_on_run)
+
+    async def test_handler_calls_run_best_trades(self):
+        with patch("agents.trade_ranker.run_best_trades", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = {"top": [], "rejected": [], "warnings": [], "watchlists": []}
+            ui = self._build_ui()
+            ui.session = MagicMock()
+            await ui._run_best_trades()
+            mock_run.assert_called_once()
+            self.assertEqual(mock_run.call_args[0][0], ui.session)
+
+    async def test_handler_prints_via_text_printer(self):
+        with patch("agents.trade_ranker.run_best_trades", new_callable=AsyncMock) as mock_run, \
+             patch("agents.trade_ranker._print_best_trades_text") as mock_printer:
+            mock_run.return_value = {"top": [], "rejected": [], "warnings": [], "watchlists": []}
+            ui = self._build_ui()
+            ui.session = MagicMock()
+            await ui._run_best_trades()
+            mock_printer.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/launcher_ui.py
+++ b/utils/launcher_ui.py
@@ -224,6 +224,7 @@ class LauncherUI:
             LauncherAction("d", "Account dashboard", "Unified portfolio, performance, and risk view", self._run_account_dashboard),
             LauncherAction("t", "Event timeline", "Recent fills, assignments, exercises, and rolls", self._run_event_timeline),
             LauncherAction("9", "Dashboard", "Open the market quality dashboard", self._run_dashboard),
+            LauncherAction("b", "Best trades today", "Rank best trade ideas across watchlists", self._run_best_trades),
             LauncherAction("a", "Switch account", "Pick a different linked account", self._switch_account),
             LauncherAction("s", "Settings", "Edit thresholds and alert toggles", self._run_settings_editor),
             LauncherAction("q", "Quit", "Exit the launcher", self._quit, exit_on_run=True, shortcut="F10"),
@@ -655,6 +656,12 @@ class LauncherUI:
 
         open_html = await self._prompt_confirm("Open in browser?", default=False)
         await run_dashboard(self.session, html=open_html)
+
+    async def _run_best_trades(self) -> None:
+        """Launcher handler: run watchlist-wide best-trades stub with defaults (no prompts)."""
+        from agents.trade_ranker import run_best_trades, _print_best_trades_text
+        result = await run_best_trades(self.session)
+        _print_best_trades_text(result, top=3)
 
     def _get_watchlist_catalog(self) -> list[dict[str, str]]:
         """Return a combined private/public watchlist catalog."""


### PR DESCRIPTION
## Summary
- Wires the `--best-trades` CLI flag (plus `--top N` and repeatable `--bt-watchlist NAME`) and a launcher action ("b") for the watchlist-wide trade ranking pipeline introduced in [Linear TCBT-2](Linear: TCBT-2).
- The orchestrator (`agents/trade_ranker.py:run_best_trades`) is a deliberate stub returning a canonical empty result; full logic lands in TCBT-3..11.
- New dispatch branch in `async_main()` runs without account context (verified by test) and does not touch existing flags' code paths.

## Test plan
- [x] `./venv/bin/python main.py --help` shows the three new flags
- [x] `./venv/bin/python -m unittest tests.test_best_trades_cli -v` — 27 / 27 pass
- [x] Full suite — only pre-existing `test_risk_manager.test_calculate_risk_metrics` failure (verified on `main` before this branch)
- [x] `--best-trades` text mode prints stub marker `stub — full logic in TCBT-8/3/9/10/4/5/6/7`
- [x] `--best-trades --format json` emits valid JSON parseable by `json.loads`
- [x] Launcher menu exposes "Best trades today" with key `b`, no prompts in handler

## Out of scope
Stub only. Watchlist scanning, candidate generation, gates, scoring, account-fit, and logging come in subsequent PRs (TCBT-3..11).

## QA
Built via `/build-qa` (Opus plan → Haiku build → Sonnet review → Opus final review → fixes applied). Codex independent review (Step 5) skipped — `/codex:review` skill not available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)