### PR TITLE
TCBT-5: top-3 output integrating the full pipeline

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -16,16 +16,17 @@ from tastytrade import Session
 from tastytrade.metrics import get_market_metrics
 from tastytrade.market_data import get_market_data_by_type
 
+from agents.manager import RiskManager
 from agents.options_researcher import OptionsResearcherAgent
+from agents.portfolio import PortfolioAgent
 from agents.scanner import ScannerAgent
+from utils.settings import settings
 
 
 DEFAULT_WATCHLISTS: tuple[str, ...] = (
     "Chris Historical Trades",
     "High Options Volume",
 )
-
-STUB_MARKER: str = "stub — full logic in TCBT-8/3/9/10/4/5/6/7"
 
 _BATCH_SIZE: int = 50
 
@@ -252,41 +253,214 @@ def _build_context(
     return ctx
 
 
+def _load_thresholds() -> dict[str, Any]:
+    """Read all 9 best-trades threshold settings into a single dict."""
+    return {
+        "blackout_days": settings.get("bt_earnings_blackout_days"),
+        "min_dte": settings.get("bt_min_dte"),
+        "max_dte": settings.get("bt_max_dte"),
+        "min_open_interest": settings.get("bt_min_open_interest"),
+        "max_spread_pct": settings.get("bt_max_spread_pct"),
+        "max_per_symbol": settings.get("bt_max_per_symbol"),
+        "max_pct_nlv_per_trade": settings.get("bt_max_pct_nlv_per_trade"),
+        "bp_cap_for_new": settings.get("bt_bp_cap_for_new"),
+        "concentration_block_pct": settings.get("bt_concentration_overlap_block_pct"),
+    }
+
+
+def _select_top_per_symbol(candidates: list[Candidate], top: int) -> list[Candidate]:
+    """Best score per symbol, sorted by (score desc, symbol asc), capped at `top`."""
+    if not candidates or top <= 0:
+        return []
+    best_per_symbol: dict[str, Candidate] = {}
+    for c in candidates:
+        existing = best_per_symbol.get(c.symbol)
+        if existing is None or c.score > existing.score:
+            best_per_symbol[c.symbol] = c
+    ranked = sorted(
+        best_per_symbol.values(),
+        key=lambda c: (-c.score, c.symbol),
+    )
+    return ranked[:top]
+
+
+def _rejection_to_dict(r: Rejection) -> dict[str, Any]:
+    """Serialize a Rejection to a JSON-safe dict."""
+    return {
+        "symbol": r.symbol,
+        "reason": r.reason,
+        "detail": r.detail,
+    }
+
+
+def _candidate_to_dict(c: Candidate) -> dict[str, Any]:
+    """Serialize a Candidate to a JSON-safe dict for the top-trades output."""
+    return {
+        "symbol": c.symbol,
+        "structure": c.structure,
+        "expiration": c.expiration.isoformat() if hasattr(c.expiration, "isoformat") else str(c.expiration),
+        "dte": c.dte,
+        "credit": float(c.credit),
+        "max_loss": float(c.max_loss),
+        "short_delta": float(c.short_delta),
+        "breakevens": [float(b) for b in c.breakevens],
+        "score": float(c.score),
+        "score_breakdown": dict(c.score_breakdown) if c.score_breakdown else {},
+        "summary_reason": c.summary_reason or "",
+    }
+
+
+async def _build_account_state(session: Session, account_number: str) -> AccountState:
+    """Build AccountState from RiskManager + PortfolioAgent (existing_exposures={} for v1)."""
+    risk_manager = RiskManager(session, account_number)
+    report = await risk_manager.calculate_portfolio_risk()
+    nlv = float(report["nlv"])
+    bp_usage_pct = float(report["bp_usage_pct"]) / 100.0
+    portfolio_agent = await PortfolioAgent(session, account_number).init()
+    _positions = await portfolio_agent.get_positions()
+    return AccountState(
+        nlv=nlv,
+        bp_usage_pct=bp_usage_pct,
+        existing_exposures={},
+    )
+
+
 async def run_best_trades(
     session: Session,
     *,
     watchlists: Optional[Sequence[str]] = None,
     top: int = 3,
     output_format: str = "text",
+    account_number: Optional[str] = None,
+    today: Optional[date] = None,
 ) -> dict[str, Any]:
-    """Rank trade ideas across watchlists; stub returns an empty canonical result."""
-    resolved = list(watchlists) if watchlists is not None else list(DEFAULT_WATCHLISTS)
-    return {
+    """Run the full Best-Trades pipeline and return a canonical result dict."""
+    resolved_watchlists = list(watchlists) if watchlists is not None else list(DEFAULT_WATCHLISTS)
+    result: dict[str, Any] = {
         "top": [],
         "rejected": [],
         "warnings": [],
-        "watchlists": resolved,
+        "watchlists": resolved_watchlists,
+        "account": None,
     }
+
+    contexts, scan_warnings = await scan_watchlists(session, resolved_watchlists)
+    result["warnings"].extend(scan_warnings)
+    if not contexts:
+        return result
+
+    thresholds = _load_thresholds()
+
+    candidates, gen_rejections = await generate_candidates(
+        session,
+        contexts,
+        max_per_symbol=thresholds["max_per_symbol"],
+    )
+    for r in gen_rejections:
+        result["rejected"].append(_rejection_to_dict(r))
+
+    if not candidates:
+        return result
+
+    passing, gate_rejections = apply_quality_gates(
+        candidates,
+        blackout_days=thresholds["blackout_days"],
+        min_dte=thresholds["min_dte"],
+        max_dte=thresholds["max_dte"],
+        min_open_interest=thresholds["min_open_interest"],
+        max_spread_pct=thresholds["max_spread_pct"],
+        today=today,
+    )
+    for r in gate_rejections:
+        result["rejected"].append(_rejection_to_dict(r))
+
+    if not passing:
+        return result
+
+    account_state: Optional[AccountState] = None
+    if account_number is not None:
+        try:
+            account_state = await _build_account_state(session, account_number)
+            result["account"] = {
+                "nlv": account_state.nlv,
+                "bp_usage_pct": account_state.bp_usage_pct,
+            }
+        except Exception as e:
+            result["warnings"].append(f"account state unavailable: {e}")
+            account_state = None
+
+    if account_state is not None:
+        passing, account_rejections = apply_account_filters(
+            passing,
+            account_state,
+            max_pct_nlv_per_trade=thresholds["max_pct_nlv_per_trade"],
+            bp_cap_for_new=thresholds["bp_cap_for_new"],
+            concentration_block_pct=thresholds["concentration_block_pct"],
+        )
+        for r in account_rejections:
+            result["rejected"].append(_rejection_to_dict(r))
+
+        if not passing:
+            return result
+
+    scored = score_candidates(passing, today=today, account_state=account_state)
+    selected = _select_top_per_symbol(scored, top)
+    result["top"] = [_candidate_to_dict(c) for c in selected]
+    return result
 
 
 def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
-    """Print a best-trades result dict in human-readable form including the stub marker."""
+    """Print a best-trades result dict in human-readable text form."""
+    watchlists = result.get("watchlists") or []
+    print(f"=== Best Trades Today (top {top}) ===")
+    if watchlists:
+        print(f"Watchlists: {', '.join(watchlists)}")
+
+    account = result.get("account")
+    if account is not None:
+        nlv = account.get("nlv", 0.0)
+        bp = account.get("bp_usage_pct", 0.0)
+        print(f"Account: NLV ${nlv:,.0f}, BP usage {bp * 100:.1f}%")
+
+    top_items = result.get("top") or []
     print()
-    print("=" * 80)
-    print(f"Best Trades Today  ({STUB_MARKER})")
-    print("=" * 80)
-    watchlists = result["watchlists"]
-    print(f"Watchlists: {', '.join(watchlists) if watchlists else '(none)'}")
-    print(f"Top requested: {top}")
-    print(f"Ranked: {len(result['top'])}   Rejected: {len(result['rejected'])}   Warnings: {len(result['warnings'])}")
-    if not result["top"]:
+    if not top_items:
+        print("No trades passed all gates today.")
+    else:
+        for idx, item in enumerate(top_items, start=1):
+            symbol = item.get("symbol", "?")
+            structure = item.get("structure", "?")
+            expiration = item.get("expiration", "?")
+            dte = item.get("dte", 0)
+            credit = item.get("credit", 0.0)
+            max_loss = item.get("max_loss", 0.0)
+            score = item.get("score", 0.0)
+            summary = item.get("summary_reason", "")
+            breakdown = item.get("score_breakdown") or {}
+            print(f"[{idx}] {symbol} {structure} {expiration} ({dte} DTE)")
+            print(f"    Credit ${credit:.2f} / Max risk ${max_loss:.0f}")
+            print(f"    Score: {score:.1f}/100 — {summary}")
+            if breakdown:
+                parts = [f"{k} {float(v):.1f}" for k, v in breakdown.items()]
+                print(f"    Breakdown: {', '.join(parts)}")
+
+    rejected = result.get("rejected") or []
+    if rejected:
+        counts: dict[str, int] = {}
+        for r in rejected:
+            reason = r.get("reason", "unknown")
+            counts[reason] = counts.get(reason, 0) + 1
         print()
-        print("No trade ideas yet — orchestrator stub. Implementation lands in TCBT-3..11.")
-    if result["warnings"]:
+        print("Rejection summary:")
+        for reason, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+            print(f"  {reason}: {n}")
+
+    warnings = result.get("warnings") or []
+    if warnings:
         print()
         print("Warnings:")
-        for w in result["warnings"]:
-            print(f"  • {w}")
+        for w in warnings:
+            print(f"  - {w}")
 
 
 def _check_earnings_blackout(candidate: Candidate, blackout_days: int, today: date) -> Optional[Rejection]:

--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -175,7 +175,11 @@ async def scan_watchlists(
     seen: set[str] = set()
     symbols: list[str] = []
     for name in names:
-        wl_symbols = await scanner.get_symbols_from_watchlist(name, equity_only=True)
+        try:
+            wl_symbols = await scanner.get_symbols_from_watchlist(name, equity_only=True)
+        except Exception as e:
+            warnings.append(f"watchlist '{name}' fetch failed: {e}")
+            continue
         if not wl_symbols:
             warnings.append(f"watchlist '{name}' not found or empty")
             continue
@@ -344,7 +348,11 @@ async def run_best_trades(
         "account": None,
     }
 
-    contexts, scan_warnings = await scan_watchlists(session, resolved_watchlists)
+    try:
+        contexts, scan_warnings = await scan_watchlists(session, resolved_watchlists)
+    except Exception as e:
+        result["warnings"].append(f"watchlist scan failed: {e}")
+        return result
     result["warnings"].extend(scan_warnings)
     if not contexts:
         return result

--- a/main.py
+++ b/main.py
@@ -269,6 +269,7 @@ async def async_main() -> int:
                 watchlists=args.bt_watchlist,
                 top=args.top,
                 output_format=args.format,
+                account_number=args.account or getattr(client.config, "account_number", None),
             )
 
             if args.format == "json":

--- a/tests/test_best_trades_cli.py
+++ b/tests/test_best_trades_cli.py
@@ -61,59 +61,67 @@ class TestBestTradesArgparse(unittest.TestCase):
 
 
 class TestRunBestTradesStub(unittest.IsolatedAsyncioTestCase):
-    """Test the run_best_trades stub function."""
+    """Smoke tests on run_best_trades that mock scan_watchlists to skip real I/O."""
 
-    async def test_default_watchlists_used_when_none(self):
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_default_watchlists_used_when_none(self, mock_scan):
         from agents.trade_ranker import run_best_trades, DEFAULT_WATCHLISTS
-        result = await run_best_trades(MagicMock())
+        mock_scan.return_value = ([], [])
+        result = await run_best_trades(MagicMock(), watchlists=None)
         self.assertEqual(result["watchlists"], list(DEFAULT_WATCHLISTS))
+        mock_scan.assert_awaited_once()
+        called_args = mock_scan.await_args
+        self.assertEqual(called_args.args[1], list(DEFAULT_WATCHLISTS))
 
-    async def test_explicit_watchlists_honoured(self):
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_explicit_watchlists_honoured(self, mock_scan):
         from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([], [])
         result = await run_best_trades(MagicMock(), watchlists=["X", "Y"])
         self.assertEqual(result["watchlists"], ["X", "Y"])
 
-    async def test_explicit_empty_watchlists_honoured(self):
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_explicit_empty_watchlists_honoured(self, mock_scan):
         from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([], [])
         result = await run_best_trades(MagicMock(), watchlists=[])
         self.assertEqual(result["watchlists"], [])
 
-    async def test_canonical_shape(self):
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_canonical_shape(self, mock_scan):
         from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([], [])
         result = await run_best_trades(MagicMock())
-        self.assertEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
+        self.assertGreaterEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
         self.assertEqual(result["top"], [])
         self.assertEqual(result["rejected"], [])
         self.assertEqual(result["warnings"], [])
 
-    async def test_session_not_called(self):
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_top_arg_accepted(self, mock_scan):
         from agents.trade_ranker import run_best_trades
-        session = MagicMock()
-        await run_best_trades(session)
-        self.assertEqual(session.method_calls, [])
-        self.assertEqual(session.mock_calls, [])
-
-    async def test_top_arg_accepted(self):
-        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([], [])
         result = await run_best_trades(MagicMock(), top=10)
-        self.assertEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
+        self.assertGreaterEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
 
-    async def test_output_format_arg_accepted(self):
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_output_format_arg_accepted(self, mock_scan):
         from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([], [])
         result = await run_best_trades(MagicMock(), output_format="json")
-        self.assertEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
+        self.assertGreaterEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
 
 
 class TestBestTradesCliOutput(unittest.IsolatedAsyncioTestCase):
     """Test text and JSON output formats and CLI dispatch."""
 
-    def test_text_output_contains_stub_marker(self):
-        from agents.trade_ranker import _print_best_trades_text, STUB_MARKER
+    def test_text_output_contains_header(self):
+        from agents.trade_ranker import _print_best_trades_text
         result = {"top": [], "rejected": [], "warnings": [], "watchlists": ["A"]}
         f = io.StringIO()
         with redirect_stdout(f):
             _print_best_trades_text(result, 3)
-        self.assertIn(STUB_MARKER, f.getvalue())
+        self.assertIn("Best Trades Today", f.getvalue())
 
     def test_text_output_lists_watchlists(self):
         from agents.trade_ranker import _print_best_trades_text

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -264,6 +264,28 @@ class TestScanWatchlists(unittest.IsolatedAsyncioTestCase):
 
     @patch("agents.trade_ranker.get_market_metrics")
     @patch("agents.trade_ranker.get_market_data_by_type")
+    async def test_per_watchlist_fetch_failure_warns_does_not_crash(self, mock_prices, mock_metrics):
+        mock_metrics.return_value = []
+        mock_prices.return_value = []
+        scanner = MagicMock()
+        scanner.get_symbols_from_watchlist = AsyncMock(side_effect=[
+            RuntimeError("auth expired"),
+            ["AAPL"],
+        ])
+        mock_metrics.return_value = [_make_metric("AAPL")]
+        mock_prices.return_value = [_make_price("AAPL")]
+        session = MagicMock()
+        contexts, warnings = await scan_watchlists(
+            session, watchlists=["Bad", "Good"], scanner=scanner
+        )
+        self.assertEqual(len(contexts), 1)
+        self.assertEqual(contexts[0].symbol, "AAPL")
+        self.assertEqual(len(warnings), 1)
+        self.assertTrue(warnings[0].startswith("watchlist 'Bad' fetch failed: "))
+        self.assertIn("auth expired", warnings[0])
+
+    @patch("agents.trade_ranker.get_market_metrics")
+    @patch("agents.trade_ranker.get_market_data_by_type")
     async def test_batch_failure_warns_does_not_crash(self, mock_prices, mock_metrics):
         mock_metrics.side_effect = RuntimeError("boom")
         scanner = MagicMock()
@@ -1376,6 +1398,16 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
         await run_best_trades(MagicMock(), watchlists=None)
         called_args = mock_scan.await_args
         self.assertEqual(called_args.args[1], list(DEFAULT_WATCHLISTS))
+
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_scan_failure_degrades_gracefully(self, mock_scan):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.side_effect = RuntimeError("api down")
+        result = await run_best_trades(MagicMock(), watchlists=["X"])
+        self.assertEqual(result["top"], [])
+        self.assertEqual(result["rejected"], [])
+        self.assertIsNone(result["account"])
+        self.assertTrue(any("watchlist scan failed" in w and "api down" in w for w in result["warnings"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -1019,5 +1019,364 @@ class TestAccountFiltersAndScoring(unittest.TestCase):
         self.assertEqual(scored.score_breakdown["concentration_penalty"], 0.0)
 
 
+def _mk_top_candidate(symbol: str, score: float, structure: str = "BULL_PUT_SPREAD") -> Candidate:
+    """Build a minimal Candidate for top-selection tests."""
+    return Candidate(
+        symbol=symbol,
+        structure=structure,
+        expiration=date(2026, 6, 19),
+        dte=45,
+        width=5.0,
+        credit=1.50,
+        max_loss=350.0,
+        credit_pct_of_width=0.30,
+        short_delta=0.20,
+        pop_estimate=0.75,
+        breakevens=[148.50],
+        net_greeks={},
+        legs=[],
+        researcher_score=80.0,
+        researcher_score_breakdown={},
+        context=SymbolContext(symbol=symbol),
+        score=score,
+        score_breakdown={"liquidity": score * 0.4},
+        summary_reason=f"{symbol} test",
+    )
+
+
+class TestSelectTopPerSymbol(unittest.TestCase):
+    """Tests for _select_top_per_symbol helper."""
+
+    def test_select_top_empty_returns_empty(self):
+        from agents.trade_ranker import _select_top_per_symbol
+        self.assertEqual(_select_top_per_symbol([], 3), [])
+
+    def test_select_top_one_per_symbol(self):
+        from agents.trade_ranker import _select_top_per_symbol
+        candidates = [_mk_top_candidate("A", 90), _mk_top_candidate("B", 80), _mk_top_candidate("C", 70)]
+        result = _select_top_per_symbol(candidates, 3)
+        self.assertEqual([c.symbol for c in result], ["A", "B", "C"])
+
+    def test_select_top_picks_max_score_within_symbol(self):
+        from agents.trade_ranker import _select_top_per_symbol
+        candidates = [
+            _mk_top_candidate("A", 60),
+            _mk_top_candidate("A", 90),
+            _mk_top_candidate("B", 70),
+        ]
+        result = _select_top_per_symbol(candidates, 3)
+        self.assertEqual(len(result), 2)
+        symbols_to_scores = {c.symbol: c.score for c in result}
+        self.assertEqual(symbols_to_scores["A"], 90)
+        self.assertEqual(symbols_to_scores["B"], 70)
+
+    def test_select_top_caps_at_n(self):
+        from agents.trade_ranker import _select_top_per_symbol
+        candidates = [_mk_top_candidate(s, 90 - i * 10) for i, s in enumerate(["A", "B", "C", "D", "E"])]
+        result = _select_top_per_symbol(candidates, 3)
+        self.assertEqual(len(result), 3)
+        self.assertEqual([c.symbol for c in result], ["A", "B", "C"])
+
+    def test_select_top_sorts_by_score_desc_with_symbol_tiebreak(self):
+        from agents.trade_ranker import _select_top_per_symbol
+        candidates = [_mk_top_candidate("C", 80), _mk_top_candidate("A", 80), _mk_top_candidate("B", 80)]
+        result = _select_top_per_symbol(candidates, 3)
+        self.assertEqual([c.symbol for c in result], ["A", "B", "C"])
+
+    def test_select_top_zero_returns_empty(self):
+        from agents.trade_ranker import _select_top_per_symbol
+        candidates = [_mk_top_candidate("A", 90)]
+        self.assertEqual(_select_top_per_symbol(candidates, 0), [])
+
+    def test_select_top_negative_returns_empty(self):
+        from agents.trade_ranker import _select_top_per_symbol
+        candidates = [_mk_top_candidate("A", 90)]
+        self.assertEqual(_select_top_per_symbol(candidates, -1), [])
+
+
+class TestLoadThresholds(unittest.TestCase):
+    """Tests for _load_thresholds helper."""
+
+    @patch("agents.trade_ranker.settings")
+    def test_load_thresholds_returns_all_nine_keys(self, mock_settings):
+        from agents.trade_ranker import _load_thresholds
+        mock_settings.get.side_effect = lambda key: f"value_for_{key}"
+        result = _load_thresholds()
+        self.assertEqual(
+            set(result.keys()),
+            {
+                "blackout_days",
+                "min_dte",
+                "max_dte",
+                "min_open_interest",
+                "max_spread_pct",
+                "max_per_symbol",
+                "max_pct_nlv_per_trade",
+                "bp_cap_for_new",
+                "concentration_block_pct",
+            },
+        )
+        expected_calls = [
+            "bt_earnings_blackout_days",
+            "bt_min_dte",
+            "bt_max_dte",
+            "bt_min_open_interest",
+            "bt_max_spread_pct",
+            "bt_max_per_symbol",
+            "bt_max_pct_nlv_per_trade",
+            "bt_bp_cap_for_new",
+            "bt_concentration_overlap_block_pct",
+        ]
+        actual_calls = [call.args[0] for call in mock_settings.get.call_args_list]
+        self.assertEqual(set(actual_calls), set(expected_calls))
+
+
+class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
+    """End-to-end pipeline tests for run_best_trades."""
+
+    @staticmethod
+    def _passing_candidate(symbol: str = "AAPL", score: float = 0.0) -> Candidate:
+        return _mk_top_candidate(symbol, score)
+
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_empty_scan_returns_no_trades(self, mock_scan):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([], ["no symbols"])
+        result = await run_best_trades(MagicMock(), watchlists=["X"])
+        self.assertEqual(result["top"], [])
+        self.assertEqual(result["rejected"], [])
+        self.assertEqual(result["warnings"], ["no symbols"])
+        self.assertIsNone(result["account"])
+
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_no_candidates_returns_no_trades(self, mock_scan, mock_gen):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        mock_gen.return_value = ([], [Rejection(symbol="AAPL", reason="no_chains", detail="none")])
+        result = await run_best_trades(MagicMock(), watchlists=["X"])
+        self.assertEqual(result["top"], [])
+        self.assertEqual(len(result["rejected"]), 1)
+        self.assertEqual(result["rejected"][0]["reason"], "no_chains")
+
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_all_rejected_by_gates_returns_no_trades(self, mock_scan, mock_gen, mock_gates):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidate = self._passing_candidate()
+        mock_gen.return_value = ([candidate], [])
+        mock_gates.return_value = ([], [Rejection(symbol="AAPL", reason="earnings_blackout", detail="2 days")])
+        result = await run_best_trades(MagicMock(), watchlists=["X"])
+        self.assertEqual(result["top"], [])
+        self.assertEqual(result["rejected"][0]["reason"], "earnings_blackout")
+
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_basic_pipeline_returns_scored_top(self, mock_scan, mock_gen, mock_gates):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidate = self._passing_candidate("AAPL", 75.0)
+        mock_gen.return_value = ([candidate], [])
+        mock_gates.return_value = ([candidate], [])
+        result = await run_best_trades(MagicMock(), watchlists=["X"])
+        self.assertEqual(len(result["top"]), 1)
+        self.assertEqual(result["top"][0]["symbol"], "AAPL")
+        self.assertIsNone(result["account"])
+        self.assertIsInstance(result["top"][0]["score"], float)
+
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_top_selection_dedupes_by_symbol(self, mock_scan, mock_gen, mock_gates):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        c1 = self._passing_candidate("AAPL", 60.0)
+        c2 = self._passing_candidate("AAPL", 90.0)
+        c3 = self._passing_candidate("AAPL", 70.0)
+        mock_gen.return_value = ([c1, c2, c3], [])
+        mock_gates.return_value = ([c1, c2, c3], [])
+        result = await run_best_trades(MagicMock(), watchlists=["X"])
+        self.assertEqual(len(result["top"]), 1)
+        self.assertEqual(result["top"][0]["symbol"], "AAPL")
+
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_top_selection_caps_at_n(self, mock_scan, mock_gen, mock_gates):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidates = [self._passing_candidate(s, 100 - i * 10) for i, s in enumerate(["A", "B", "C", "D", "E"])]
+        mock_gen.return_value = (candidates, [])
+        mock_gates.return_value = (candidates, [])
+        result = await run_best_trades(MagicMock(), watchlists=["X"], top=3)
+        self.assertEqual(len(result["top"]), 3)
+
+    @patch("agents.trade_ranker.score_candidates")
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_top_selection_sorts_by_score_descending(self, mock_scan, mock_gen, mock_gates, mock_score):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidates = [self._passing_candidate(s, 50) for s in ["X", "Y", "Z"]]
+        mock_gen.return_value = (candidates, [])
+        mock_gates.return_value = (candidates, [])
+        mock_score.return_value = [
+            self._passing_candidate("X", 10),
+            self._passing_candidate("Y", 90),
+            self._passing_candidate("Z", 50),
+        ]
+        result = await run_best_trades(MagicMock(), watchlists=["W"])
+        self.assertEqual([t["symbol"] for t in result["top"]], ["Y", "Z", "X"])
+
+    @patch("agents.trade_ranker.score_candidates")
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_top_selection_tie_breaks_by_symbol_ascending(self, mock_scan, mock_gen, mock_gates, mock_score):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidates = [self._passing_candidate(s, 75) for s in ["B", "A", "C"]]
+        mock_gen.return_value = (candidates, [])
+        mock_gates.return_value = (candidates, [])
+        mock_score.return_value = [
+            self._passing_candidate("B", 75),
+            self._passing_candidate("A", 75),
+            self._passing_candidate("C", 75),
+        ]
+        result = await run_best_trades(MagicMock(), watchlists=["W"])
+        self.assertEqual([t["symbol"] for t in result["top"]], ["A", "B", "C"])
+
+    @patch("agents.trade_ranker._build_account_state", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.apply_account_filters")
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_account_state_provided_runs_account_filters(
+        self, mock_scan, mock_gen, mock_gates, mock_account_filters, mock_build_state
+    ):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidate = self._passing_candidate("AAPL", 75.0)
+        mock_gen.return_value = ([candidate], [])
+        mock_gates.return_value = ([candidate], [])
+        mock_state = AccountState(nlv=50000.0, bp_usage_pct=0.30, existing_exposures={})
+        mock_build_state.return_value = mock_state
+        mock_account_filters.return_value = ([candidate], [])
+        result = await run_best_trades(MagicMock(), watchlists=["X"], account_number="ABC123")
+        mock_account_filters.assert_called_once()
+        args, kwargs = mock_account_filters.call_args
+        self.assertEqual(args[1], mock_state)
+        self.assertEqual(result["account"], {"nlv": 50000.0, "bp_usage_pct": 0.30})
+
+    @patch("agents.trade_ranker.apply_account_filters")
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_account_state_skipped_when_no_account_number(
+        self, mock_scan, mock_gen, mock_gates, mock_account_filters
+    ):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidate = self._passing_candidate("AAPL", 75.0)
+        mock_gen.return_value = ([candidate], [])
+        mock_gates.return_value = ([candidate], [])
+        result = await run_best_trades(MagicMock(), watchlists=["X"], account_number=None)
+        mock_account_filters.assert_not_called()
+        self.assertIsNone(result["account"])
+
+    @patch("agents.trade_ranker._build_account_state", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.apply_account_filters")
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_build_account_state_failure_degrades_gracefully(
+        self, mock_scan, mock_gen, mock_gates, mock_account_filters, mock_build_state
+    ):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidate = self._passing_candidate("AAPL", 75.0)
+        mock_gen.return_value = ([candidate], [])
+        mock_gates.return_value = ([candidate], [])
+        mock_build_state.side_effect = RuntimeError("api down")
+        result = await run_best_trades(MagicMock(), watchlists=["X"], account_number="ABC123")
+        mock_account_filters.assert_not_called()
+        self.assertIsNone(result["account"])
+        self.assertTrue(any("account state unavailable" in w and "api down" in w for w in result["warnings"]))
+        self.assertEqual(len(result["top"]), 1)
+
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_result_shape_has_canonical_keys(self, mock_scan, mock_gen, mock_gates):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidate = self._passing_candidate("AAPL", 75.0)
+        mock_gen.return_value = ([candidate], [])
+        mock_gates.return_value = ([candidate], [])
+        result = await run_best_trades(MagicMock(), watchlists=["X"])
+        self.assertGreaterEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists", "account"})
+
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_rejected_items_have_symbol_reason_detail_only(self, mock_scan, mock_gen):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        mock_gen.return_value = ([], [Rejection(symbol="AAPL", reason="no_chains", detail="none")])
+        result = await run_best_trades(MagicMock(), watchlists=["X"])
+        for item in result["rejected"]:
+            self.assertEqual(set(item.keys()), {"symbol", "reason", "detail"})
+
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_warnings_aggregated_from_scan(self, mock_scan):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([], ["w1", "w2"])
+        result = await run_best_trades(MagicMock(), watchlists=["X"])
+        self.assertEqual(result["warnings"], ["w1", "w2"])
+
+    @patch("agents.trade_ranker.score_candidates")
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_today_parameter_threaded_to_gates_and_scoring(
+        self, mock_scan, mock_gen, mock_gates, mock_score
+    ):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidate = self._passing_candidate("AAPL", 75.0)
+        mock_gen.return_value = ([candidate], [])
+        mock_gates.return_value = ([candidate], [])
+        mock_score.return_value = [candidate]
+        target_date = date(2026, 5, 1)
+        await run_best_trades(MagicMock(), watchlists=["X"], today=target_date)
+        gates_kwargs = mock_gates.call_args.kwargs
+        self.assertEqual(gates_kwargs["today"], target_date)
+        score_kwargs = mock_score.call_args.kwargs
+        self.assertEqual(score_kwargs["today"], target_date)
+
+    @patch("agents.trade_ranker.apply_quality_gates")
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_top_zero_returns_empty_top(self, mock_scan, mock_gen, mock_gates):
+        from agents.trade_ranker import run_best_trades
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL")], [])
+        candidate = self._passing_candidate("AAPL", 75.0)
+        mock_gen.return_value = ([candidate], [])
+        mock_gates.return_value = ([candidate], [])
+        result = await run_best_trades(MagicMock(), watchlists=["X"], top=0)
+        self.assertEqual(result["top"], [])
+
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_default_watchlists_used_when_none(self, mock_scan):
+        from agents.trade_ranker import run_best_trades, DEFAULT_WATCHLISTS
+        mock_scan.return_value = ([], [])
+        await run_best_trades(MagicMock(), watchlists=None)
+        called_args = mock_scan.await_args
+        self.assertEqual(called_args.args[1], list(DEFAULT_WATCHLISTS))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
**\`run_best_trades\` is no longer a stub.** It runs the full end-to-end pipeline introduced across TCBT-2..TCBT-4:

\`\`\`
scan_watchlists → generate_candidates → apply_quality_gates →
apply_account_filters → score_candidates → top-N (one-per-symbol)
\`\`\`

Settings is the single source of truth for the 9 thresholds; \`_load_thresholds()\` reads them once per run.

## New API surface
\`\`\`python
async def run_best_trades(
    session: Session,
    *,
    watchlists: Optional[Sequence[str]] = None,
    top: int = 3,
    output_format: str = "text",
    account_number: Optional[str] = None,   # NEW
    today: Optional[date] = None,           # NEW
) -> dict[str, Any]
\`\`\`

## Result dict shape (canonical)
\`\`\`python
{
    "top": [{symbol, structure, expiration, dte, credit, max_loss, short_delta, breakevens, score, score_breakdown, summary_reason}, …],
    "rejected": [{symbol, reason, detail}, …],
    "warnings": [str, …],
    "watchlists": [str, …],
    "account": {"nlv": float, "bp_usage_pct": float} | None,   # NEW
}
\`\`\`

## Account-state handling
- \`account_number=None\` → skip \`apply_account_filters\` and account-aware scoring (TCBT-10 placeholders preserved)
- \`account_number\` provided → build \`AccountState\` from \`RiskManager\` + \`PortfolioAgent\`; bp_usage_pct converted from percent (0-100) to fraction (0..1)
- Account-state fetch errors caught broadly → run continues without account context, warning appended (\`"account state unavailable: …"\`)

## Top-N selection
\`_select_top_per_symbol\` picks the highest-scored candidate per symbol, sorts by \`(score desc, symbol asc)\` for deterministic tie-breaking, slices to top.

## Output formatter
\`_print_best_trades_text\` rewritten end-to-end: header, account line, ranked top trades with per-component breakdown and summary_reason, rejection summary aggregated by reason, warnings list.

## Test plan
- [x] \`./venv/bin/python -m unittest tests.test_trade_ranker tests.test_settings tests.test_best_trades_cli\` — 197 / 197 pass (was 173)
- [x] 25 new tests across 3 new classes:
  - \`TestSelectTopPerSymbol\` (7) — empty/dedup/cap/sort/tiebreak/zero/negative
  - \`TestLoadThresholds\` (1) — reads all 9 \`bt_*\` keys
  - \`TestRunBestTradesIntegration\` (17) — empty scan, no candidates, gates rejecting all, happy path, dedupe, top-cap, score sort, tiebreak, account-state on/off/error, canonical shape, rejection schema, warnings aggregation, today-threading, top=0, default watchlists
- [x] \`TestRunBestTradesStub\` updated (6 tests now mock \`scan_watchlists\`; \`test_session_not_called\` removed — function legitimately uses session)
- [x] \`./venv/bin/python main.py --help\` still works
- [x] \`STUB_MARKER\` constant removed; replacement test asserts header

## Known limitation (v1)
\`existing_exposures = {}\` — concentration_overlap only fires when a single new candidate exceeds the cap, not on already-crowded underlyings. Per-position max-loss math (which depends on structure/strike/quantity) will plug in later without API changes.

## QA
Built via \`/build-qa\`: Opus plan → Haiku build → tests caught one orphan stub-marker test → fixed → 197/197 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)