### PR TITLE
TCBT-3: candidate generation orchestrating OptionsResearcherAgent

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -16,6 +16,7 @@ from tastytrade import Session
 from tastytrade.metrics import get_market_metrics
 from tastytrade.market_data import get_market_data_by_type
 
+from agents.options_researcher import OptionsResearcherAgent
 from agents.scanner import ScannerAgent
 
 
@@ -41,6 +42,96 @@ class SymbolContext:
     beta: Optional[float] = None
     liquidity_rank: Optional[float] = None
     next_earnings_date: Optional[date] = None
+
+
+@dataclass
+class Candidate:
+    """A single trade idea ready for gates/scoring/ranking."""
+    symbol: str
+    structure: str
+    expiration: date
+    dte: int
+    width: float
+    credit: float
+    max_loss: float
+    credit_pct_of_width: float
+    short_delta: float
+    pop_estimate: float
+    breakevens: list[float]
+    net_greeks: dict[str, float]
+    legs: list[dict[str, Any]]
+    researcher_score: float
+    researcher_score_breakdown: dict[str, Any]
+    context: SymbolContext
+
+
+@dataclass
+class Rejection:
+    """A symbol or candidate that was filtered out before scoring."""
+    symbol: str
+    reason: str
+    detail: Optional[str] = None
+
+
+def _idea_to_candidate(symbol: str, idea: dict[str, Any], context: SymbolContext) -> Candidate:
+    """Translate a researcher trade_ideas dict into a Candidate, preserving the source SymbolContext."""
+    expiration = date.fromisoformat(idea["expiration"])
+    return Candidate(
+        symbol=symbol,
+        structure=idea["strategy"],
+        expiration=expiration,
+        dte=idea["dte"],
+        width=idea["width"],
+        credit=idea["credit"],
+        max_loss=idea["max_loss"],
+        credit_pct_of_width=idea["credit_pct_of_width"],
+        short_delta=idea["short_delta"],
+        pop_estimate=idea["pop_estimate"],
+        breakevens=list(idea.get("breakevens") or []),
+        net_greeks=dict(idea.get("net_greeks") or {}),
+        legs=list(idea.get("legs") or []),
+        researcher_score=idea["score"],
+        researcher_score_breakdown=dict(idea.get("score_breakdown") or {}),
+        context=context,
+    )
+
+
+async def generate_candidates(
+    session: Session,
+    contexts: Sequence[SymbolContext],
+    *,
+    researcher: Optional[OptionsResearcherAgent] = None,
+    max_per_symbol: int = 3,
+) -> tuple[list[Candidate], list[Rejection]]:
+    """For each SymbolContext, call OptionsResearcherAgent.research; return candidates + rejections."""
+    candidates: list[Candidate] = []
+    rejections: list[Rejection] = []
+
+    if not contexts:
+        return (candidates, rejections)
+
+    if researcher is None:
+        researcher = OptionsResearcherAgent(session)
+
+    for ctx in contexts:
+        try:
+            report = await researcher.research(ctx.symbol)
+        except Exception as e:
+            rejections.append(Rejection(symbol=ctx.symbol, reason="researcher_exception", detail=str(e)))
+            continue
+
+        status = report.get("status")
+        if status != "OK":
+            warnings = report.get("warnings") or []
+            detail = warnings[0] if warnings else None
+            rejections.append(Rejection(symbol=ctx.symbol, reason=str(status), detail=detail))
+            continue
+
+        ideas = report.get("trade_ideas") or []
+        for idea in ideas[:max_per_symbol]:
+            candidates.append(_idea_to_candidate(ctx.symbol, idea, ctx))
+
+    return (candidates, rejections)
 
 
 async def scan_watchlists(

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -5,7 +5,14 @@ from datetime import date
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from agents.trade_ranker import SymbolContext, _build_context, scan_watchlists
+from agents.trade_ranker import (
+    Candidate,
+    Rejection,
+    SymbolContext,
+    _build_context,
+    generate_candidates,
+    scan_watchlists,
+)
 
 
 def _make_metric(
@@ -254,6 +261,181 @@ class TestScanWatchlists(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(warnings), 1)
         self.assertTrue(warnings[0].startswith("batch fetch failed: "))
         self.assertIn("boom", warnings[0])
+
+
+def _make_idea(strategy="BULL_PUT_SPREAD", *, expiration="2026-06-19", dte=45,
+               width=5.0, credit=1.5, max_loss=350.0, credit_pct=0.30,
+               short_delta=0.30, pop=0.65, score=72.0,
+               score_breakdown=None, breakevens=None, net_greeks=None, legs=None):
+    return {
+        "rank": 1,
+        "strategy": strategy,
+        "expiration": expiration,
+        "dte": dte,
+        "width": width,
+        "credit": credit,
+        "max_loss": max_loss,
+        "credit_pct_of_width": credit_pct,
+        "short_delta": short_delta,
+        "pop_estimate": pop,
+        "breakevens": breakevens if breakevens is not None else [148.5],
+        "net_greeks": net_greeks if net_greeks is not None else {"delta": 0.05, "gamma": 0.001, "theta": 0.20, "vega": -0.15},
+        "legs": legs if legs is not None else [{"action": "SELL"}, {"action": "BUY"}],
+        "score": score,
+        "score_breakdown": score_breakdown if score_breakdown is not None else {"raw": {}},
+    }
+
+
+def _make_ok_report(symbol="AAPL", *, ideas=None, warnings=None):
+    return {
+        "status": "OK",
+        "symbol": symbol,
+        "warnings": warnings if warnings is not None else [],
+        "trade_ideas": ideas if ideas is not None else [_make_idea()],
+    }
+
+
+def _make_failure_report(symbol="AAPL", status="NO_CHAIN", warnings=None):
+    return {
+        "status": status,
+        "symbol": symbol,
+        "warnings": warnings if warnings is not None else [],
+        "trade_ideas": [],
+    }
+
+
+class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
+    """Tests for generate_candidates orchestration."""
+
+    async def test_single_context_produces_candidate(self):
+        researcher = MagicMock()
+        researcher.research = AsyncMock(return_value=_make_ok_report())
+        ctx = SymbolContext(symbol="AAPL")
+        candidates, rejections = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(len(rejections), 0)
+        c = candidates[0]
+        self.assertEqual(c.symbol, "AAPL")
+        self.assertEqual(c.structure, "BULL_PUT_SPREAD")
+        self.assertEqual(c.dte, 45)
+        self.assertEqual(c.credit, 1.5)
+        self.assertEqual(c.max_loss, 350.0)
+        self.assertEqual(c.short_delta, 0.30)
+        self.assertEqual(c.legs, [{"action": "SELL"}, {"action": "BUY"}])
+        self.assertEqual(c.researcher_score, 72.0)
+        self.assertEqual(c.researcher_score_breakdown, {"raw": {}})
+
+    async def test_expiration_parsed_to_date_object(self):
+        researcher = MagicMock()
+        researcher.research = AsyncMock(return_value=_make_ok_report(ideas=[_make_idea(expiration="2026-06-19")]))
+        ctx = SymbolContext(symbol="AAPL")
+        candidates, _ = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
+        self.assertEqual(candidates[0].expiration, date(2026, 6, 19))
+        self.assertIsInstance(candidates[0].expiration, date)
+
+    async def test_context_carried_through_to_candidate(self):
+        researcher = MagicMock()
+        researcher.research = AsyncMock(return_value=_make_ok_report())
+        ctx = SymbolContext(symbol="AAPL")
+        candidates, _ = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
+        self.assertIs(candidates[0].context, ctx)
+
+    async def test_status_not_ok_emits_rejection(self):
+        researcher = MagicMock()
+        researcher.research = AsyncMock(return_value=_make_failure_report(status="NO_VIABLE_IDEAS", warnings=[]))
+        ctx = SymbolContext(symbol="AAPL")
+        candidates, rejections = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
+        self.assertEqual(candidates, [])
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0].reason, "NO_VIABLE_IDEAS")
+        self.assertIsNone(rejections[0].detail)
+        self.assertEqual(rejections[0].symbol, "AAPL")
+
+    async def test_rejection_includes_first_warning(self):
+        researcher = MagicMock()
+        researcher.research = AsyncMock(return_value=_make_failure_report(status="NO_CHAIN", warnings=["chain unavailable", "x"]))
+        ctx = SymbolContext(symbol="AAPL")
+        _, rejections = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
+        self.assertEqual(rejections[0].detail, "chain unavailable")
+        self.assertEqual(rejections[0].reason, "NO_CHAIN")
+
+    async def test_researcher_exception_emits_rejection(self):
+        researcher = MagicMock()
+        researcher.research = AsyncMock(side_effect=RuntimeError("boom"))
+        ctx = SymbolContext(symbol="AAPL")
+        candidates, rejections = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
+        self.assertEqual(candidates, [])
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0].reason, "researcher_exception")
+        self.assertIn("boom", rejections[0].detail)
+
+    async def test_max_per_symbol_caps_candidates(self):
+        ideas = [_make_idea(score=float(i)) for i in range(5)]
+        researcher = MagicMock()
+        researcher.research = AsyncMock(return_value=_make_ok_report(ideas=ideas))
+        ctx = SymbolContext(symbol="AAPL")
+        candidates, _ = await generate_candidates(MagicMock(), [ctx], researcher=researcher, max_per_symbol=2)
+        self.assertEqual(len(candidates), 2)
+        self.assertEqual(candidates[0].researcher_score, 0.0)
+        self.assertEqual(candidates[1].researcher_score, 1.0)
+
+    async def test_empty_contexts_returns_empty(self):
+        researcher = MagicMock()
+        researcher.research = AsyncMock()
+        candidates, rejections = await generate_candidates(MagicMock(), [], researcher=researcher)
+        self.assertEqual(candidates, [])
+        self.assertEqual(rejections, [])
+        researcher.research.assert_not_called()
+
+    @patch("agents.trade_ranker.OptionsResearcherAgent")
+    async def test_default_researcher_constructed_when_not_passed(self, mock_class):
+        instance = MagicMock()
+        instance.research = AsyncMock(return_value=_make_ok_report())
+        mock_class.return_value = instance
+        session = MagicMock()
+        ctx = SymbolContext(symbol="AAPL")
+        await generate_candidates(session, [ctx])
+        mock_class.assert_called_once_with(session)
+
+    async def test_each_strategy_type_handled(self):
+        researcher = MagicMock()
+        researcher.research = AsyncMock(side_effect=[
+            _make_ok_report(symbol="AAPL", ideas=[_make_idea(strategy="BULL_PUT_SPREAD")]),
+            _make_ok_report(symbol="MSFT", ideas=[_make_idea(strategy="BEAR_CALL_SPREAD")]),
+            _make_ok_report(symbol="SPY", ideas=[_make_idea(strategy="IRON_CONDOR")]),
+        ])
+        contexts = [SymbolContext(symbol=s) for s in ("AAPL", "MSFT", "SPY")]
+        candidates, _ = await generate_candidates(MagicMock(), contexts, researcher=researcher)
+        self.assertEqual([c.structure for c in candidates], ["BULL_PUT_SPREAD", "BEAR_CALL_SPREAD", "IRON_CONDOR"])
+
+    async def test_multiple_contexts_preserve_order(self):
+        researcher = MagicMock()
+        researcher.research = AsyncMock(side_effect=[
+            _make_ok_report(symbol="AAPL"),
+            _make_ok_report(symbol="MSFT"),
+        ])
+        contexts = [SymbolContext(symbol="AAPL"), SymbolContext(symbol="MSFT")]
+        candidates, _ = await generate_candidates(MagicMock(), contexts, researcher=researcher)
+        self.assertEqual([c.symbol for c in candidates], ["AAPL", "MSFT"])
+
+    async def test_optional_fields_default_to_empty(self):
+        idea = {
+            "rank": 1, "strategy": "BULL_PUT_SPREAD", "expiration": "2026-06-19",
+            "dte": 45, "width": 5.0, "credit": 1.5, "max_loss": 350.0,
+            "credit_pct_of_width": 0.30, "short_delta": 0.30, "pop_estimate": 0.65,
+            "breakevens": None, "net_greeks": None, "legs": None,
+            "score": 72.0, "score_breakdown": None,
+        }
+        report = {"status": "OK", "symbol": "AAPL", "warnings": [], "trade_ideas": [idea]}
+        researcher = MagicMock()
+        researcher.research = AsyncMock(return_value=report)
+        ctx = SymbolContext(symbol="AAPL")
+        candidates, _ = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
+        c = candidates[0]
+        self.assertEqual(c.breakevens, [])
+        self.assertEqual(c.net_greeks, {})
+        self.assertEqual(c.legs, [])
+        self.assertEqual(c.researcher_score_breakdown, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds the layer between `scan_watchlists` (TCBT-8) and the gates/scoring/ranking coming in TCBT-9..7.
- New `async generate_candidates(session, contexts, *, researcher=None, max_per_symbol=3) -> (list[Candidate], list[Rejection])` calls `OptionsResearcherAgent.research(symbol)` per context and translates the researcher's `trade_ideas` dicts into typed `Candidate` records. Symbols whose researcher returns a non-OK status, or whose research call raises, become `Rejection` records — never a crash.
- New `Candidate` dataclass carries everything downstream gates and account-fit will need: `structure, expiration (date), dte, width, credit, max_loss, credit_pct_of_width, short_delta, pop_estimate, breakevens, net_greeks, legs`, the researcher's existing `researcher_score / researcher_score_breakdown`, plus the original `SymbolContext`.
- `max_per_symbol=3` caps work per symbol; researcher already caps at 20 internally.
- `run_best_trades` is still a stub. Wiring across `scan_watchlists → generate_candidates → gates → scoring → top-N` lands in TCBT-9 where the flow becomes end-to-end meaningful.

## Test plan
- [x] `./venv/bin/python -m unittest tests.test_trade_ranker tests.test_best_trades_cli` — 56 / 56 pass (12 new TCBT-3 + 17 TCBT-8 regression + 27 TCBT-2 regression)
- [x] No changes to `agents/options_researcher.py`, `agents/scanner.py`, or any existing test
- [x] `run_best_trades` and `_print_best_trades_text` byte-identical

## Out of scope
- Hard quality gates (earnings blackout, liquidity, DTE bounds) — TCBT-9
- Scoring with explanation breakdown — TCBT-10 / Task 5
- Account-aware ranking — TCBT-4 / Task 6
- Top-N selection / dedupe — TCBT-5 / Task 7
- Wiring into `run_best_trades` — TCBT-9

## QA
Built via `/build-qa`: Opus plan → Haiku build (one clean iteration) → Sonnet review → Opus APPROVED first pass. Codex review skipped — `/codex:review` skill still not available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)