### PR TITLE
TCBT-10: scoring with explanation breakdown

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -7,7 +7,7 @@ CLI and launcher entry points can be wired in isolation.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from datetime import date
 from decimal import Decimal
 from typing import Any, Optional, Sequence
@@ -63,6 +63,9 @@ class Candidate:
     researcher_score: float
     researcher_score_breakdown: dict[str, Any]
     context: SymbolContext
+    score: float = 0.0
+    score_breakdown: dict[str, float] = field(default_factory=dict)
+    summary_reason: str = ""
 
 
 @dataclass
@@ -391,3 +394,197 @@ def apply_quality_gates(
         else:
             rejections.append(rejection)
     return (passing, rejections)
+
+
+_WEIGHT_REGIME_FIT: float = 15.0
+_WEIGHT_LIQUIDITY: float = 20.0
+_WEIGHT_VOLATILITY_EDGE: float = 25.0
+_WEIGHT_EVENT_RISK: float = 10.0
+_WEIGHT_STRUCTURE_QUALITY: float = 20.0
+_WEIGHT_ACCOUNT_FIT: float = 10.0
+
+
+def _score_regime_fit(candidate: Candidate) -> float:
+    """Map IVR (0-100) linearly to [0, 15]; neutral 7.5 when iv_rank is None."""
+    ivr = candidate.context.iv_rank
+    if ivr is None:
+        return 7.5
+    factor = max(0.0, min(1.0, ivr / 100.0))
+    return factor * _WEIGHT_REGIME_FIT
+
+
+def _score_liquidity(candidate: Candidate) -> float:
+    """Blend min-OI factor (full at 1000+) and worst-spread factor (zero at 10%) into [0, 20]."""
+    legs = candidate.legs
+    if not legs:
+        return 0.0
+
+    ois = [leg.get("open_interest") for leg in legs if leg.get("open_interest") is not None]
+    min_oi = min(ois) if ois else 0
+    oi_factor = min(1.0, min_oi / 1000.0)
+
+    ratios: list[float] = []
+    for leg in legs:
+        bid = leg.get("bid")
+        ask = leg.get("ask")
+        mid = leg.get("mid")
+        if bid is None or ask is None or mid is None or mid <= 0:
+            continue
+        ratios.append((ask - bid) / mid)
+    if ratios:
+        worst_spread = max(ratios)
+        spread_factor = max(0.0, 1.0 - (worst_spread / 0.10))
+    else:
+        spread_factor = 0.0
+
+    return _WEIGHT_LIQUIDITY * (0.5 * oi_factor + 0.5 * spread_factor)
+
+
+def _score_volatility_edge(candidate: Candidate) -> float:
+    """Blend IVR factor (60%) and credit/width factor (40%) into [0, 25]."""
+    ivr = candidate.context.iv_rank
+    ivr_factor = max(0.0, min(1.0, (ivr or 0.0) / 100.0))
+    credit_factor = max(
+        0.0,
+        min(1.0, (candidate.credit_pct_of_width - 0.20) / 0.30),
+    )
+    return _WEIGHT_VOLATILITY_EDGE * (0.6 * ivr_factor + 0.4 * credit_factor)
+
+
+def _score_event_risk(candidate: Candidate, today: date) -> float:
+    """Linear ramp 7d→21d to earnings; full 10 when no earnings or earnings past/>=21d away."""
+    earnings = candidate.context.next_earnings_date
+    if earnings is None:
+        return _WEIGHT_EVENT_RISK
+    delta_days = (earnings - today).days
+    if delta_days < 0:
+        return _WEIGHT_EVENT_RISK
+    if delta_days >= 21:
+        return _WEIGHT_EVENT_RISK
+    if delta_days <= 7:
+        return 0.0
+    return ((delta_days - 7) / 14.0) * _WEIGHT_EVENT_RISK
+
+
+def _score_structure_quality(candidate: Candidate) -> float:
+    """Blend delta-band fit (peak at 0.25) and credit/width (full at 40%+) into [0, 20]."""
+    delta_factor = max(0.0, 1.0 - abs(candidate.short_delta - 0.25) / 0.20)
+    credit_width_factor = max(0.0, min(1.0, candidate.credit_pct_of_width / 0.40))
+    return _WEIGHT_STRUCTURE_QUALITY * (0.5 * delta_factor + 0.5 * credit_width_factor)
+
+
+def _score_account_fit(candidate: Candidate) -> float:
+    """Placeholder (TCBT-4 wires real logic): always returns 10.0."""
+    return _WEIGHT_ACCOUNT_FIT
+
+
+def _score_concentration_penalty(candidate: Candidate) -> float:
+    """Placeholder (TCBT-4 wires real logic): always returns 0.0 (positive penalty value)."""
+    return 0.0
+
+
+def _format_summary_reason(
+    candidate: Candidate,
+    breakdown: dict[str, float],
+    today: date,
+) -> str:
+    """Build a one-line plain-English string of the 2-4 strongest positive factors."""
+    phrases: list[str] = []
+
+    ivr = candidate.context.iv_rank
+    if breakdown["regime_fit"] / _WEIGHT_REGIME_FIT >= 0.6 and ivr is not None:
+        phrases.append(f"IVR {round(ivr)}")
+
+    legs = candidate.legs
+    ois = [leg.get("open_interest") for leg in legs if leg.get("open_interest") is not None]
+    min_oi = min(ois) if ois else 0
+    oi_factor = min(1.0, min_oi / 1000.0)
+    ratios: list[float] = []
+    for leg in legs:
+        bid = leg.get("bid")
+        ask = leg.get("ask")
+        mid = leg.get("mid")
+        if bid is None or ask is None or mid is None or mid <= 0:
+            continue
+        ratios.append((ask - bid) / mid)
+    if ratios:
+        worst_spread = max(ratios)
+        spread_factor = max(0.0, 1.0 - (worst_spread / 0.10))
+    else:
+        spread_factor = 0.0
+    if breakdown["liquidity"] / _WEIGHT_LIQUIDITY >= 0.6:
+        if spread_factor > oi_factor:
+            phrases.append("tight spreads")
+        else:
+            phrases.append("deep liquidity")
+
+    if breakdown["volatility_edge"] / _WEIGHT_VOLATILITY_EDGE >= 0.6:
+        phrases.append(f"credit {round(candidate.credit_pct_of_width * 100)}% of width")
+
+    earnings = candidate.context.next_earnings_date
+    if breakdown["event_risk"] >= _WEIGHT_EVENT_RISK:
+        if earnings is None:
+            phrases.append("no earnings")
+        else:
+            delta_days = (earnings - today).days
+            if delta_days >= 21 or delta_days < 0:
+                phrases.append("clean event window")
+
+    if breakdown["structure_quality"] / _WEIGHT_STRUCTURE_QUALITY >= 0.6:
+        phrases.append(f"delta {candidate.short_delta:.2f}")
+
+    if not phrases:
+        return "weak across all factors"
+
+    return ", ".join(phrases[:4])
+
+
+def score_candidate(
+    candidate: Candidate,
+    *,
+    today: Optional[date] = None,
+) -> Candidate:
+    """Return a new Candidate with score, score_breakdown, and summary_reason populated."""
+    if today is None:
+        today = date.today()
+
+    regime = _score_regime_fit(candidate)
+    liquidity = _score_liquidity(candidate)
+    vol_edge = _score_volatility_edge(candidate)
+    event = _score_event_risk(candidate, today)
+    structure = _score_structure_quality(candidate)
+    account = _score_account_fit(candidate)
+    penalty = _score_concentration_penalty(candidate)
+
+    breakdown: dict[str, float] = {
+        "regime_fit": regime,
+        "liquidity": liquidity,
+        "volatility_edge": vol_edge,
+        "event_risk": event,
+        "structure_quality": structure,
+        "account_fit": account,
+        "concentration_penalty": penalty,
+    }
+
+    total = regime + liquidity + vol_edge + event + structure + account - penalty
+    score = max(0.0, min(100.0, total))
+
+    summary = _format_summary_reason(candidate, breakdown, today)
+
+    return replace(
+        candidate,
+        score=score,
+        score_breakdown=breakdown,
+        summary_reason=summary,
+    )
+
+
+def score_candidates(
+    candidates: list[Candidate],
+    *,
+    today: Optional[date] = None,
+) -> list[Candidate]:
+    """Score each candidate; preserve input order; pure (returns new list of new Candidates)."""
+    if today is None:
+        today = date.today()
+    return [score_candidate(c, today=today) for c in candidates]

--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -433,7 +433,7 @@ def _score_liquidity(candidate: Candidate) -> float:
         ratios.append((ask - bid) / mid)
     if ratios:
         worst_spread = max(ratios)
-        spread_factor = max(0.0, 1.0 - (worst_spread / 0.10))
+        spread_factor = max(0.0, min(1.0, 1.0 - (worst_spread / 0.10)))
     else:
         spread_factor = 0.0
 
@@ -467,8 +467,8 @@ def _score_event_risk(candidate: Candidate, today: date) -> float:
 
 
 def _score_structure_quality(candidate: Candidate) -> float:
-    """Blend delta-band fit (peak at 0.25) and credit/width (full at 40%+) into [0, 20]."""
-    delta_factor = max(0.0, 1.0 - abs(candidate.short_delta - 0.25) / 0.20)
+    """Blend delta-band fit (peak at 0.25 magnitude) and credit/width (full at 40%+) into [0, 20]."""
+    delta_factor = max(0.0, 1.0 - abs(abs(candidate.short_delta) - 0.25) / 0.20)
     credit_width_factor = max(0.0, min(1.0, candidate.credit_pct_of_width / 0.40))
     return _WEIGHT_STRUCTURE_QUALITY * (0.5 * delta_factor + 0.5 * credit_width_factor)
 
@@ -509,7 +509,7 @@ def _format_summary_reason(
         ratios.append((ask - bid) / mid)
     if ratios:
         worst_spread = max(ratios)
-        spread_factor = max(0.0, 1.0 - (worst_spread / 0.10))
+        spread_factor = max(0.0, min(1.0, 1.0 - (worst_spread / 0.10)))
     else:
         spread_factor = 0.0
     if breakdown["liquidity"] / _WEIGHT_LIQUIDITY >= 0.6:

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -19,6 +19,8 @@ from agents.trade_ranker import (
     apply_quality_gates,
     generate_candidates,
     scan_watchlists,
+    score_candidate,
+    score_candidates,
 )
 
 
@@ -329,8 +331,9 @@ def _make_candidate(
     researcher_score: float = 72.0,
     researcher_score_breakdown: Optional[dict] = None,
     next_earnings_date: Optional[date] = None,
+    iv_rank: Optional[float] = None,
 ) -> Candidate:
-    ctx = SymbolContext(symbol=symbol, next_earnings_date=next_earnings_date)
+    ctx = SymbolContext(symbol=symbol, next_earnings_date=next_earnings_date, iv_rank=iv_rank)
     default_legs = [
         {"action": "SELL", "bid": 1.50, "ask": 1.55, "mid": 1.525, "open_interest": 500},
         {"action": "BUY", "bid": 0.40, "ask": 0.42, "mid": 0.41, "open_interest": 500},
@@ -645,6 +648,178 @@ class TestQualityGates(unittest.TestCase):
         self.assertEqual(len(rejections), 1)
         self.assertEqual(rejections[0].symbol, "MSFT")
         self.assertEqual(rejections[0].reason, "dte_out_of_range")
+
+
+class TestScoring(unittest.TestCase):
+    """Tests for score_candidate and score_candidates."""
+
+    _TODAY = date(2026, 4, 26)
+
+    @staticmethod
+    def _liquid_legs():
+        return [
+            {"action": "SELL", "bid": 1.00, "ask": 1.02, "mid": 1.01, "open_interest": 5000},
+            {"action": "BUY",  "bid": 0.50, "ask": 0.52, "mid": 0.51, "open_interest": 5000},
+        ]
+
+    def test_score_in_zero_to_hundred_range(self):
+        c = _make_candidate(iv_rank=70.0, credit_pct_of_width=0.35, legs=self._liquid_legs())
+        scored = score_candidate(c, today=self._TODAY)
+        self.assertGreaterEqual(scored.score, 0.0)
+        self.assertLessEqual(scored.score, 100.0)
+
+    def test_breakdown_keys_exactly_seven(self):
+        c = _make_candidate()
+        scored = score_candidate(c, today=self._TODAY)
+        self.assertEqual(
+            set(scored.score_breakdown.keys()),
+            {"regime_fit", "liquidity", "volatility_edge", "event_risk", "structure_quality", "account_fit", "concentration_penalty"},
+        )
+
+    def test_breakdown_sums_within_tolerance_of_score(self):
+        c = _make_candidate(iv_rank=50.0, credit_pct_of_width=0.30, legs=self._liquid_legs())
+        scored = score_candidate(c, today=self._TODAY)
+        b = scored.score_breakdown
+        total = b["regime_fit"] + b["liquidity"] + b["volatility_edge"] + b["event_risk"] + b["structure_quality"] + b["account_fit"] - b["concentration_penalty"]
+        self.assertAlmostEqual(total, scored.score, places=9)
+
+    def test_high_ivr_scores_higher_than_low_ivr(self):
+        high = _make_candidate(iv_rank=80.0, legs=self._liquid_legs())
+        low = _make_candidate(iv_rank=20.0, legs=self._liquid_legs())
+        self.assertGreater(score_candidate(high, today=self._TODAY).score, score_candidate(low, today=self._TODAY).score)
+
+    def test_higher_credit_ratio_scores_higher(self):
+        good = _make_candidate(credit_pct_of_width=0.45, legs=self._liquid_legs())
+        bad = _make_candidate(credit_pct_of_width=0.22, legs=self._liquid_legs())
+        self.assertGreater(score_candidate(good, today=self._TODAY).score, score_candidate(bad, today=self._TODAY).score)
+
+    def test_tighter_spread_scores_higher(self):
+        tight_legs = [
+            {"action": "SELL", "bid": 1.00, "ask": 1.01, "mid": 1.005, "open_interest": 5000},
+            {"action": "BUY",  "bid": 0.50, "ask": 0.51, "mid": 0.505, "open_interest": 5000},
+        ]
+        wide_legs = [
+            {"action": "SELL", "bid": 1.00, "ask": 1.09, "mid": 1.045, "open_interest": 5000},
+            {"action": "BUY",  "bid": 0.50, "ask": 0.55, "mid": 0.525, "open_interest": 5000},
+        ]
+        tight_score = score_candidate(_make_candidate(legs=tight_legs), today=self._TODAY).score_breakdown["liquidity"]
+        wide_score = score_candidate(_make_candidate(legs=wide_legs), today=self._TODAY).score_breakdown["liquidity"]
+        self.assertGreater(tight_score, wide_score)
+
+    def test_higher_oi_scores_higher(self):
+        deep = self._liquid_legs()
+        thin = [
+            {"action": "SELL", "bid": 1.00, "ask": 1.02, "mid": 1.01, "open_interest": 50},
+            {"action": "BUY",  "bid": 0.50, "ask": 0.52, "mid": 0.51, "open_interest": 50},
+        ]
+        deep_lq = score_candidate(_make_candidate(legs=deep), today=self._TODAY).score_breakdown["liquidity"]
+        thin_lq = score_candidate(_make_candidate(legs=thin), today=self._TODAY).score_breakdown["liquidity"]
+        self.assertGreater(deep_lq, thin_lq)
+
+    def test_no_earnings_full_event_risk_score(self):
+        c = _make_candidate(next_earnings_date=None)
+        self.assertEqual(score_candidate(c, today=self._TODAY).score_breakdown["event_risk"], 10.0)
+
+    def test_close_earnings_8d_lowers_event_score(self):
+        c = _make_candidate(next_earnings_date=date(2026, 5, 4))
+        ev = score_candidate(c, today=self._TODAY).score_breakdown["event_risk"]
+        self.assertGreater(ev, 0.0)
+        self.assertLess(ev, 10.0)
+        self.assertAlmostEqual(ev, (1 / 14.0) * 10.0, places=9)
+
+    def test_close_earnings_14d_partial_event_score(self):
+        c = _make_candidate(next_earnings_date=date(2026, 5, 10))
+        self.assertAlmostEqual(score_candidate(c, today=self._TODAY).score_breakdown["event_risk"], 5.0, places=9)
+
+    def test_far_earnings_full_event_score(self):
+        c = _make_candidate(next_earnings_date=date(2026, 5, 26))
+        self.assertEqual(score_candidate(c, today=self._TODAY).score_breakdown["event_risk"], 10.0)
+
+    def test_past_earnings_full_event_score(self):
+        c = _make_candidate(next_earnings_date=date(2026, 4, 21))
+        self.assertEqual(score_candidate(c, today=self._TODAY).score_breakdown["event_risk"], 10.0)
+
+    def test_short_delta_at_quarter_scores_high(self):
+        c = _make_candidate(short_delta=0.25, credit_pct_of_width=0.40, legs=self._liquid_legs())
+        sq = score_candidate(c, today=self._TODAY).score_breakdown["structure_quality"]
+        self.assertGreaterEqual(sq, 10.0)
+
+    def test_short_delta_at_45_scores_lower(self):
+        good = _make_candidate(short_delta=0.25, credit_pct_of_width=0.40, legs=self._liquid_legs())
+        bad = _make_candidate(short_delta=0.45, credit_pct_of_width=0.40, legs=self._liquid_legs())
+        self.assertGreater(
+            score_candidate(good, today=self._TODAY).score_breakdown["structure_quality"],
+            score_candidate(bad, today=self._TODAY).score_breakdown["structure_quality"],
+        )
+
+    def test_account_fit_placeholder_returns_ten(self):
+        c = _make_candidate()
+        self.assertEqual(score_candidate(c, today=self._TODAY).score_breakdown["account_fit"], 10.0)
+
+    def test_concentration_penalty_placeholder_returns_zero(self):
+        c = _make_candidate()
+        self.assertEqual(score_candidate(c, today=self._TODAY).score_breakdown["concentration_penalty"], 0.0)
+
+    def test_summary_reason_is_single_line(self):
+        c = _make_candidate(iv_rank=70.0, credit_pct_of_width=0.40, legs=self._liquid_legs())
+        self.assertNotIn("\n", score_candidate(c, today=self._TODAY).summary_reason)
+
+    def test_summary_reason_mentions_strong_factors(self):
+        c = _make_candidate(iv_rank=70.0, credit_pct_of_width=0.40, legs=self._liquid_legs())
+        self.assertIn("IVR", score_candidate(c, today=self._TODAY).summary_reason)
+
+    def test_summary_reason_fallback_when_all_weak(self):
+        c = _make_candidate(
+            iv_rank=0.0,
+            credit_pct_of_width=0.18,
+            legs=[],
+            short_delta=0.05,
+            next_earnings_date=date(2026, 5, 1),
+        )
+        self.assertEqual(score_candidate(c, today=self._TODAY).summary_reason, "weak across all factors")
+
+    def test_score_candidates_preserves_order(self):
+        candidates = [
+            _make_candidate(symbol="AAPL"),
+            _make_candidate(symbol="MSFT"),
+            _make_candidate(symbol="SPY"),
+        ]
+        scored = score_candidates(candidates, today=self._TODAY)
+        self.assertEqual([c.symbol for c in scored], ["AAPL", "MSFT", "SPY"])
+
+    def test_score_candidates_empty_returns_empty(self):
+        self.assertEqual(score_candidates([], today=self._TODAY), [])
+
+    def test_score_candidate_returns_new_instance_not_mutated(self):
+        c = _make_candidate(iv_rank=50.0, legs=self._liquid_legs())
+        scored = score_candidate(c, today=self._TODAY)
+        self.assertEqual(c.score, 0.0)
+        self.assertGreater(scored.score, 0.0)
+        self.assertIsNot(scored, c)
+
+    def test_legs_empty_zero_liquidity(self):
+        c = _make_candidate(legs=[])
+        self.assertEqual(score_candidate(c, today=self._TODAY).score_breakdown["liquidity"], 0.0)
+
+    def test_iv_rank_none_neutral_regime_fit(self):
+        c = _make_candidate(iv_rank=None)
+        self.assertEqual(score_candidate(c, today=self._TODAY).score_breakdown["regime_fit"], 7.5)
+
+    def test_score_clamped_to_hundred(self):
+        max_legs = [
+            {"action": "SELL", "bid": 1.00, "ask": 1.00, "mid": 1.00, "open_interest": 10000},
+            {"action": "BUY",  "bid": 0.50, "ask": 0.50, "mid": 0.50, "open_interest": 10000},
+        ]
+        c = _make_candidate(
+            iv_rank=100.0,
+            credit_pct_of_width=0.50,
+            short_delta=0.25,
+            legs=max_legs,
+            next_earnings_date=date(2026, 6, 25),
+        )
+        scored = score_candidate(c, today=self._TODAY)
+        self.assertLessEqual(scored.score, 100.0)
+        self.assertAlmostEqual(scored.score, 100.0, places=2)
 
 
 if __name__ == "__main__":

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -805,6 +805,25 @@ class TestScoring(unittest.TestCase):
         c = _make_candidate(iv_rank=None)
         self.assertEqual(score_candidate(c, today=self._TODAY).score_breakdown["regime_fit"], 7.5)
 
+    def test_negative_short_delta_scores_same_as_positive(self):
+        """PUT spreads carry signed (negative) short_delta from researcher; structure_quality must use magnitude."""
+        legs = self._liquid_legs()
+        put = _make_candidate(short_delta=-0.25, credit_pct_of_width=0.40, legs=legs)
+        call = _make_candidate(short_delta=0.25, credit_pct_of_width=0.40, legs=legs)
+        put_sq = score_candidate(put, today=self._TODAY).score_breakdown["structure_quality"]
+        call_sq = score_candidate(call, today=self._TODAY).score_breakdown["structure_quality"]
+        self.assertAlmostEqual(put_sq, call_sq, places=9)
+
+    def test_crossed_market_does_not_inflate_liquidity(self):
+        """Crossed quote (ask < bid) → negative spread → liquidity must stay at weight cap, not exceed it."""
+        crossed_legs = [
+            {"action": "SELL", "bid": 1.05, "ask": 1.00, "mid": 1.025, "open_interest": 5000},
+            {"action": "BUY",  "bid": 0.55, "ask": 0.50, "mid": 0.525, "open_interest": 5000},
+        ]
+        c = _make_candidate(legs=crossed_legs)
+        liquidity = score_candidate(c, today=self._TODAY).score_breakdown["liquidity"]
+        self.assertLessEqual(liquidity, 20.0)
+
     def test_score_clamped_to_hundred(self):
         max_legs = [
             {"action": "SELL", "bid": 1.00, "ask": 1.00, "mid": 1.00, "open_interest": 10000},


### PR DESCRIPTION
## Summary
- Adds the cross-symbol composite scoring layer between TCBT-9 gates and the top-N output coming in TCBT-5/7.
- New \`score_candidate(candidate, *, today=None)\` is **pure** — returns a NEW \`Candidate\` via \`dataclasses.replace\` with \`score\` (0-100), \`score_breakdown\` (7 components), and \`summary_reason\` (one-line plain-English) populated.
- New \`score_candidates(list, *, today=None)\` preserves input order.

## Components (weights sum to 100)
| Component | Weight | Logic |
|---|---|---|
| \`regime_fit\` | 15 | IVR-as-regime-proxy; neutral 7.5 when \`iv_rank=None\` |
| \`liquidity\` | 20 | 50% min-OI factor (full at 1000+) + 50% spread factor (zero at 10%) |
| \`volatility_edge\` | 25 | 60% IVR factor + 40% credit/width above 0.20 floor |
| \`event_risk\` | 10 | Linear ramp 7d→21d to earnings; full when no earnings or already past |
| \`structure_quality\` | 20 | 50% delta-band fit (peaks at 0.25) + 50% credit/width above 0.40 ceiling |
| \`account_fit\` | 10 | **Placeholder** — returns 10.0 neutral; TCBT-4 wires real logic |
| \`concentration_penalty\` | subtractive | **Placeholder** — returns 0.0; TCBT-4 wires real logic |

Final score: \`clamp(sum_positive - concentration_penalty, 0, 100)\`.

## summary_reason
One-line, comma-separated, max 4 phrases. Examples:
- \`"IVR 70, tight spreads, credit 40% of width, delta 0.25"\`
- \`"no earnings, deep liquidity, delta 0.28"\`
- \`"weak across all factors"\` (fallback when no component clears the 60% threshold)

## Candidate dataclass changes
3 new fields appended (with defaults — existing constructors stay green):
- \`score: float = 0.0\`
- \`score_breakdown: dict[str, float] = field(default_factory=dict)\`
- \`summary_reason: str = ""\`

## Test plan
- [x] \`./venv/bin/python -m unittest tests.test_trade_ranker tests.test_settings tests.test_best_trades_cli\` — 143 / 143 pass
- [x] 25 new \`TestScoring\` tests covering: 0-100 range, breakdown shape, breakdown sums to score, monotonicity per component (IVR, credit ratio, spread, OI, earnings, delta), placeholders, summary_reason format + fallback, list ordering, empty input, immutability (\`score_candidate\` returns new instance), ceiling clamp at 100
- [x] All 118 pre-existing tests still pass — TCBT-2/3/8/9 untouched
- [x] No changes to \`agents/scanner.py\`, \`agents/options_researcher.py\`, \`utils/\`, \`main.py\`, launcher
- [x] \`run_best_trades\` still a stub — does not call \`score_candidate(s)\`. Wiring in TCBT-5/7.

## Out of scope
- Sorting + dedupe by symbol + top-N selection — TCBT-5 (Task 7)
- Account-aware fields (real BP/concentration math) — TCBT-4 (Task 6)
- Reading weights from settings — defaults are constants for now; tuning comes if/when user asks
- \`run_best_trades\` integration — happens in TCBT-5/7 when output formatting catches up

## QA
Built via \`/build-qa\`: Opus plan → Haiku build (one iteration) → applied directly → tests caught one fixture issue (\`test_score_clamped_to_hundred\` had a tiny non-zero spread that prevented hitting exactly 100; fixed by using literal zero-spread legs) → 143/143 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)