### PR TITLE
TCBT-4: account-aware ranking layer

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -425,6 +425,15 @@ def apply_account_filters(
     bp_usage = account_state.bp_usage_pct
     exposures = account_state.existing_exposures
 
+    if nlv <= 0:
+        for c in candidates:
+            rejections.append(Rejection(
+                symbol=c.symbol,
+                reason="non_positive_nlv",
+                detail=f"NLV ${nlv:.0f} is non-positive; cannot evaluate account fit",
+            ))
+        return survivors, rejections
+
     for c in candidates:
         size_pct = c.max_loss / nlv
 
@@ -552,8 +561,8 @@ def _score_account_fit(
     candidate: Candidate,
     account_state: Optional[AccountState] = None,
 ) -> float:
-    """Score 0..10 for trade-size fit; placeholder 10.0 when account_state is None."""
-    if account_state is None:
+    """Score 0..10 for trade-size fit; placeholder 10.0 when account_state is None or NLV non-positive."""
+    if account_state is None or account_state.nlv <= 0:
         return _WEIGHT_ACCOUNT_FIT
     pct = candidate.max_loss / account_state.nlv
     return max(0.0, min(10.0, 10.0 * (0.05 - pct) / 0.03))
@@ -563,8 +572,8 @@ def _score_concentration_penalty(
     candidate: Candidate,
     account_state: Optional[AccountState] = None,
 ) -> float:
-    """Subtractive penalty 0..10 for concentration; placeholder 0.0 when account_state is None."""
-    if account_state is None:
+    """Subtractive penalty 0..10 for concentration; placeholder 0.0 when account_state is None or NLV non-positive."""
+    if account_state is None or account_state.nlv <= 0:
         return 0.0
     existing = account_state.existing_exposures.get(candidate.symbol, 0.0)
     post_trade_pct = (existing + candidate.max_loss) / account_state.nlv

--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -76,6 +76,19 @@ class Rejection:
     detail: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class AccountState:
+    """Snapshot of live account state used by the account-aware ranking layer.
+
+    Built once per `run_best_trades` invocation and passed into
+    `apply_account_filters` and `score_candidate(s)`. Floats (not Decimals)
+    so scoring math stays uniform with the rest of `trade_ranker`.
+    """
+    nlv: float
+    bp_usage_pct: float
+    existing_exposures: dict[str, float] = field(default_factory=dict)
+
+
 def _idea_to_candidate(symbol: str, idea: dict[str, Any], context: SymbolContext) -> Candidate:
     """Translate a researcher trade_ideas dict into a Candidate, preserving the source SymbolContext."""
     expiration = date.fromisoformat(idea["expiration"])
@@ -396,6 +409,68 @@ def apply_quality_gates(
     return (passing, rejections)
 
 
+def apply_account_filters(
+    candidates: list[Candidate],
+    account_state: AccountState,
+    *,
+    max_pct_nlv_per_trade: float,
+    bp_cap_for_new: float,
+    concentration_block_pct: float,
+) -> tuple[list[Candidate], list[Rejection]]:
+    """Hard-reject candidates that worsen account state beyond configured caps."""
+    survivors: list[Candidate] = []
+    rejections: list[Rejection] = []
+
+    nlv = account_state.nlv
+    bp_usage = account_state.bp_usage_pct
+    exposures = account_state.existing_exposures
+
+    for c in candidates:
+        size_pct = c.max_loss / nlv
+
+        if size_pct > max_pct_nlv_per_trade:
+            rejections.append(Rejection(
+                symbol=c.symbol,
+                reason="oversized_vs_nlv",
+                detail=(
+                    f"max_loss ${c.max_loss:.0f} = "
+                    f"{size_pct * 100:.1f}% NLV above cap "
+                    f"{max_pct_nlv_per_trade * 100:.1f}%"
+                ),
+            ))
+            continue
+
+        post_bp = bp_usage + size_pct
+        if post_bp > bp_cap_for_new:
+            rejections.append(Rejection(
+                symbol=c.symbol,
+                reason="bp_over_cap",
+                detail=(
+                    f"post-trade BP {post_bp * 100:.1f}% above cap "
+                    f"{bp_cap_for_new * 100:.1f}%"
+                ),
+            ))
+            continue
+
+        existing = exposures.get(c.symbol, 0.0)
+        post_exposure_pct = (existing + c.max_loss) / nlv
+        if post_exposure_pct > concentration_block_pct:
+            rejections.append(Rejection(
+                symbol=c.symbol,
+                reason="concentration_overlap",
+                detail=(
+                    f"{c.symbol} exposure ${existing:.0f} + ${c.max_loss:.0f} = "
+                    f"{post_exposure_pct * 100:.1f}% NLV above cap "
+                    f"{concentration_block_pct * 100:.1f}%"
+                ),
+            ))
+            continue
+
+        survivors.append(c)
+
+    return survivors, rejections
+
+
 _WEIGHT_REGIME_FIT: float = 15.0
 _WEIGHT_LIQUIDITY: float = 20.0
 _WEIGHT_VOLATILITY_EDGE: float = 25.0
@@ -473,14 +548,27 @@ def _score_structure_quality(candidate: Candidate) -> float:
     return _WEIGHT_STRUCTURE_QUALITY * (0.5 * delta_factor + 0.5 * credit_width_factor)
 
 
-def _score_account_fit(candidate: Candidate) -> float:
-    """Placeholder (TCBT-4 wires real logic): always returns 10.0."""
-    return _WEIGHT_ACCOUNT_FIT
+def _score_account_fit(
+    candidate: Candidate,
+    account_state: Optional[AccountState] = None,
+) -> float:
+    """Score 0..10 for trade-size fit; placeholder 10.0 when account_state is None."""
+    if account_state is None:
+        return _WEIGHT_ACCOUNT_FIT
+    pct = candidate.max_loss / account_state.nlv
+    return max(0.0, min(10.0, 10.0 * (0.05 - pct) / 0.03))
 
 
-def _score_concentration_penalty(candidate: Candidate) -> float:
-    """Placeholder (TCBT-4 wires real logic): always returns 0.0 (positive penalty value)."""
-    return 0.0
+def _score_concentration_penalty(
+    candidate: Candidate,
+    account_state: Optional[AccountState] = None,
+) -> float:
+    """Subtractive penalty 0..10 for concentration; placeholder 0.0 when account_state is None."""
+    if account_state is None:
+        return 0.0
+    existing = account_state.existing_exposures.get(candidate.symbol, 0.0)
+    post_trade_pct = (existing + candidate.max_loss) / account_state.nlv
+    return max(0.0, min(10.0, 10.0 * (post_trade_pct - 0.05) / 0.20))
 
 
 def _format_summary_reason(
@@ -543,6 +631,7 @@ def score_candidate(
     candidate: Candidate,
     *,
     today: Optional[date] = None,
+    account_state: Optional[AccountState] = None,
 ) -> Candidate:
     """Return a new Candidate with score, score_breakdown, and summary_reason populated."""
     if today is None:
@@ -553,8 +642,8 @@ def score_candidate(
     vol_edge = _score_volatility_edge(candidate)
     event = _score_event_risk(candidate, today)
     structure = _score_structure_quality(candidate)
-    account = _score_account_fit(candidate)
-    penalty = _score_concentration_penalty(candidate)
+    account = _score_account_fit(candidate, account_state)
+    penalty = _score_concentration_penalty(candidate, account_state)
 
     breakdown: dict[str, float] = {
         "regime_fit": regime,
@@ -583,8 +672,9 @@ def score_candidates(
     candidates: list[Candidate],
     *,
     today: Optional[date] = None,
+    account_state: Optional[AccountState] = None,
 ) -> list[Candidate]:
     """Score each candidate; preserve input order; pure (returns new list of new Candidates)."""
     if today is None:
         today = date.today()
-    return [score_candidate(c, today=today) for c in candidates]
+    return [score_candidate(c, today=today, account_state=account_state) for c in candidates]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -328,6 +328,24 @@ class TestBestTradesSettingsRoundTrip(unittest.TestCase):
             s.set("bt_max_spread_pct", 0.05)
             self.assertEqual(s.get("bt_max_spread_pct"), 0.05)
 
+    def test_bt_max_pct_nlv_per_trade_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("bt_max_pct_nlv_per_trade", 0.07)
+            self.assertEqual(s.get("bt_max_pct_nlv_per_trade"), 0.07)
+
+    def test_bt_bp_cap_for_new_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("bt_bp_cap_for_new", 0.40)
+            self.assertEqual(s.get("bt_bp_cap_for_new"), 0.40)
+
+    def test_bt_concentration_overlap_block_pct_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("bt_concentration_overlap_block_pct", 0.30)
+            self.assertEqual(s.get("bt_concentration_overlap_block_pct"), 0.30)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -978,6 +978,46 @@ class TestAccountFiltersAndScoring(unittest.TestCase):
         s_high = score_candidate(c, today=date(2026, 4, 26), account_state=state_high).score
         self.assertGreater(s_low, s_high)
 
+    # Non-positive NLV guards (Codex review on PR #15)
+
+    def test_zero_nlv_rejects_all_candidates_with_reason(self):
+        candidates = [
+            _make_candidate(symbol="AAPL", max_loss=200.0),
+            _make_candidate(symbol="MSFT", max_loss=300.0),
+        ]
+        state = AccountState(nlv=0.0, bp_usage_pct=0.0, existing_exposures={})
+        survivors, rejections = apply_account_filters(candidates, state, **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [])
+        self.assertEqual(len(rejections), 2)
+        self.assertEqual({r.reason for r in rejections}, {"non_positive_nlv"})
+        self.assertEqual([r.symbol for r in rejections], ["AAPL", "MSFT"])
+
+    def test_negative_nlv_rejects_all_candidates_with_reason(self):
+        c = _make_candidate(symbol="AAPL", max_loss=200.0)
+        state = AccountState(nlv=-500.0, bp_usage_pct=0.0, existing_exposures={})
+        survivors, rejections = apply_account_filters([c], state, **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [])
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0].reason, "non_positive_nlv")
+        self.assertIn("non-positive", rejections[0].detail)
+
+    def test_zero_nlv_account_fit_returns_placeholder(self):
+        c = _make_candidate(max_loss=99999.0)
+        state = AccountState(nlv=0.0, bp_usage_pct=0.0)
+        self.assertEqual(_score_account_fit(c, state), 10.0)
+
+    def test_zero_nlv_concentration_penalty_returns_zero(self):
+        c = _make_candidate(symbol="AAPL", max_loss=99999.0)
+        state = AccountState(nlv=0.0, bp_usage_pct=0.0, existing_exposures={"AAPL": 50000.0})
+        self.assertEqual(_score_concentration_penalty(c, state), 0.0)
+
+    def test_zero_nlv_score_candidate_does_not_raise(self):
+        c = _make_candidate(iv_rank=50.0, max_loss=1000.0)
+        state = AccountState(nlv=0.0, bp_usage_pct=0.0)
+        scored = score_candidate(c, today=date(2026, 4, 26), account_state=state)
+        self.assertEqual(scored.score_breakdown["account_fit"], 10.0)
+        self.assertEqual(scored.score_breakdown["concentration_penalty"], 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -7,6 +7,7 @@ from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agents.trade_ranker import (
+    AccountState,
     Candidate,
     Rejection,
     SymbolContext,
@@ -16,6 +17,9 @@ from agents.trade_ranker import (
     _check_earnings_blackout,
     _check_open_interest,
     _check_spread,
+    _score_account_fit,
+    _score_concentration_penalty,
+    apply_account_filters,
     apply_quality_gates,
     generate_candidates,
     scan_watchlists,
@@ -839,6 +843,140 @@ class TestScoring(unittest.TestCase):
         scored = score_candidate(c, today=self._TODAY)
         self.assertLessEqual(scored.score, 100.0)
         self.assertAlmostEqual(scored.score, 100.0, places=2)
+
+
+class TestAccountFiltersAndScoring(unittest.TestCase):
+    """Tests for apply_account_filters and account-aware scoring (TCBT-4)."""
+
+    DEFAULT_FILTERS = dict(
+        max_pct_nlv_per_trade=0.05,
+        bp_cap_for_new=0.50,
+        concentration_block_pct=0.25,
+    )
+
+    @staticmethod
+    def _state(nlv=20000.0, bp_usage_pct=0.20, exposures=None):
+        return AccountState(nlv=nlv, bp_usage_pct=bp_usage_pct, existing_exposures=exposures or {})
+
+    def test_passing_candidate_survives_all_account_filters(self):
+        c = _make_candidate(symbol="AAPL", max_loss=200.0)
+        survivors, rejections = apply_account_filters([c], self._state(), **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [c])
+        self.assertEqual(rejections, [])
+
+    def test_oversized_vs_nlv_rejected(self):
+        c = _make_candidate(symbol="AAPL", max_loss=2000.0)
+        survivors, rejections = apply_account_filters([c], self._state(), **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [])
+        self.assertEqual(rejections[0].reason, "oversized_vs_nlv")
+        self.assertIn("10.0% NLV above cap 5.0%", rejections[0].detail)
+
+    def test_bp_over_cap_rejected(self):
+        c = _make_candidate(symbol="AAPL", max_loss=200.0)
+        survivors, rejections = apply_account_filters([c], self._state(bp_usage_pct=0.495), **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [])
+        self.assertEqual(rejections[0].reason, "bp_over_cap")
+        self.assertIn("post-trade BP 50.5% above cap 50.0%", rejections[0].detail)
+
+    def test_concentration_overlap_rejected(self):
+        c = _make_candidate(symbol="AAPL", max_loss=1500.0)
+        state = self._state(exposures={"AAPL": 4000.0})
+        filters = dict(self.DEFAULT_FILTERS, max_pct_nlv_per_trade=0.10)
+        survivors, rejections = apply_account_filters([c], state, **filters)
+        self.assertEqual(survivors, [])
+        self.assertEqual(rejections[0].reason, "concentration_overlap")
+        self.assertIn("AAPL exposure $4000 + $1500 = 27.5% NLV above cap 25.0%", rejections[0].detail)
+
+    def test_first_failure_wins_oversized_before_bp(self):
+        c = _make_candidate(symbol="AAPL", max_loss=2000.0)
+        state = self._state(bp_usage_pct=0.495)
+        survivors, rejections = apply_account_filters([c], state, **self.DEFAULT_FILTERS)
+        self.assertEqual(rejections[0].reason, "oversized_vs_nlv")
+
+    def test_empty_candidates_returns_empty_account_filters(self):
+        survivors, rejections = apply_account_filters([], self._state(), **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [])
+        self.assertEqual(rejections, [])
+
+    def test_threshold_boundary_oversized_just_under_passes(self):
+        c = _make_candidate(symbol="AAPL", max_loss=1000.0)
+        survivors, _ = apply_account_filters([c], self._state(), **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [c])
+
+    def test_threshold_boundary_concentration_no_existing_exposure_passes(self):
+        c = _make_candidate(symbol="AAPL", max_loss=1000.0)
+        state = self._state(bp_usage_pct=0.10, exposures={"AAPL": 4000.0})
+        survivors, _ = apply_account_filters([c], state, **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [c])
+
+    def test_account_fit_full_when_max_loss_under_two_pct(self):
+        c = _make_candidate(max_loss=200.0)
+        self.assertEqual(_score_account_fit(c, self._state()), 10.0)
+
+    def test_account_fit_zero_when_max_loss_at_or_above_five_pct(self):
+        c5 = _make_candidate(max_loss=1000.0)
+        c10 = _make_candidate(max_loss=2000.0)
+        self.assertEqual(_score_account_fit(c5, self._state()), 0.0)
+        self.assertEqual(_score_account_fit(c10, self._state()), 0.0)
+
+    def test_account_fit_linear_ramp_at_three_pct(self):
+        c = _make_candidate(max_loss=600.0)
+        self.assertAlmostEqual(_score_account_fit(c, self._state()), 6.6667, places=4)
+
+    def test_account_fit_no_state_returns_ten_placeholder(self):
+        c = _make_candidate(max_loss=99999.0)
+        self.assertEqual(_score_account_fit(c, None), 10.0)
+
+    def test_concentration_penalty_zero_no_existing_exposure_small_trade(self):
+        c = _make_candidate(symbol="AAPL", max_loss=400.0)
+        self.assertEqual(_score_concentration_penalty(c, self._state()), 0.0)
+
+    def test_concentration_penalty_ramps_with_exposure(self):
+        c = _make_candidate(symbol="AAPL", max_loss=1000.0)
+        state = self._state(exposures={"AAPL": 2000.0})
+        self.assertAlmostEqual(_score_concentration_penalty(c, state), 5.0, places=4)
+
+    def test_concentration_penalty_full_at_or_above_twentyfive_pct(self):
+        c = _make_candidate(symbol="AAPL", max_loss=1000.0)
+        state25 = self._state(exposures={"AAPL": 4000.0})
+        state40 = self._state(exposures={"AAPL": 7000.0})
+        self.assertEqual(_score_concentration_penalty(c, state25), 10.0)
+        self.assertEqual(_score_concentration_penalty(c, state40), 10.0)
+
+    def test_concentration_penalty_no_state_returns_zero_placeholder(self):
+        c = _make_candidate(symbol="AAPL", max_loss=99999.0)
+        self.assertEqual(_score_concentration_penalty(c, None), 0.0)
+
+    def test_score_candidate_threads_account_state_to_components(self):
+        c = _make_candidate(symbol="AAPL", max_loss=600.0, iv_rank=50.0)
+        state = self._state(exposures={"AAPL": 2000.0})
+        scored_with = score_candidate(c, today=date(2026, 4, 26), account_state=state)
+        scored_without = score_candidate(c, today=date(2026, 4, 26))
+        self.assertNotEqual(scored_with.score_breakdown["account_fit"], scored_without.score_breakdown["account_fit"])
+        self.assertGreater(scored_without.score, scored_with.score)
+
+    def test_score_candidate_without_state_matches_tcbt10_baseline(self):
+        c = _make_candidate(iv_rank=60.0)
+        a = score_candidate(c, today=date(2026, 4, 26))
+        b = score_candidate(c, today=date(2026, 4, 26), account_state=None)
+        self.assertEqual(a.score, b.score)
+        self.assertEqual(a.score_breakdown, b.score_breakdown)
+
+    def test_score_candidates_propagates_state_to_each(self):
+        c1 = _make_candidate(symbol="AAPL", max_loss=200.0)
+        c2 = _make_candidate(symbol="MSFT", max_loss=2000.0)
+        state = self._state()
+        scored = score_candidates([c1, c2], today=date(2026, 4, 26), account_state=state)
+        self.assertEqual(scored[0].score_breakdown["account_fit"], 10.0)
+        self.assertEqual(scored[1].score_breakdown["account_fit"], 0.0)
+
+    def test_higher_existing_exposure_lowers_score(self):
+        c = _make_candidate(symbol="AAPL", max_loss=1000.0, iv_rank=50.0)
+        state_low = self._state(exposures={"AAPL": 0.0})
+        state_high = self._state(exposures={"AAPL": 3000.0})
+        s_low = score_candidate(c, today=date(2026, 4, 26), account_state=state_low).score
+        s_high = score_candidate(c, today=date(2026, 4, 26), account_state=state_high).score
+        self.assertGreater(s_low, s_high)
 
 
 if __name__ == "__main__":

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -14,6 +14,9 @@ NUMERIC_KEYS: frozenset[str] = frozenset({
     "bp_usage_block",
     "concentration_pct_nlv_warn",
     "bt_max_spread_pct",
+    "bt_max_pct_nlv_per_trade",
+    "bt_bp_cap_for_new",
+    "bt_concentration_overlap_block_pct",
 })
 OPTIONAL_NUMERIC_KEYS: frozenset[str] = frozenset({
     "theta_target",  # may be None
@@ -38,6 +41,9 @@ DEFAULTS: dict[str, Any] = {
     "bt_min_open_interest": 200,
     "bt_max_per_symbol": 3,
     "bt_max_spread_pct": 0.10,
+    "bt_max_pct_nlv_per_trade": 0.05,
+    "bt_bp_cap_for_new": 0.50,
+    "bt_concentration_overlap_block_pct": 0.25,
     "alert_toggles": {
         "position_size": True,
         "bp": True,


### PR DESCRIPTION
> **Stacked on #14 (TCBT-10 scoring).** When #14 merges, GitHub will auto-rebase this PR's base to \`main\` (and per the lesson from #11/#12, this PR's base may need a manual retarget if #14 is merged with \`--delete-branch\`). Review #14 first.

## Summary
- Plugs the **account_fit** and **concentration_penalty** placeholders that TCBT-10 left behind.
- Adds a hard-reject filter layer parallel to TCBT-9 quality gates, driven by live account state.
- New \`AccountState\` dataclass abstracts the per-run snapshot so \`agents/manager.py\` / \`agents/portfolio.py\` stay untouched (real wiring in TCBT-7).

## New API surface
\`\`\`python
@dataclass(frozen=True)
class AccountState:
    nlv: float
    bp_usage_pct: float                          # 0..1
    existing_exposures: dict[str, float]         # underlying → max-loss

def apply_account_filters(candidates, account_state, *,
    max_pct_nlv_per_trade, bp_cap_for_new, concentration_block_pct
) -> (survivors, rejections)
\`\`\`

## Hard rejects (in fixed order, first failure wins)
| Reason | Condition | Detail example |
|---|---|---|
| \`oversized_vs_nlv\` | \`max_loss / nlv > 5%\` | \`max_loss \$2000 = 10.0% NLV above cap 5.0%\` |
| \`bp_over_cap\` | \`bp_usage + size_pct > 50%\` | \`post-trade BP 50.5% above cap 50.0%\` |
| \`concentration_overlap\` | \`(existing + max_loss) / nlv > 25%\` | \`AAPL exposure \$4000 + \$1500 = 27.5% NLV above cap 25.0%\` |

Strict \`>\` semantics — boundary values pass.

## Soft scoring (fills TCBT-10 placeholders)
- \`_score_account_fit\`: ramp 10→0 between 2% and 5% of NLV
- \`_score_concentration_penalty\`: ramp 0→10 between 5% and 25% post-trade exposure
- Both return TCBT-10 placeholder (10 / 0) when \`account_state=None\` — verified byte-identical baseline by \`test_score_candidate_without_state_matches_tcbt10_baseline\`

## New settings keys (all floats)
| Key | Default |
|---|---|
| \`bt_max_pct_nlv_per_trade\` | 0.05 |
| \`bt_bp_cap_for_new\` | 0.50 |
| \`bt_concentration_overlap_block_pct\` | 0.25 |

## Test plan
- [x] \`./venv/bin/python -m unittest tests.test_trade_ranker tests.test_settings tests.test_best_trades_cli\` — 166 / 166 pass
- [x] 20 new \`TestAccountFiltersAndScoring\` tests covering all 3 reject reasons, threshold boundaries, ramp endpoints, placeholder fallback, threading through \`score_candidate\`/\`score_candidates\`, monotonicity (higher exposure → lower score)
- [x] 3 new round-trip tests for the new settings keys
- [x] All 143 pre-existing tests still pass — TCBT-2/3/8/9/10 untouched
- [x] No changes to \`agents/manager.py\`, \`agents/portfolio.py\`, \`agents/scanner.py\`, \`agents/options_researcher.py\`, \`main.py\`, launcher
- [x] \`run_best_trades\` still a stub — does not call \`apply_account_filters\`, does not pass \`account_state\`. Wiring in TCBT-7.

## Out of scope
- Wiring \`AccountState\` from real \`RiskManager\` + \`PortfolioAgent\` — TCBT-7 (Top-3 output)
- Correlation-bucket overlap (only same-underlying in v1)
- Surface account-aware notes in \`summary_reason\` — deferred to TCBT-7 where output formatting can use them

## QA
Built via \`/build-qa\`: Opus plan → Haiku build → tests caught one fixture issue (\`test_concentration_overlap_rejected\` needed \`max_pct_nlv_per_trade\` raised so concentration was the binding constraint, not size) → fixed → 166/166 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)