### PR TITLE
TCBT-perf: parallelize generate_candidates + per-symbol timeout

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field, replace
 from datetime import date
@@ -117,8 +118,15 @@ async def generate_candidates(
     *,
     researcher: Optional[OptionsResearcherAgent] = None,
     max_per_symbol: int = 3,
+    concurrency: int = 1,
+    timeout_seconds: Optional[float] = None,
 ) -> tuple[list[Candidate], list[Rejection]]:
-    """For each SymbolContext, call OptionsResearcherAgent.research; return candidates + rejections."""
+    """For each SymbolContext, call OptionsResearcherAgent.research; return candidates + rejections.
+
+    `concurrency` caps simultaneous research calls (default 1 = sequential).
+    `timeout_seconds` applies a per-symbol hard cap; on timeout the symbol becomes a
+    research_timeout rejection instead of blocking the run.
+    """
     candidates: list[Candidate] = []
     rejections: list[Rejection] = []
 
@@ -129,27 +137,58 @@ async def generate_candidates(
         researcher = OptionsResearcherAgent(session)
 
     total = len(contexts)
-    logger.info("researching %d symbols", total)
-    for i, ctx in enumerate(contexts, start=1):
-        logger.info("[%d/%d] %s", i, total, ctx.symbol)
-        try:
-            report = await researcher.research(ctx.symbol)
-        except Exception as e:
-            logger.warning("[%d/%d] %s: research failed - %s", i, total, ctx.symbol, e)
-            rejections.append(Rejection(symbol=ctx.symbol, reason="researcher_exception", detail=str(e)))
-            continue
+    logger.info(
+        "researching %d symbols (concurrency=%d, timeout=%s)",
+        total,
+        concurrency,
+        f"{timeout_seconds}s" if timeout_seconds is not None else "none",
+    )
+    semaphore = asyncio.Semaphore(max(1, concurrency))
 
+    async def research_one(idx: int, ctx: SymbolContext):
+        async with semaphore:
+            logger.info("[%d/%d] %s", idx, total, ctx.symbol)
+            try:
+                if timeout_seconds is not None:
+                    report = await asyncio.wait_for(
+                        researcher.research(ctx.symbol),
+                        timeout=timeout_seconds,
+                    )
+                else:
+                    report = await researcher.research(ctx.symbol)
+            except asyncio.TimeoutError:
+                logger.warning("[%d/%d] %s: timed out after %ss", idx, total, ctx.symbol, timeout_seconds)
+                return ctx, None, Rejection(
+                    symbol=ctx.symbol,
+                    reason="research_timeout",
+                    detail=f"exceeded {timeout_seconds}s",
+                )
+            except Exception as e:
+                logger.warning("[%d/%d] %s: research failed - %s", idx, total, ctx.symbol, e)
+                return ctx, None, Rejection(
+                    symbol=ctx.symbol,
+                    reason="researcher_exception",
+                    detail=str(e),
+                )
+            return ctx, report, None
+
+    tasks = [research_one(i + 1, ctx) for i, ctx in enumerate(contexts)]
+    results = await asyncio.gather(*tasks)
+
+    for ctx, report, rejection in results:
+        if rejection is not None:
+            rejections.append(rejection)
+            continue
         status = report.get("status")
         if status != "OK":
             warnings = report.get("warnings") or []
             detail = warnings[0] if warnings else None
-            logger.info("[%d/%d] %s: %s", i, total, ctx.symbol, status)
+            logger.info("%s: %s", ctx.symbol, status)
             rejections.append(Rejection(symbol=ctx.symbol, reason=str(status), detail=detail))
             continue
-
         ideas = report.get("trade_ideas") or []
         accepted = ideas[:max_per_symbol]
-        logger.info("[%d/%d] %s: %d ideas", i, total, ctx.symbol, len(accepted))
+        logger.info("%s: %d ideas", ctx.symbol, len(accepted))
         for idea in accepted:
             candidates.append(_idea_to_candidate(ctx.symbol, idea, ctx))
 
@@ -275,6 +314,8 @@ def _load_thresholds() -> dict[str, Any]:
         "bp_cap_for_new": settings.get("bt_bp_cap_for_new"),
         "concentration_block_pct": settings.get("bt_concentration_overlap_block_pct"),
         "min_ivr": settings.get("bt_min_ivr"),
+        "research_concurrency": settings.get("bt_research_concurrency"),
+        "research_timeout_seconds": settings.get("bt_research_timeout_seconds"),
     }
 
 
@@ -402,6 +443,8 @@ async def run_best_trades(
         session,
         contexts,
         max_per_symbol=thresholds["max_per_symbol"],
+        concurrency=thresholds["research_concurrency"],
+        timeout_seconds=thresholds["research_timeout_seconds"],
     )
     for r in gen_rejections:
         result["rejected"].append(_rejection_to_dict(r))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -357,6 +357,28 @@ class TestBestTradesSettingsRoundTrip(unittest.TestCase):
             s = Settings(config_path=Path(tmpdir) / "config.json")
             self.assertEqual(s.get("bt_min_ivr"), 30.0)
 
+    def test_bt_research_concurrency_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("bt_research_concurrency", 8)
+            self.assertEqual(s.get("bt_research_concurrency"), 8)
+
+    def test_bt_research_concurrency_default_five(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            self.assertEqual(s.get("bt_research_concurrency"), 5)
+
+    def test_bt_research_timeout_seconds_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            s.set("bt_research_timeout_seconds", 60)
+            self.assertEqual(s.get("bt_research_timeout_seconds"), 60)
+
+    def test_bt_research_timeout_seconds_default_forty_five(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = Settings(config_path=Path(tmpdir) / "config.json")
+            self.assertEqual(s.get("bt_research_timeout_seconds"), 45)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -1,5 +1,6 @@
 """Tests for agents.trade_ranker watchlist scanning and symbol context building."""
 
+import asyncio
 import unittest
 from datetime import date
 from decimal import Decimal
@@ -391,7 +392,7 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
     async def test_single_context_produces_candidate(self):
         researcher = MagicMock()
         researcher.research = AsyncMock(return_value=_make_ok_report())
-        ctx = SymbolContext(symbol="AAPL", iv_rank=50.0)
+        ctx = SymbolContext(symbol="AAPL", iv_rank=99.0)
         candidates, rejections = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
         self.assertEqual(len(candidates), 1)
         self.assertEqual(len(rejections), 0)
@@ -409,7 +410,7 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
     async def test_expiration_parsed_to_date_object(self):
         researcher = MagicMock()
         researcher.research = AsyncMock(return_value=_make_ok_report(ideas=[_make_idea(expiration="2026-06-19")]))
-        ctx = SymbolContext(symbol="AAPL", iv_rank=50.0)
+        ctx = SymbolContext(symbol="AAPL", iv_rank=99.0)
         candidates, _ = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
         self.assertEqual(candidates[0].expiration, date(2026, 6, 19))
         self.assertIsInstance(candidates[0].expiration, date)
@@ -417,14 +418,14 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
     async def test_context_carried_through_to_candidate(self):
         researcher = MagicMock()
         researcher.research = AsyncMock(return_value=_make_ok_report())
-        ctx = SymbolContext(symbol="AAPL", iv_rank=50.0)
+        ctx = SymbolContext(symbol="AAPL", iv_rank=99.0)
         candidates, _ = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
         self.assertIs(candidates[0].context, ctx)
 
     async def test_status_not_ok_emits_rejection(self):
         researcher = MagicMock()
         researcher.research = AsyncMock(return_value=_make_failure_report(status="NO_VIABLE_IDEAS", warnings=[]))
-        ctx = SymbolContext(symbol="AAPL", iv_rank=50.0)
+        ctx = SymbolContext(symbol="AAPL", iv_rank=99.0)
         candidates, rejections = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
         self.assertEqual(candidates, [])
         self.assertEqual(len(rejections), 1)
@@ -435,7 +436,7 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
     async def test_rejection_includes_first_warning(self):
         researcher = MagicMock()
         researcher.research = AsyncMock(return_value=_make_failure_report(status="NO_CHAIN", warnings=["chain unavailable", "x"]))
-        ctx = SymbolContext(symbol="AAPL", iv_rank=50.0)
+        ctx = SymbolContext(symbol="AAPL", iv_rank=99.0)
         _, rejections = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
         self.assertEqual(rejections[0].detail, "chain unavailable")
         self.assertEqual(rejections[0].reason, "NO_CHAIN")
@@ -443,7 +444,7 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
     async def test_researcher_exception_emits_rejection(self):
         researcher = MagicMock()
         researcher.research = AsyncMock(side_effect=RuntimeError("boom"))
-        ctx = SymbolContext(symbol="AAPL", iv_rank=50.0)
+        ctx = SymbolContext(symbol="AAPL", iv_rank=99.0)
         candidates, rejections = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
         self.assertEqual(candidates, [])
         self.assertEqual(len(rejections), 1)
@@ -454,7 +455,7 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
         ideas = [_make_idea(score=float(i)) for i in range(5)]
         researcher = MagicMock()
         researcher.research = AsyncMock(return_value=_make_ok_report(ideas=ideas))
-        ctx = SymbolContext(symbol="AAPL", iv_rank=50.0)
+        ctx = SymbolContext(symbol="AAPL", iv_rank=99.0)
         candidates, _ = await generate_candidates(MagicMock(), [ctx], researcher=researcher, max_per_symbol=2)
         self.assertEqual(len(candidates), 2)
         self.assertEqual(candidates[0].researcher_score, 0.0)
@@ -474,7 +475,7 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
         instance.research = AsyncMock(return_value=_make_ok_report())
         mock_class.return_value = instance
         session = MagicMock()
-        ctx = SymbolContext(symbol="AAPL", iv_rank=50.0)
+        ctx = SymbolContext(symbol="AAPL", iv_rank=99.0)
         await generate_candidates(session, [ctx])
         mock_class.assert_called_once_with(session)
 
@@ -495,9 +496,47 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
             _make_ok_report(symbol="AAPL"),
             _make_ok_report(symbol="MSFT"),
         ])
-        contexts = [SymbolContext(symbol="AAPL", iv_rank=50.0), SymbolContext(symbol="MSFT")]
+        contexts = [SymbolContext(symbol="AAPL", iv_rank=99.0), SymbolContext(symbol="MSFT")]
         candidates, _ = await generate_candidates(MagicMock(), contexts, researcher=researcher)
         self.assertEqual([c.symbol for c in candidates], ["AAPL", "MSFT"])
+
+    async def test_research_timeout_emits_rejection(self):
+        async def hang(symbol):
+            await asyncio.sleep(10)
+            return _make_ok_report(symbol=symbol)
+        researcher = MagicMock()
+        researcher.research = AsyncMock(side_effect=hang)
+        ctx = SymbolContext(symbol="AAPL")
+        candidates, rejections = await generate_candidates(
+            MagicMock(), [ctx], researcher=researcher, timeout_seconds=0.05
+        )
+        self.assertEqual(candidates, [])
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0].reason, "research_timeout")
+        self.assertIn("0.05", rejections[0].detail)
+
+    async def test_concurrency_runs_calls_in_parallel(self):
+        active = 0
+        peak = 0
+        lock = asyncio.Lock()
+
+        async def slow(symbol):
+            nonlocal active, peak
+            async with lock:
+                active += 1
+                if active > peak:
+                    peak = active
+            await asyncio.sleep(0.05)
+            async with lock:
+                active -= 1
+            return _make_ok_report(symbol=symbol)
+
+        researcher = MagicMock()
+        researcher.research = AsyncMock(side_effect=slow)
+        contexts = [SymbolContext(symbol=s) for s in ("A", "B", "C", "D", "E")]
+        await generate_candidates(MagicMock(), contexts, researcher=researcher, concurrency=3)
+        self.assertGreaterEqual(peak, 2)
+        self.assertLessEqual(peak, 3)
 
     async def test_optional_fields_default_to_empty(self):
         idea = {
@@ -510,7 +549,7 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
         report = {"status": "OK", "symbol": "AAPL", "warnings": [], "trade_ideas": [idea]}
         researcher = MagicMock()
         researcher.research = AsyncMock(return_value=report)
-        ctx = SymbolContext(symbol="AAPL", iv_rank=50.0)
+        ctx = SymbolContext(symbol="AAPL", iv_rank=99.0)
         candidates, _ = await generate_candidates(MagicMock(), [ctx], researcher=researcher)
         c = candidates[0]
         self.assertEqual(c.breakevens, [])
@@ -1183,6 +1222,8 @@ class TestLoadThresholds(unittest.TestCase):
                 "bp_cap_for_new",
                 "concentration_block_pct",
                 "min_ivr",
+                "research_concurrency",
+                "research_timeout_seconds",
             },
         )
         expected_calls = [
@@ -1196,6 +1237,8 @@ class TestLoadThresholds(unittest.TestCase):
             "bt_bp_cap_for_new",
             "bt_concentration_overlap_block_pct",
             "bt_min_ivr",
+            "bt_research_concurrency",
+            "bt_research_timeout_seconds",
         ]
         actual_calls = [call.args[0] for call in mock_settings.get.call_args_list]
         self.assertEqual(set(actual_calls), set(expected_calls))
@@ -1203,6 +1246,15 @@ class TestLoadThresholds(unittest.TestCase):
 
 class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     """End-to-end pipeline tests for run_best_trades."""
+
+    def setUp(self):
+        from utils.settings import DEFAULTS
+        self._settings_patcher = patch("agents.trade_ranker.settings")
+        mock_settings = self._settings_patcher.start()
+        mock_settings.get.side_effect = lambda key: DEFAULTS.get(key)
+
+    def tearDown(self):
+        self._settings_patcher.stop()
 
     @staticmethod
     def _passing_candidate(symbol: str = "AAPL", score: float = 0.0) -> Candidate:
@@ -1222,7 +1274,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_no_candidates_returns_no_trades(self, mock_scan, mock_gen):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         mock_gen.return_value = ([], [Rejection(symbol="AAPL", reason="no_chains", detail="none")])
         result = await run_best_trades(MagicMock(), watchlists=["X"])
         self.assertEqual(result["top"], [])
@@ -1234,7 +1286,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_all_rejected_by_gates_returns_no_trades(self, mock_scan, mock_gen, mock_gates):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidate = self._passing_candidate()
         mock_gen.return_value = ([candidate], [])
         mock_gates.return_value = ([], [Rejection(symbol="AAPL", reason="earnings_blackout", detail="2 days")])
@@ -1247,7 +1299,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_basic_pipeline_returns_scored_top(self, mock_scan, mock_gen, mock_gates):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidate = self._passing_candidate("AAPL", 75.0)
         mock_gen.return_value = ([candidate], [])
         mock_gates.return_value = ([candidate], [])
@@ -1262,7 +1314,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_top_selection_dedupes_by_symbol(self, mock_scan, mock_gen, mock_gates):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         c1 = self._passing_candidate("AAPL", 60.0)
         c2 = self._passing_candidate("AAPL", 90.0)
         c3 = self._passing_candidate("AAPL", 70.0)
@@ -1277,7 +1329,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_top_selection_caps_at_n(self, mock_scan, mock_gen, mock_gates):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidates = [self._passing_candidate(s, 100 - i * 10) for i, s in enumerate(["A", "B", "C", "D", "E"])]
         mock_gen.return_value = (candidates, [])
         mock_gates.return_value = (candidates, [])
@@ -1290,7 +1342,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_top_selection_sorts_by_score_descending(self, mock_scan, mock_gen, mock_gates, mock_score):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidates = [self._passing_candidate(s, 50) for s in ["X", "Y", "Z"]]
         mock_gen.return_value = (candidates, [])
         mock_gates.return_value = (candidates, [])
@@ -1308,7 +1360,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_top_selection_tie_breaks_by_symbol_ascending(self, mock_scan, mock_gen, mock_gates, mock_score):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidates = [self._passing_candidate(s, 75) for s in ["B", "A", "C"]]
         mock_gen.return_value = (candidates, [])
         mock_gates.return_value = (candidates, [])
@@ -1329,7 +1381,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
         self, mock_scan, mock_gen, mock_gates, mock_account_filters, mock_build_state
     ):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidate = self._passing_candidate("AAPL", 75.0)
         mock_gen.return_value = ([candidate], [])
         mock_gates.return_value = ([candidate], [])
@@ -1350,7 +1402,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
         self, mock_scan, mock_gen, mock_gates, mock_account_filters
     ):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidate = self._passing_candidate("AAPL", 75.0)
         mock_gen.return_value = ([candidate], [])
         mock_gates.return_value = ([candidate], [])
@@ -1367,7 +1419,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
         self, mock_scan, mock_gen, mock_gates, mock_account_filters, mock_build_state
     ):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidate = self._passing_candidate("AAPL", 75.0)
         mock_gen.return_value = ([candidate], [])
         mock_gates.return_value = ([candidate], [])
@@ -1383,7 +1435,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_result_shape_has_canonical_keys(self, mock_scan, mock_gen, mock_gates):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidate = self._passing_candidate("AAPL", 75.0)
         mock_gen.return_value = ([candidate], [])
         mock_gates.return_value = ([candidate], [])
@@ -1394,7 +1446,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_rejected_items_have_symbol_reason_detail_only(self, mock_scan, mock_gen):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         mock_gen.return_value = ([], [Rejection(symbol="AAPL", reason="no_chains", detail="none")])
         result = await run_best_trades(MagicMock(), watchlists=["X"])
         for item in result["rejected"]:
@@ -1415,7 +1467,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
         self, mock_scan, mock_gen, mock_gates, mock_score
     ):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidate = self._passing_candidate("AAPL", 75.0)
         mock_gen.return_value = ([candidate], [])
         mock_gates.return_value = ([candidate], [])
@@ -1432,7 +1484,7 @@ class TestRunBestTradesIntegration(unittest.IsolatedAsyncioTestCase):
     @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
     async def test_top_zero_returns_empty_top(self, mock_scan, mock_gen, mock_gates):
         from agents.trade_ranker import run_best_trades
-        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=50.0)], [])
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
         candidate = self._passing_candidate("AAPL", 75.0)
         mock_gen.return_value = ([candidate], [])
         mock_gates.return_value = ([candidate], [])

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -28,6 +28,8 @@ INTEGER_KEYS: frozenset[str] = frozenset({
     "bt_max_dte",
     "bt_min_open_interest",
     "bt_max_per_symbol",
+    "bt_research_concurrency",
+    "bt_research_timeout_seconds",
 })
 
 DEFAULTS: dict[str, Any] = {
@@ -46,6 +48,8 @@ DEFAULTS: dict[str, Any] = {
     "bt_bp_cap_for_new": 0.50,
     "bt_concentration_overlap_block_pct": 0.25,
     "bt_min_ivr": 30.0,
+    "bt_research_concurrency": 5,
+    "bt_research_timeout_seconds": 45,
     "alert_toggles": {
         "position_size": True,
         "bp": True,


### PR DESCRIPTION
## Why
Even with the IVR prefilter, a real run still hangs. User reports 60 symbols passing IVR>=60 and the run hanging at \`[2/60]\`. Sequential research at 5-15s per symbol is 5-15 minutes minimum, plus a single stuck dxLink Greeks stream blocks the whole run indefinitely.

## What

### 1. Parallel research
\`generate_candidates\` now uses \`asyncio.Semaphore\` + \`asyncio.gather\`. Default production concurrency is **5** (configurable via \`bt_research_concurrency\`). Order of returned candidates is preserved.

### 2. Per-symbol hard timeout
Each \`researcher.research(symbol)\` call wrapped in \`asyncio.wait_for(timeout=N)\`. A stuck symbol becomes a \`research_timeout\` rejection instead of hanging the run. Default **45s** (configurable via \`bt_research_timeout_seconds\`).

### Numbers
60 symbols × ~5s research, sequential = **~5 minutes**.
60 symbols × ~5s research, concurrency=5 = **~60s**.

## API changes
\`\`\`python
async def generate_candidates(
    session,
    contexts,
    *,
    researcher=None,
    max_per_symbol=3,
    concurrency=1,           # NEW (default 1 = sequential)
    timeout_seconds=None,    # NEW (default no cap)
)
\`\`\`

\`run_best_trades\` reads concurrency + timeout from settings and threads them through.

## New settings (both INTEGER_KEYS path)
| Key | Default |
|---|---|
| \`bt_research_concurrency\` | \`5\` |
| \`bt_research_timeout_seconds\` | \`45\` |

## Test plan
- [x] Suite 214/214 pass (was 208)
- [x] \`test_research_timeout_emits_rejection\` — slow research → \`research_timeout\` rejection with detail \`"exceeded 0.05s"\`
- [x] \`test_concurrency_runs_calls_in_parallel\` — semaphore lets multiple calls run concurrently up to the cap
- [x] 4 new settings round-trip tests
- [x] \`TestRunBestTradesIntegration.setUp\` now patches \`agents.trade_ranker.settings\` to use \`DEFAULTS\` regardless of user's \`~/.tasty-coach/config.json\` (previously a custom \`bt_min_ivr=60\` in user config broke fixtures with \`iv_rank=50.0\`)
- [x] Live smoke on Snapshot watchlist (3 symbols passed IVR>=60): all started within 3s, all completed at the same instant — ~5s total vs ~15s sequential

## Carry-forward (not in this PR)
- \`options_researcher._fetch_greeks\` doesn't gracefully recover from dxLink websocket "service restart" (1012). Pre-existing fragility in the researcher, not the orchestrator. The per-symbol timeout now contains the damage to a single symbol's rejection rather than aborting the whole run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)