### PR TITLE
TCBT-9: hard quality gates + settings validator + CLI guard

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -279,7 +279,7 @@ def _check_earnings_blackout(candidate: Candidate, blackout_days: int, today: da
     if earnings is None:
         return None
     delta_days = (earnings - today).days
-    if delta_days <= blackout_days:
+    if 0 <= delta_days <= blackout_days:
         return Rejection(
             symbol=candidate.symbol,
             reason="earnings_blackout",

--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -271,3 +271,123 @@ def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
         print("Warnings:")
         for w in result["warnings"]:
             print(f"  • {w}")
+
+
+def _check_earnings_blackout(candidate: Candidate, blackout_days: int, today: date) -> Optional[Rejection]:
+    """Reject if next_earnings_date is within the blackout window relative to today."""
+    earnings = candidate.context.next_earnings_date
+    if earnings is None:
+        return None
+    delta_days = (earnings - today).days
+    if delta_days <= blackout_days:
+        return Rejection(
+            symbol=candidate.symbol,
+            reason="earnings_blackout",
+            detail=f"earnings {earnings.isoformat()} within {blackout_days}d window",
+        )
+    return None
+
+
+def _check_dte_bounds(candidate: Candidate, min_dte: int, max_dte: int) -> Optional[Rejection]:
+    """Reject if candidate.dte falls outside [min_dte, max_dte]."""
+    if candidate.dte < min_dte:
+        return Rejection(
+            symbol=candidate.symbol,
+            reason="dte_out_of_range",
+            detail=f"dte={candidate.dte} below min={min_dte}",
+        )
+    if candidate.dte > max_dte:
+        return Rejection(
+            symbol=candidate.symbol,
+            reason="dte_out_of_range",
+            detail=f"dte={candidate.dte} above max={max_dte}",
+        )
+    return None
+
+
+def _check_broken_pricing(candidate: Candidate) -> Optional[Rejection]:
+    """Reject if credit is non-positive or any SELL leg has missing/non-positive bid."""
+    if candidate.credit <= 0:
+        return Rejection(
+            symbol=candidate.symbol,
+            reason="broken_pricing",
+            detail=f"credit={candidate.credit}",
+        )
+    for leg in candidate.legs:
+        if leg.get("action") != "SELL":
+            continue
+        bid = leg.get("bid")
+        if bid is None or bid <= 0:
+            return Rejection(
+                symbol=candidate.symbol,
+                reason="broken_pricing",
+                detail=f"sell-leg bid={bid if bid is not None else 0.0}",
+            )
+    return None
+
+
+def _check_open_interest(candidate: Candidate, min_open_interest: int) -> Optional[Rejection]:
+    """Reject if the minimum non-None open interest across legs falls below the floor."""
+    ois = [leg.get("open_interest") for leg in candidate.legs if leg.get("open_interest") is not None]
+    if not ois:
+        return None
+    min_oi = min(ois)
+    if min_oi < min_open_interest:
+        return Rejection(
+            symbol=candidate.symbol,
+            reason="low_open_interest",
+            detail=f"min OI {min_oi} below floor {min_open_interest}",
+        )
+    return None
+
+
+def _check_spread(candidate: Candidate, max_spread_pct: float) -> Optional[Rejection]:
+    """Reject if the worst (ask-bid)/mid across legs with full pricing exceeds the cap."""
+    ratios: list[float] = []
+    for leg in candidate.legs:
+        bid = leg.get("bid")
+        ask = leg.get("ask")
+        mid = leg.get("mid")
+        if bid is None or ask is None or mid is None or mid <= 0:
+            continue
+        ratios.append((ask - bid) / mid)
+    if not ratios:
+        return None
+    worst = max(ratios)
+    if worst > max_spread_pct:
+        return Rejection(
+            symbol=candidate.symbol,
+            reason="wide_spread",
+            detail=f"max spread {worst:.3f} above cap {max_spread_pct:.3f}",
+        )
+    return None
+
+
+def apply_quality_gates(
+    candidates: list[Candidate],
+    *,
+    blackout_days: int,
+    min_dte: int,
+    max_dte: int,
+    min_open_interest: int,
+    max_spread_pct: float,
+    today: Optional[date] = None,
+) -> tuple[list[Candidate], list[Rejection]]:
+    """Filter candidates through 5 hard gates; return (passing, rejections) preserving input order."""
+    if today is None:
+        today = date.today()
+    passing: list[Candidate] = []
+    rejections: list[Rejection] = []
+    for c in candidates:
+        rejection = (
+            _check_earnings_blackout(c, blackout_days, today)
+            or _check_dte_bounds(c, min_dte, max_dte)
+            or _check_broken_pricing(c)
+            or _check_open_interest(c, min_open_interest)
+            or _check_spread(c, max_spread_pct)
+        )
+        if rejection is None:
+            passing.append(c)
+        else:
+            rejections.append(rejection)
+    return (passing, rejections)

--- a/main.py
+++ b/main.py
@@ -80,7 +80,7 @@ def setup_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--min-delta", type=float, default=None, help="Minimum absolute short delta (default: 0.15)")
     parser.add_argument("--max-delta", type=float, default=None, help="Maximum absolute short delta (default: 0.45)")
     parser.add_argument("--best-trades", action="store_true", help="Rank best trade ideas across watchlists")
-    parser.add_argument("--top", type=int, default=3, help="Number of top ideas to surface (use with --best-trades, default: 3)")
+    parser.add_argument("--top", type=_nonneg_int, default=3, help="Number of top ideas to surface (use with --best-trades, default: 3)")
     parser.add_argument("--bt-watchlist", action="append", dest="bt_watchlist", metavar="NAME", help="Watchlist to include in --best-trades (repeatable; defaults: Chris Historical Trades, High Options Volume)")
     parser.add_argument("--force", action="store_true", help="Override Risk Manager blocks")
     parser.add_argument("--debug", "-D", action="store_true", help="Enable debug logging")
@@ -93,6 +93,17 @@ def _warn_if_not_in_venv() -> None:
             "⚠️  You are not running inside the project venv. "
             "If you see import/type errors, run: source venv/bin/activate"
         )
+
+
+def _nonneg_int(value: str) -> int:
+    """Argparse type: parse a non-negative integer; raise ArgumentTypeError otherwise."""
+    try:
+        i = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"expected non-negative integer, got {value!r}")
+    if i < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {i}")
+    return i
 
 
 def _print_research_text(report: dict) -> None:

--- a/tests/test_best_trades_cli.py
+++ b/tests/test_best_trades_cli.py
@@ -42,6 +42,14 @@ class TestBestTradesArgparse(unittest.TestCase):
         args = self.parser.parse_args(["--best-trades", "--top", "7"])
         self.assertEqual(args.top, 7)
 
+    def test_top_negative_rejected_by_argparse(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["--best-trades", "--top", "-1"])
+
+    def test_top_non_int_rejected_by_argparse(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["--best-trades", "--top", "abc"])
+
     def test_format_choice_reused(self):
         args = self.parser.parse_args(["--best-trades", "--format", "json"])
         self.assertEqual(args.format, "json")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -268,5 +268,66 @@ class TestDecimalSettingFallback(unittest.TestCase):
                 manager_mod.settings = original
 
 
+class TestCoerceNonnegInt(unittest.TestCase):
+    """Direct tests for Settings._coerce_nonneg_int."""
+
+    def test_int_passes_through(self):
+        self.assertEqual(Settings._coerce_nonneg_int("k", 5), 5)
+
+    def test_string_int_coerces(self):
+        self.assertEqual(Settings._coerce_nonneg_int("k", "3"), 3)
+
+    def test_whole_float_coerces(self):
+        self.assertEqual(Settings._coerce_nonneg_int("k", 1.0), 1)
+
+    def test_negative_int_rejected(self):
+        with self.assertRaises(ValueError):
+            Settings._coerce_nonneg_int("k", -1)
+
+    def test_non_whole_float_rejected(self):
+        with self.assertRaises(ValueError):
+            Settings._coerce_nonneg_int("k", 1.5)
+
+    def test_non_numeric_string_rejected(self):
+        with self.assertRaises(ValueError):
+            Settings._coerce_nonneg_int("k", "abc")
+
+    def test_bool_rejected(self):
+        with self.assertRaises(ValueError):
+            Settings._coerce_nonneg_int("k", True)
+
+    def test_none_rejected(self):
+        with self.assertRaises(ValueError):
+            Settings._coerce_nonneg_int("k", None)
+
+
+class TestBestTradesSettingsRoundTrip(unittest.TestCase):
+    """Round-trip new bt_* keys through Settings.set/get."""
+
+    def test_bt_earnings_blackout_days_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("bt_earnings_blackout_days", 5)
+            self.assertEqual(s.get("bt_earnings_blackout_days"), 5)
+
+    def test_bt_min_dte_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("bt_min_dte", 30)
+            self.assertEqual(s.get("bt_min_dte"), 30)
+
+    def test_bt_max_per_symbol_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("bt_max_per_symbol", 2)
+            self.assertEqual(s.get("bt_max_per_symbol"), 2)
+
+    def test_bt_max_spread_pct_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("bt_max_spread_pct", 0.05)
+            self.assertEqual(s.get("bt_max_spread_pct"), 0.05)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -525,6 +525,23 @@ class TestQualityGates(unittest.TestCase):
         c = _make_candidate(next_earnings_date=None)
         self.assertIsNone(_check_earnings_blackout(c, 7, date(2026, 4, 26)))
 
+    def test_earnings_today_still_rejected(self):
+        today = date(2026, 4, 26)
+        c = _make_candidate(next_earnings_date=today)
+        rejection = _check_earnings_blackout(c, 7, today)
+        self.assertIsNotNone(rejection)
+        self.assertEqual(rejection.reason, "earnings_blackout")
+
+    def test_earnings_yesterday_does_not_reject(self):
+        today = date(2026, 4, 26)
+        c = _make_candidate(next_earnings_date=date(2026, 4, 25))
+        self.assertIsNone(_check_earnings_blackout(c, 7, today))
+
+    def test_earnings_far_past_does_not_reject(self):
+        today = date(2026, 4, 26)
+        c = _make_candidate(next_earnings_date=date(2026, 3, 27))
+        self.assertIsNone(_check_earnings_blackout(c, 7, today))
+
     def test_dte_below_min_rejected(self):
         c = _make_candidate(dte=12)
         passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -3,6 +3,7 @@
 import unittest
 from datetime import date
 from decimal import Decimal
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agents.trade_ranker import (
@@ -10,6 +11,12 @@ from agents.trade_ranker import (
     Rejection,
     SymbolContext,
     _build_context,
+    _check_broken_pricing,
+    _check_dte_bounds,
+    _check_earnings_blackout,
+    _check_open_interest,
+    _check_spread,
+    apply_quality_gates,
     generate_candidates,
     scan_watchlists,
 )
@@ -304,6 +311,50 @@ def _make_failure_report(symbol="AAPL", status="NO_CHAIN", warnings=None):
     }
 
 
+def _make_candidate(
+    *,
+    symbol: str = "AAPL",
+    structure: str = "BULL_PUT_SPREAD",
+    expiration: date = date(2026, 6, 19),
+    dte: int = 45,
+    width: float = 5.0,
+    credit: float = 1.5,
+    max_loss: float = 350.0,
+    credit_pct_of_width: float = 0.30,
+    short_delta: float = 0.30,
+    pop_estimate: float = 0.65,
+    breakevens: Optional[list] = None,
+    net_greeks: Optional[dict] = None,
+    legs: Optional[list] = None,
+    researcher_score: float = 72.0,
+    researcher_score_breakdown: Optional[dict] = None,
+    next_earnings_date: Optional[date] = None,
+) -> Candidate:
+    ctx = SymbolContext(symbol=symbol, next_earnings_date=next_earnings_date)
+    default_legs = [
+        {"action": "SELL", "bid": 1.50, "ask": 1.55, "mid": 1.525, "open_interest": 500},
+        {"action": "BUY", "bid": 0.40, "ask": 0.42, "mid": 0.41, "open_interest": 500},
+    ]
+    return Candidate(
+        symbol=symbol,
+        structure=structure,
+        expiration=expiration,
+        dte=dte,
+        width=width,
+        credit=credit,
+        max_loss=max_loss,
+        credit_pct_of_width=credit_pct_of_width,
+        short_delta=short_delta,
+        pop_estimate=pop_estimate,
+        breakevens=breakevens if breakevens is not None else [148.5],
+        net_greeks=net_greeks if net_greeks is not None else {"delta": 0.05, "gamma": 0.001, "theta": 0.20, "vega": -0.15},
+        legs=legs if legs is not None else default_legs,
+        researcher_score=researcher_score,
+        researcher_score_breakdown=researcher_score_breakdown if researcher_score_breakdown is not None else {"raw": {}},
+        context=ctx,
+    )
+
+
 class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
     """Tests for generate_candidates orchestration."""
 
@@ -436,6 +487,147 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(c.net_greeks, {})
         self.assertEqual(c.legs, [])
         self.assertEqual(c.researcher_score_breakdown, {})
+
+
+class TestQualityGates(unittest.TestCase):
+    """Tests for apply_quality_gates and individual _check_* helpers."""
+
+    DEFAULT_KW = dict(
+        blackout_days=7,
+        min_dte=21,
+        max_dte=60,
+        min_open_interest=200,
+        max_spread_pct=0.10,
+        today=date(2026, 4, 26),
+    )
+
+    def test_passing_candidate_survives_all_gates(self):
+        c = _make_candidate()
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [c])
+        self.assertEqual(rejections, [])
+
+    def test_earnings_within_blackout_rejected(self):
+        c = _make_candidate(next_earnings_date=date(2026, 5, 1))
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [])
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0].reason, "earnings_blackout")
+        self.assertEqual(rejections[0].detail, "earnings 2026-05-01 within 7d window")
+
+    def test_earnings_outside_blackout_passes(self):
+        c = _make_candidate(next_earnings_date=date(2026, 5, 15))
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [c])
+        self.assertEqual(rejections, [])
+
+    def test_no_earnings_data_skips_gate(self):
+        c = _make_candidate(next_earnings_date=None)
+        self.assertIsNone(_check_earnings_blackout(c, 7, date(2026, 4, 26)))
+
+    def test_dte_below_min_rejected(self):
+        c = _make_candidate(dte=12)
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [])
+        self.assertEqual(rejections[0].reason, "dte_out_of_range")
+        self.assertEqual(rejections[0].detail, "dte=12 below min=21")
+
+    def test_dte_above_max_rejected(self):
+        c = _make_candidate(dte=70)
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [])
+        self.assertEqual(rejections[0].reason, "dte_out_of_range")
+        self.assertEqual(rejections[0].detail, "dte=70 above max=60")
+
+    def test_dte_in_range_passes(self):
+        c = _make_candidate(dte=45)
+        passing, _ = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [c])
+
+    def test_zero_credit_rejected(self):
+        c = _make_candidate(credit=0.0)
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [])
+        self.assertEqual(rejections[0].reason, "broken_pricing")
+        self.assertEqual(rejections[0].detail, "credit=0.0")
+
+    def test_sell_leg_zero_bid_rejected(self):
+        legs = [
+            {"action": "SELL", "bid": 0.0, "ask": 0.05, "mid": 0.025, "open_interest": 500},
+            {"action": "BUY", "bid": 0.40, "ask": 0.42, "mid": 0.41, "open_interest": 500},
+        ]
+        c = _make_candidate(legs=legs)
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [])
+        self.assertEqual(rejections[0].reason, "broken_pricing")
+        self.assertEqual(rejections[0].detail, "sell-leg bid=0.0")
+
+    def test_buy_leg_zero_bid_does_not_reject(self):
+        legs = [
+            {"action": "SELL", "bid": 1.50, "ask": 1.55, "mid": 1.525, "open_interest": 500},
+            {"action": "BUY", "bid": 0.0, "ask": 0.05, "mid": 0.025, "open_interest": 500},
+        ]
+        c = _make_candidate(legs=legs)
+        self.assertIsNone(_check_broken_pricing(c))
+
+    def test_low_open_interest_rejected(self):
+        legs = [
+            {"action": "SELL", "bid": 1.50, "ask": 1.55, "mid": 1.525, "open_interest": 150},
+            {"action": "BUY", "bid": 0.40, "ask": 0.42, "mid": 0.41, "open_interest": 500},
+        ]
+        c = _make_candidate(legs=legs)
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [])
+        self.assertEqual(rejections[0].reason, "low_open_interest")
+        self.assertEqual(rejections[0].detail, "min OI 150 below floor 200")
+
+    def test_all_oi_none_does_not_reject(self):
+        legs = [
+            {"action": "SELL", "bid": 1.50, "ask": 1.55, "mid": 1.525, "open_interest": None},
+            {"action": "BUY", "bid": 0.40, "ask": 0.45, "mid": 0.425, "open_interest": None},
+        ]
+        c = _make_candidate(legs=legs)
+        self.assertIsNone(_check_open_interest(c, 200))
+
+    def test_wide_spread_rejected(self):
+        legs = [
+            {"action": "SELL", "bid": 1.40, "ask": 1.70, "mid": 1.55, "open_interest": 500},
+            {"action": "BUY", "bid": 0.40, "ask": 0.42, "mid": 0.41, "open_interest": 500},
+        ]
+        c = _make_candidate(legs=legs)
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [])
+        self.assertEqual(rejections[0].reason, "wide_spread")
+        self.assertEqual(rejections[0].detail, "max spread 0.194 above cap 0.100")
+
+    def test_missing_pricing_skips_spread_gate(self):
+        legs = [
+            {"action": "SELL", "bid": None, "ask": None, "mid": None, "open_interest": 500},
+            {"action": "BUY", "bid": None, "ask": None, "mid": None, "open_interest": 500},
+        ]
+        c = _make_candidate(legs=legs)
+        self.assertIsNone(_check_spread(c, 0.10))
+
+    def test_first_failure_wins_earnings_before_dte(self):
+        c = _make_candidate(next_earnings_date=date(2026, 5, 1), dte=12)
+        passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
+        self.assertEqual(passing, [])
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0].reason, "earnings_blackout")
+
+    def test_empty_candidates_returns_empty(self):
+        passing, rejections = apply_quality_gates([], **self.DEFAULT_KW)
+        self.assertEqual(passing, [])
+        self.assertEqual(rejections, [])
+
+    def test_passing_and_failing_partition_correctly(self):
+        good = _make_candidate(symbol="AAPL")
+        bad = _make_candidate(symbol="MSFT", dte=12)
+        passing, rejections = apply_quality_gates([good, bad], **self.DEFAULT_KW)
+        self.assertEqual(passing, [good])
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0].symbol, "MSFT")
+        self.assertEqual(rejections[0].reason, "dte_out_of_range")
 
 
 if __name__ == "__main__":

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -13,9 +13,17 @@ NUMERIC_KEYS: frozenset[str] = frozenset({
     "bp_usage_warn",
     "bp_usage_block",
     "concentration_pct_nlv_warn",
+    "bt_max_spread_pct",
 })
 OPTIONAL_NUMERIC_KEYS: frozenset[str] = frozenset({
     "theta_target",  # may be None
+})
+INTEGER_KEYS: frozenset[str] = frozenset({
+    "bt_earnings_blackout_days",
+    "bt_min_dte",
+    "bt_max_dte",
+    "bt_min_open_interest",
+    "bt_max_per_symbol",
 })
 
 DEFAULTS: dict[str, Any] = {
@@ -24,6 +32,12 @@ DEFAULTS: dict[str, Any] = {
     "bp_usage_block": 0.50,
     "theta_target": None,
     "concentration_pct_nlv_warn": 0.15,
+    "bt_earnings_blackout_days": 7,
+    "bt_min_dte": 21,
+    "bt_max_dte": 60,
+    "bt_min_open_interest": 200,
+    "bt_max_per_symbol": 3,
+    "bt_max_spread_pct": 0.10,
     "alert_toggles": {
         "position_size": True,
         "bp": True,
@@ -125,6 +139,8 @@ class Settings:
             return self._coerce_nonneg_float(key, value)
         if key in NUMERIC_KEYS:
             return self._coerce_nonneg_float(key, value)
+        if key in INTEGER_KEYS:
+            return self._coerce_nonneg_int(key, value)
         if key in DEFAULTS:
             # Unknown behavior for non-numeric keys in DEFAULTS — pass through
             return value
@@ -151,6 +167,35 @@ class Settings:
         if f < 0:
             raise ValueError(f"{key}: must be >= 0 (got {f})")
         return f
+
+    @staticmethod
+    def _coerce_nonneg_int(key: str, value: Any) -> int:
+        """Coerce value to a non-negative int; reject bool, non-finite, non-whole, or negative."""
+        if isinstance(value, bool):
+            raise ValueError(f"{key}: expected int, got bool")
+        if isinstance(value, int):
+            i = value
+        elif isinstance(value, float):
+            if not math.isfinite(value):
+                raise ValueError(f"{key}: must be finite (got {value})")
+            if not value.is_integer():
+                raise ValueError(f"{key}: must be a whole number (got {value})")
+            i = int(value)
+        elif isinstance(value, str):
+            try:
+                f = float(value)
+            except ValueError as e:
+                raise ValueError(f"{key}: not a number ({value!r})") from e
+            if not math.isfinite(f):
+                raise ValueError(f"{key}: must be finite (got {f})")
+            if not f.is_integer():
+                raise ValueError(f"{key}: must be a whole number (got {f})")
+            i = int(f)
+        else:
+            raise ValueError(f"{key}: not a number ({value!r})")
+        if i < 0:
+            raise ValueError(f"{key}: must be >= 0 (got {i})")
+        return i
 
     @staticmethod
     def _apply_dotted(d: dict, dotted_key: str, value: Any) -> None:


### PR DESCRIPTION
> **⚠️ Stacked on #11 (TCBT-3 candidate generation).** Review #11 first; merge order matters. When #11 merges, GitHub auto-rebases this PR's base to \`main\`.

## Summary
- Adds the gates layer between TCBT-3 candidate generation and the scoring/output coming in TCBT-5/7.
- Five hard gates run as pure functions over \`Candidate\` lists in fixed order — first failure wins, candidate becomes a \`Rejection\` with a snake_case reason and human-readable detail.
- Bundles the **carry-forward from PR #11 Codex review** (negative \`max_per_symbol\`): new \`_coerce_nonneg_int\` validator at the settings boundary + new \`_nonneg_int\` argparse type for \`--top\`. Validation stays at the boundary per CLAUDE.md, the orchestrator stays clean.

## Gates (in order — first failure wins)
| Reason | Condition | Detail example |
|---|---|---|
| \`earnings_blackout\` | \`next_earnings_date\` within N days of today | \`earnings 2026-05-01 within 7d window\` |
| \`dte_out_of_range\` | \`dte\` outside \`[min, max]\` | \`dte=12 below min=21\` |
| \`broken_pricing\` | \`credit <= 0\` OR any SELL leg with bid None/≤0 | \`credit=0.0\` / \`sell-leg bid=0.0\` |
| \`low_open_interest\` | min non-None OI across legs below floor | \`min OI 150 below floor 200\` |
| \`wide_spread\` | max \`(ask-bid)/mid\` across legs above cap | \`max spread 0.194 above cap 0.100\` |

Missing-data semantics: a gate that has no data to check (e.g. all legs \`open_interest=None\`) doesn't reject — better to surface the candidate and let the user see it than drop it silently.

## New settings keys (with locked defaults)
| Key | Default | Type |
|---|---|---|
| \`bt_earnings_blackout_days\` | 7 | int |
| \`bt_min_dte\` | 21 | int |
| \`bt_max_dte\` | 60 | int |
| \`bt_min_open_interest\` | 200 | int |
| \`bt_max_per_symbol\` | 3 | int (no consumer yet — pre-promoted from TCBT-3 kwarg per Codex follow-up) |
| \`bt_max_spread_pct\` | 0.10 | float |

All int keys route through the new \`_coerce_nonneg_int\` static method on \`Settings\` (mirrors existing \`_coerce_nonneg_float\` pattern). Bool, non-finite, non-whole-float, non-numeric strings, negatives, and \`None\` all rejected with explicit error messages.

## CLI guard
\`--top\` now uses \`type=_nonneg_int\` instead of \`type=int\`. \`./venv/bin/python main.py --best-trades --top -1\` exits non-zero with \`argument --top: must be >= 0, got -1\`.

## Test plan
- [x] \`./venv/bin/python -m unittest tests.test_trade_ranker tests.test_settings tests.test_best_trades_cli\` — 115 / 115 pass
- [x] 17 new \`TestQualityGates\` tests (per-gate pos/neg, ordering, partition, empty, missing-data)
- [x] 8 new \`TestCoerceNonnegInt\` direct validator tests
- [x] 4 new \`TestBestTradesSettingsRoundTrip\` tests
- [x] 2 new argparse tests for \`--top -1\` and \`--top abc\`
- [x] CLI smoke: \`--top -1\` rejected; \`--top 5 --format json\` still emits valid JSON
- [x] No changes to \`agents/scanner.py\`, \`agents/options_researcher.py\`, \`utils/launcher_ui.py\`
- [x] \`run_best_trades\` still a stub — does not call \`apply_quality_gates\`. Wiring lands in TCBT-5/7.

## Out of scope
- Wiring \`apply_quality_gates\` into \`run_best_trades\` — happens in TCBT-5 (scoring) or TCBT-7 (output) when end-to-end flow is meaningful
- Reading gate thresholds from settings — same reasoning, plumbing comes with the wiring task
- Soft \"market closed / liquidity warning\" tag — not a quality-of-trade issue, more a runtime context. Reconsider for TCBT-5/7

## QA
Built via \`/build-qa\`: Opus plan → Haiku build → Sonnet review caught one fixture issue (default BUY-leg spread of 11.8% tripped the new 10% cap) → fixed → 115/115 pass. Codex review skipped (skill not available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)