### PR TITLE
TCBT-8: watchlist scanning into SymbolContext

### DIFF
--- a/agents/scanner.py
+++ b/agents/scanner.py
@@ -233,23 +233,23 @@ class ScannerAgent:
                         
                     if metric:
                         try:
-                            ivr.iv_rank = (float(metric.implied_volatility_index_rank) * 100) if metric.implied_volatility_index_rank else None
+                            ivr.iv_rank = (float(metric.implied_volatility_index_rank) * 100) if metric.implied_volatility_index_rank is not None else None
                         except (ValueError, TypeError):
                             ivr.iv_rank = None
                         try:
-                            ivr.iv_percentile = (float(metric.implied_volatility_percentile) * 100) if metric.implied_volatility_percentile else None
+                            ivr.iv_percentile = (float(metric.implied_volatility_percentile) * 100) if metric.implied_volatility_percentile is not None else None
                         except (ValueError, TypeError):
                             ivr.iv_percentile = None
                         try:
-                            ivr.current_iv = float(metric.implied_volatility_index) if metric.implied_volatility_index else None
+                            ivr.current_iv = float(metric.implied_volatility_index) if metric.implied_volatility_index is not None else None
                         except (ValueError, TypeError):
                             ivr.current_iv = None
                         try:
-                            ivr.beta = float(metric.beta) if metric.beta else None
+                            ivr.beta = float(metric.beta) if metric.beta is not None else None
                         except (ValueError, TypeError):
                             ivr.beta = None
                         try:
-                            ivr.liquidity_rank = float(metric.liquidity_rank) if metric.liquidity_rank else None
+                            ivr.liquidity_rank = float(metric.liquidity_rank) if metric.liquidity_rank is not None else None
                         except (ValueError, TypeError):
                             ivr.liquidity_rank = None
                         if metric.earnings and metric.earnings.expected_report_date:

--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -120,23 +120,23 @@ def _build_context(
 
     if metric is not None:
         try:
-            ctx.iv_rank = (float(metric.implied_volatility_index_rank) * 100) if metric.implied_volatility_index_rank else None
+            ctx.iv_rank = (float(metric.implied_volatility_index_rank) * 100) if metric.implied_volatility_index_rank is not None else None
         except (ValueError, TypeError):
             ctx.iv_rank = None
         try:
-            ctx.iv_percentile = (float(metric.implied_volatility_percentile) * 100) if metric.implied_volatility_percentile else None
+            ctx.iv_percentile = (float(metric.implied_volatility_percentile) * 100) if metric.implied_volatility_percentile is not None else None
         except (ValueError, TypeError):
             ctx.iv_percentile = None
         try:
-            ctx.current_iv = float(metric.implied_volatility_index) if metric.implied_volatility_index else None
+            ctx.current_iv = float(metric.implied_volatility_index) if metric.implied_volatility_index is not None else None
         except (ValueError, TypeError):
             ctx.current_iv = None
         try:
-            ctx.beta = float(metric.beta) if metric.beta else None
+            ctx.beta = float(metric.beta) if metric.beta is not None else None
         except (ValueError, TypeError):
             ctx.beta = None
         try:
-            ctx.liquidity_rank = float(metric.liquidity_rank) if metric.liquidity_rank else None
+            ctx.liquidity_rank = float(metric.liquidity_rank) if metric.liquidity_rank is not None else None
         except (ValueError, TypeError):
             ctx.liquidity_rank = None
         if metric.earnings and metric.earnings.expected_report_date:

--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -7,9 +7,16 @@ CLI and launcher entry points can be wired in isolation.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
 from typing import Any, Optional, Sequence
 
 from tastytrade import Session
+from tastytrade.metrics import get_market_metrics
+from tastytrade.market_data import get_market_data_by_type
+
+from agents.scanner import ScannerAgent
 
 
 DEFAULT_WATCHLISTS: tuple[str, ...] = (
@@ -18,6 +25,124 @@ DEFAULT_WATCHLISTS: tuple[str, ...] = (
 )
 
 STUB_MARKER: str = "stub — full logic in TCBT-8/3/9/10/4/5/6/7"
+
+_BATCH_SIZE: int = 50
+
+
+@dataclass
+class SymbolContext:
+    """Normalised per-symbol scan output ready for candidate generation."""
+    symbol: str
+    current_price: Optional[Decimal] = None
+    volume: Optional[Decimal] = None
+    iv_rank: Optional[float] = None
+    iv_percentile: Optional[float] = None
+    current_iv: Optional[float] = None
+    beta: Optional[float] = None
+    liquidity_rank: Optional[float] = None
+    next_earnings_date: Optional[date] = None
+
+
+async def scan_watchlists(
+    session: Session,
+    watchlists: Optional[Sequence[str]] = None,
+    *,
+    scanner: Optional[ScannerAgent] = None,
+) -> tuple[list[SymbolContext], list[str]]:
+    """Resolve watchlist symbols and fetch metric+price data; return (contexts, warnings)."""
+    warnings: list[str] = []
+    contexts: list[SymbolContext] = []
+
+    if watchlists is None:
+        names = list(DEFAULT_WATCHLISTS)
+    else:
+        names = list(watchlists)
+
+    if not names:
+        return ([], [])
+
+    if scanner is None:
+        scanner = ScannerAgent(session)
+
+    seen: set[str] = set()
+    symbols: list[str] = []
+    for name in names:
+        wl_symbols = await scanner.get_symbols_from_watchlist(name, equity_only=True)
+        if not wl_symbols:
+            warnings.append(f"watchlist '{name}' not found or empty")
+            continue
+        for s in wl_symbols:
+            if s not in seen:
+                seen.add(s)
+                symbols.append(s)
+
+    if not symbols:
+        return (contexts, warnings)
+
+    for i in range(0, len(symbols), _BATCH_SIZE):
+        batch = symbols[i:i + _BATCH_SIZE]
+        try:
+            metrics_list = get_market_metrics(session, batch)
+            prices_list = get_market_data_by_type(session, equities=batch)
+        except Exception as e:
+            warnings.append(f"batch fetch failed: {e}")
+            continue
+
+        metrics = {m.symbol: m for m in metrics_list}
+        prices = {d.symbol: d for d in prices_list}
+
+        for symbol in batch:
+            metric = metrics.get(symbol)
+            data = prices.get(symbol)
+            ctx = _build_context(symbol, metric, data)
+            if ctx is None:
+                warnings.append(f"{symbol}: no market metrics or price data returned")
+            else:
+                contexts.append(ctx)
+
+    return (contexts, warnings)
+
+
+def _build_context(
+    symbol: str,
+    metric: Any,
+    data: Any,
+) -> Optional[SymbolContext]:
+    """Transform a metric+price pair into a SymbolContext; returns None when both inputs are absent."""
+    if metric is None and data is None:
+        return None
+
+    ctx = SymbolContext(symbol=symbol)
+
+    if data is not None:
+        ctx.current_price = data.mark if data.mark is not None else data.last
+        ctx.volume = data.volume
+
+    if metric is not None:
+        try:
+            ctx.iv_rank = (float(metric.implied_volatility_index_rank) * 100) if metric.implied_volatility_index_rank else None
+        except (ValueError, TypeError):
+            ctx.iv_rank = None
+        try:
+            ctx.iv_percentile = (float(metric.implied_volatility_percentile) * 100) if metric.implied_volatility_percentile else None
+        except (ValueError, TypeError):
+            ctx.iv_percentile = None
+        try:
+            ctx.current_iv = float(metric.implied_volatility_index) if metric.implied_volatility_index else None
+        except (ValueError, TypeError):
+            ctx.current_iv = None
+        try:
+            ctx.beta = float(metric.beta) if metric.beta else None
+        except (ValueError, TypeError):
+            ctx.beta = None
+        try:
+            ctx.liquidity_rank = float(metric.liquidity_rank) if metric.liquidity_rank else None
+        except (ValueError, TypeError):
+            ctx.liquidity_rank = None
+        if metric.earnings and metric.earnings.expected_report_date:
+            ctx.next_earnings_date = metric.earnings.expected_report_date
+
+    return ctx
 
 
 async def run_best_trades(

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -97,6 +97,40 @@ class TestBuildContext(unittest.TestCase):
         self.assertIsNotNone(ctx)
         self.assertEqual(ctx.current_price, Decimal("12.34"))
 
+    def test_zero_valued_metrics_preserved_not_coerced_to_none(self):
+        """Legitimate zero values (e.g. IVR=0 for a quiet stock) must survive as 0.0, not None."""
+        metric = _make_metric(
+            "AAPL",
+            ivr=Decimal("0"),
+            ivp=Decimal("0"),
+            iv=Decimal("0"),
+            beta=Decimal("0"),
+            liq=Decimal("0"),
+        )
+        ctx = _build_context("AAPL", metric, _make_price("AAPL"))
+        self.assertEqual(ctx.iv_rank, 0.0)
+        self.assertEqual(ctx.iv_percentile, 0.0)
+        self.assertEqual(ctx.current_iv, 0.0)
+        self.assertEqual(ctx.beta, 0.0)
+        self.assertEqual(ctx.liquidity_rank, 0.0)
+
+    def test_none_valued_metrics_remain_none(self):
+        """When the SDK returns None for a metric field, the context field stays None."""
+        metric = _make_metric(
+            "AAPL",
+            ivr=None,
+            ivp=None,
+            iv=None,
+            beta=None,
+            liq=None,
+        )
+        ctx = _build_context("AAPL", metric, _make_price("AAPL"))
+        self.assertIsNone(ctx.iv_rank)
+        self.assertIsNone(ctx.iv_percentile)
+        self.assertIsNone(ctx.current_iv)
+        self.assertIsNone(ctx.beta)
+        self.assertIsNone(ctx.liquidity_rank)
+
 
 class TestScanWatchlists(unittest.IsolatedAsyncioTestCase):
     """Tests for scan_watchlists orchestration."""

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -1,0 +1,226 @@
+"""Tests for agents.trade_ranker watchlist scanning and symbol context building."""
+
+import unittest
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agents.trade_ranker import SymbolContext, _build_context, scan_watchlists
+
+
+def _make_metric(
+    symbol,
+    *,
+    ivr=Decimal("0.45"),
+    ivp=Decimal("0.30"),
+    iv=Decimal("0.25"),
+    beta=Decimal("1.1"),
+    liq=Decimal("3"),
+    earnings_date=None,
+):
+    m = MagicMock()
+    m.symbol = symbol
+    m.implied_volatility_index_rank = ivr
+    m.implied_volatility_percentile = ivp
+    m.implied_volatility_index = iv
+    m.beta = beta
+    m.liquidity_rank = liq
+    if earnings_date is not None:
+        m.earnings = MagicMock()
+        m.earnings.expected_report_date = earnings_date
+    else:
+        m.earnings = None
+    return m
+
+
+def _make_price(symbol, *, mark=Decimal("100.00"), last=Decimal("99.50"), volume=Decimal("1000000")):
+    d = MagicMock()
+    d.symbol = symbol
+    d.mark = mark
+    d.last = last
+    d.volume = volume
+    return d
+
+
+class TestBuildContext(unittest.TestCase):
+    """Tests for _build_context helper."""
+
+    def test_single_symbol_produces_context(self):
+        metric = _make_metric("AAPL", ivr=Decimal("0.45"))
+        data = _make_price("AAPL", mark=Decimal("150.00"), volume=Decimal("5000000"))
+        ctx = _build_context("AAPL", metric, data)
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx.symbol, "AAPL")
+        self.assertEqual(ctx.current_price, Decimal("150.00"))
+        self.assertEqual(ctx.volume, Decimal("5000000"))
+        self.assertEqual(ctx.iv_rank, 45.0)
+        self.assertEqual(ctx.iv_percentile, 30.0)
+        self.assertEqual(ctx.current_iv, 0.25)
+        self.assertEqual(ctx.beta, 1.1)
+        self.assertEqual(ctx.liquidity_rank, 3.0)
+        self.assertIsNone(ctx.next_earnings_date)
+
+    def test_broken_symbol_emits_warning_no_crash(self):
+        ctx = _build_context("AAPL", None, None)
+        self.assertIsNone(ctx)
+
+    def test_earnings_date_preserved_as_date_object(self):
+        earnings_date = date(2026, 5, 1)
+        metric = _make_metric("AAPL", earnings_date=earnings_date)
+        data = _make_price("AAPL")
+        ctx = _build_context("AAPL", metric, data)
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx.next_earnings_date, date(2026, 5, 1))
+        self.assertIsInstance(ctx.next_earnings_date, date)
+
+    def test_partial_data_metric_only(self):
+        metric = _make_metric("AAPL")
+        ctx = _build_context("AAPL", metric, None)
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx.symbol, "AAPL")
+        self.assertIsNone(ctx.current_price)
+        self.assertIsNone(ctx.volume)
+        self.assertEqual(ctx.iv_rank, 45.0)
+
+    def test_partial_data_price_only(self):
+        data = _make_price("AAPL", mark=Decimal("150.00"))
+        ctx = _build_context("AAPL", None, data)
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx.symbol, "AAPL")
+        self.assertEqual(ctx.current_price, Decimal("150.00"))
+        self.assertEqual(ctx.volume, Decimal("1000000"))
+        self.assertIsNone(ctx.iv_rank)
+
+    def test_mark_none_falls_back_to_last(self):
+        data = _make_price("AAPL", mark=None, last=Decimal("12.34"))
+        ctx = _build_context("AAPL", None, data)
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx.current_price, Decimal("12.34"))
+
+
+class TestScanWatchlists(unittest.IsolatedAsyncioTestCase):
+    """Tests for scan_watchlists orchestration."""
+
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_single_symbol_produces_context(self, mock_prices, mock_metrics):
+        mock_metrics.return_value = [_make_metric("AAPL", ivr=Decimal("0.45"))]
+        mock_prices.return_value = [_make_price("AAPL")]
+        scanner = MagicMock()
+        scanner.get_symbols_from_watchlist = AsyncMock(return_value=["AAPL"])
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(session, watchlists=["Test"], scanner=scanner)
+        self.assertEqual(len(contexts), 1)
+        self.assertEqual(contexts[0].symbol, "AAPL")
+        self.assertEqual(contexts[0].iv_rank, 45.0)
+        self.assertEqual(len(warnings), 0)
+
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_broken_symbol_emits_warning_no_crash(self, mock_prices, mock_metrics):
+        mock_metrics.return_value = []
+        mock_prices.return_value = []
+        scanner = MagicMock()
+        scanner.get_symbols_from_watchlist = AsyncMock(return_value=["AAPL"])
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(session, watchlists=["Test"], scanner=scanner)
+        self.assertEqual(len(contexts), 0)
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0], "AAPL: no market metrics or price data returned")
+
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_merge_two_watchlists_dedupes_preserving_order(self, mock_prices, mock_metrics):
+        mock_metrics.return_value = [_make_metric("AAPL"), _make_metric("MSFT"), _make_metric("GOOG")]
+        mock_prices.return_value = [_make_price("AAPL"), _make_price("MSFT"), _make_price("GOOG")]
+        scanner = MagicMock()
+        scanner.get_symbols_from_watchlist = AsyncMock(side_effect=[["AAPL", "MSFT"], ["MSFT", "GOOG"]])
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(session, watchlists=["A", "B"], scanner=scanner)
+        symbols = [c.symbol for c in contexts]
+        self.assertEqual(symbols, ["AAPL", "MSFT", "GOOG"])
+        self.assertEqual(len(warnings), 0)
+
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_missing_watchlist_emits_warning(self, mock_prices, mock_metrics):
+        mock_metrics.return_value = [_make_metric("AAPL")]
+        mock_prices.return_value = [_make_price("AAPL")]
+        scanner = MagicMock()
+        scanner.get_symbols_from_watchlist = AsyncMock(side_effect=[[], ["AAPL"]])
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(session, watchlists=["Foo", "Bar"], scanner=scanner)
+        self.assertEqual(len(contexts), 1)
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0], "watchlist 'Foo' not found or empty")
+
+    @patch("agents.trade_ranker.ScannerAgent")
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_default_watchlists_used_when_none(self, mock_prices, mock_metrics, mock_scanner_class):
+        mock_metrics.return_value = []
+        mock_prices.return_value = []
+        scanner = MagicMock()
+        scanner.get_symbols_from_watchlist = AsyncMock(return_value=[])
+        mock_scanner_class.return_value = scanner
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(session, watchlists=None)
+        expected_calls = [
+            unittest.mock.call("Chris Historical Trades", equity_only=True),
+            unittest.mock.call("High Options Volume", equity_only=True),
+        ]
+        scanner.get_symbols_from_watchlist.assert_has_calls(expected_calls)
+
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_explicit_empty_watchlists_returns_empty(self, mock_prices, mock_metrics):
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(session, watchlists=[])
+        self.assertEqual(contexts, [])
+        self.assertEqual(warnings, [])
+        mock_metrics.assert_not_called()
+        mock_prices.assert_not_called()
+
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_earnings_date_preserved_as_date_object(self, mock_prices, mock_metrics):
+        earnings_date = date(2026, 5, 1)
+        mock_metrics.return_value = [_make_metric("AAPL", earnings_date=earnings_date)]
+        mock_prices.return_value = [_make_price("AAPL")]
+        scanner = MagicMock()
+        scanner.get_symbols_from_watchlist = AsyncMock(return_value=["AAPL"])
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(session, watchlists=["Test"], scanner=scanner)
+        self.assertEqual(len(contexts), 1)
+        self.assertEqual(contexts[0].next_earnings_date, date(2026, 5, 1))
+        self.assertIsInstance(contexts[0].next_earnings_date, date)
+
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_partial_data_does_not_emit_warning(self, mock_prices, mock_metrics):
+        mock_metrics.return_value = [_make_metric("AAPL")]
+        mock_prices.return_value = []
+        scanner = MagicMock()
+        scanner.get_symbols_from_watchlist = AsyncMock(return_value=["AAPL"])
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(session, watchlists=["Test"], scanner=scanner)
+        self.assertEqual(len(contexts), 1)
+        self.assertEqual(contexts[0].symbol, "AAPL")
+        self.assertEqual(len(warnings), 0)
+
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_batch_failure_warns_does_not_crash(self, mock_prices, mock_metrics):
+        mock_metrics.side_effect = RuntimeError("boom")
+        scanner = MagicMock()
+        scanner.get_symbols_from_watchlist = AsyncMock(return_value=["AAPL"])
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(session, watchlists=["Test"], scanner=scanner)
+        self.assertEqual(len(contexts), 0)
+        self.assertEqual(len(warnings), 1)
+        self.assertTrue(warnings[0].startswith("batch fetch failed: "))
+        self.assertIn("boom", warnings[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/launcher_ui.py
+++ b/utils/launcher_ui.py
@@ -1071,21 +1071,21 @@ class LauncherUI:
                         if metric:
                             ivr.iv_rank = (
                                 float(metric.implied_volatility_index_rank) * 100
-                                if metric.implied_volatility_index_rank
+                                if metric.implied_volatility_index_rank is not None
                                 else None
                             )
                             ivr.iv_percentile = (
                                 float(metric.implied_volatility_percentile) * 100
-                                if metric.implied_volatility_percentile
+                                if metric.implied_volatility_percentile is not None
                                 else None
                             )
                             ivr.current_iv = (
                                 float(metric.implied_volatility_index)
-                                if metric.implied_volatility_index
+                                if metric.implied_volatility_index is not None
                                 else None
                             )
-                            ivr.beta = float(metric.beta) if metric.beta else None
-                            ivr.liquidity_rank = float(metric.liquidity_rank) if metric.liquidity_rank else None
+                            ivr.beta = float(metric.beta) if metric.beta is not None else None
+                            ivr.liquidity_rank = float(metric.liquidity_rank) if metric.liquidity_rank is not None else None
                             if metric.earnings and metric.earnings.expected_report_date:
                                 ivr.next_earnings_date = metric.earnings.expected_report_date.strftime("%m/%d")
                             ivr.has_options = True


### PR DESCRIPTION
## Summary
- Adds `scan_watchlists(session, watchlists=None, *, scanner=None) -> (list[SymbolContext], list[str])` — the first real layer behind the `--best-trades` stub introduced in [TCBT-2](https://github.com/theglove44/tasty-coach/pull/9).
- Resolves configured watchlists (default: Chris Historical Trades + High Options Volume) via `ScannerAgent.get_symbols_from_watchlist`, dedupes across them preserving order, batches into 50-symbol chunks, fetches `get_market_metrics` + `get_market_data_by_type`.
- New `SymbolContext` carries: `current_price`, `volume`, `iv_rank`, `iv_percentile`, `current_iv`, `beta`, `liquidity_rank`, `next_earnings_date` (as a real `datetime.date`, not the year-stripped string `IVRData` uses).
- Symbol-level errors do NOT crash the scan — they collect into a `warnings` list with three locked formats: missing watchlist, no metric/price data for a symbol, batch fetch failure.

## Test plan
- [x] `./venv/bin/python -m unittest tests.test_trade_ranker -v` — 15 / 15 pass
- [x] Regression: `./venv/bin/python -m unittest tests.test_best_trades_cli -v` — 27 / 27 still pass
- [x] `run_best_trades` stub unchanged (wiring lands in TCBT-3+)

## Out of scope
- Wiring `scan_watchlists` into `run_best_trades` — that's TCBT-3 (candidate generation) and TCBT-4..7 (gates, scoring, account fit, output)
- `expected_move` field — SDK doesn't expose it; will be derived from the chain in TCBT-3 if useful
- Skipping non-equity instruments stays the responsibility of `get_symbols_from_watchlist(equity_only=True)`

## QA
Built via `/build-qa`: Opus plan → Haiku build (one iteration) → Sonnet review → Opus final review (APPROVED). Codex independent review skipped — `/codex:review` skill still not available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)