### PR TITLE
TCBT-fix: monthly-only expiry + lenient market-data + rejection diagnostics

### DIFF
--- a/agents/gex.py
+++ b/agents/gex.py
@@ -260,7 +260,9 @@ class GEXAgent:
             for i in range(0, len(all_symbols), 50):
                 chunk = all_symbols[i:i + 50]
                 try:
-                    market_data = get_market_data_by_type(self.session, options=chunk)
+                    from agents.options_researcher import _parse_market_data_item
+                    data = self.session._get("/market-data/by-type", params={"equity-option": chunk})
+                    market_data = [_parse_market_data_item(i) for i in data["items"]]
                     for md in market_data:
                         entry = {}
                         if md.open_interest is not None:

--- a/agents/options_researcher.py
+++ b/agents/options_researcher.py
@@ -2,23 +2,78 @@
 
 import logging
 import asyncio
+from types import SimpleNamespace
 from typing import List, Dict, Optional, Any, Tuple
 from datetime import datetime, date, timezone
 from dataclasses import dataclass, asdict, field
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 import math
 
 from tastytrade import Session
 from tastytrade.instruments import get_option_chain, OptionType
 from tastytrade.metrics import get_market_metrics
-from tastytrade.market_data import get_market_data_by_type
+from tastytrade.market_data import MarketData
 from tastytrade.streamer import DXLinkStreamer
 from tastytrade.dxfeed import Greeks
+
+
+def _is_standard_monthly(exp_date: date, chain_dates: set) -> bool:
+    """Standard equity-option monthlies expire the 3rd Friday of the month.
+
+    When the 3rd Friday is a market holiday (Juneteenth on 2026-06-19,
+    Good Friday in some years), the chain instead lists the 3rd-week Thursday.
+    Treat that Thursday as the monthly when no Friday in the same week is in
+    the chain.
+    """
+    if not (15 <= exp_date.day <= 21):
+        return False
+    weekday = exp_date.weekday()
+    if weekday == 4:  # Friday
+        return True
+    if weekday == 3:  # Thursday: monthly only when no Friday-in-3rd-week is listed
+        try:
+            friday = exp_date.replace(day=exp_date.day + 1)
+        except ValueError:
+            return False
+        return friday not in chain_dates
+    return False
+
+
+def _to_decimal(v: Any) -> Optional[Decimal]:
+    if v is None:
+        return None
+    try:
+        return Decimal(str(v))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _parse_market_data_item(item: Dict[str, Any]) -> Any:
+    """Lenient parse: try strict MarketData, else SimpleNamespace with the fields we use.
+
+    The TastyTrade /market-data/by-type endpoint occasionally omits summary-date /
+    prev-close-date for newly listed weekly options, which makes the strict SDK model
+    raise. We don't use those fields, so fall back rather than dropping the row.
+    """
+    try:
+        return MarketData(**item)
+    except Exception:
+        return SimpleNamespace(
+            symbol=item.get("symbol"),
+            bid=_to_decimal(item.get("bid")),
+            ask=_to_decimal(item.get("ask")),
+            mark=_to_decimal(item.get("mark")),
+            mid=_to_decimal(item.get("mid")),
+            volume=_to_decimal(item.get("volume")),
+            open_interest=_to_decimal(item.get("open-interest")),
+        )
 
 # Module-level constants
 DEFAULT_DTE_TARGET = 45
 DTE_FALLBACK_MIN = 25
 DTE_FALLBACK_MAX = 75
+MONTHLY_DTE_MIN = 25
+MONTHLY_DTE_MAX = 75
 TARGET_SHORT_DELTA = 0.30
 SHORT_DELTA_MIN = 0.15
 SHORT_DELTA_MAX = 0.45
@@ -276,47 +331,37 @@ class OptionsResearcherAgent:
         requested: Optional[date],
     ) -> Tuple[Optional[date], str]:
         """
-        Resolve target expiration from chain.
+        Resolve target expiration from chain. Defaults to standard monthlies only
+        (3rd Friday, or 3rd-week Thursday when Friday is a market holiday like
+        Juneteenth/Good Friday). Weeklies and quarterlies are ignored — they
+        carry far less open interest at the ~30-delta strikes we screen.
 
         Returns:
             (expiration_date, resolution_mode)
-            resolution_mode: 'EXPLICIT', 'MONTHLY_45DTE', 'NEAREST_IN_WINDOW', or 'NONE'
+            resolution_mode: 'EXPLICIT', 'MONTHLY', or 'NONE'
         """
-        # If explicit expiration requested
+        # If explicit expiration requested, honor it as-is (operator override)
         if requested is not None:
             if requested in chain:
                 return (requested, 'EXPLICIT')
             else:
                 return (None, 'NONE')
 
-        # Try to find nearest monthly to 45 DTE
         today = date.today()
+        chain_dates = set(chain.keys())
         candidates = []
 
-        for exp_date in chain.keys():
+        for exp_date in chain_dates:
             dte = (exp_date - today).days
-            # Check if it's a monthly (3rd Friday)
-            is_friday = exp_date.weekday() == 4
-            is_third_week = 15 <= exp_date.day <= 21
-            is_monthly = is_friday and is_third_week
-
-            if is_monthly and 30 <= dte <= 60:
-                candidates.append((abs(dte - DEFAULT_DTE_TARGET), dte, exp_date))
+            if not (MONTHLY_DTE_MIN <= dte <= MONTHLY_DTE_MAX):
+                continue
+            if not _is_standard_monthly(exp_date, chain_dates):
+                continue
+            candidates.append((abs(dte - DEFAULT_DTE_TARGET), dte, exp_date))
 
         if candidates:
             candidates.sort(key=lambda x: x[0])
-            return (candidates[0][2], 'MONTHLY_45DTE')
-
-        # Fallback: nearest within window
-        fallback_candidates = []
-        for exp_date in chain.keys():
-            dte = (exp_date - today).days
-            if DTE_FALLBACK_MIN <= dte <= DTE_FALLBACK_MAX:
-                fallback_candidates.append((abs(dte - DEFAULT_DTE_TARGET), dte, exp_date))
-
-        if fallback_candidates:
-            fallback_candidates.sort(key=lambda x: x[0])
-            return (fallback_candidates[0][2], 'NEAREST_IN_WINDOW')
+            return (candidates[0][2], 'MONTHLY')
 
         return (None, 'NONE')
 
@@ -443,9 +488,12 @@ class OptionsResearcherAgent:
             if not batch:
                 return
             try:
-                market_data = get_market_data_by_type(self.session, options=batch)
-                for md in market_data:
-                    md_map[md.symbol] = md
+                params = {"equity-option": batch}
+                data = self.session._get("/market-data/by-type", params=params)
+                for item in data["items"]:
+                    md = _parse_market_data_item(item)
+                    if md.symbol:
+                        md_map[md.symbol] = md
             except Exception as e:
                 if len(batch) == 1 or depth >= 4:
                     self.logger.warning(

--- a/agents/options_researcher.py
+++ b/agents/options_researcher.py
@@ -351,7 +351,9 @@ class OptionsResearcherAgent:
         chain_dates = set(chain.keys())
         candidates = []
 
-        for exp_date in chain_dates:
+        # Iterate sorted chain keys so candidate order is deterministic across
+        # runs/processes (set iteration is hash-randomized).
+        for exp_date in sorted(chain_dates):
             dte = (exp_date - today).days
             if not (MONTHLY_DTE_MIN <= dte <= MONTHLY_DTE_MAX):
                 continue
@@ -360,7 +362,10 @@ class OptionsResearcherAgent:
             candidates.append((abs(dte - DEFAULT_DTE_TARGET), dte, exp_date))
 
         if candidates:
-            candidates.sort(key=lambda x: x[0])
+            # Sort by (distance-from-target, dte, exp_date) — on a tie of equal
+            # distance (e.g. 31 and 59 DTE both 14 from 45), prefer the earlier
+            # expiration; exp_date is the final tiebreaker for absolute determinism.
+            candidates.sort(key=lambda x: (x[0], x[1], x[2]))
             return (candidates[0][2], 'MONTHLY')
 
         return (None, 'NONE')

--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -542,13 +542,24 @@ def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
     rejected = result.get("rejected") or []
     if rejected:
         counts: dict[str, int] = {}
+        by_reason: dict[str, list[dict[str, Any]]] = {}
         for r in rejected:
             reason = r.get("reason", "unknown")
             counts[reason] = counts.get(reason, 0) + 1
+            by_reason.setdefault(reason, []).append(r)
         print()
         print("Rejection summary:")
         for reason, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
             print(f"  {reason}: {n}")
+        if not top_items:
+            print()
+            print("Rejection details (no trades passed):")
+            for reason in sorted(by_reason, key=lambda k: (-counts[k], k)):
+                print(f"  [{reason}]")
+                for r in by_reason[reason]:
+                    sym = r.get("symbol", "?")
+                    detail = r.get("detail") or ""
+                    print(f"    {sym}: {detail}" if detail else f"    {sym}")
 
     warnings = result.get("warnings") or []
     if warnings:
@@ -611,6 +622,23 @@ def _check_broken_pricing(candidate: Candidate) -> Optional[Rejection]:
     return None
 
 
+def _format_legs(candidate: Candidate) -> str:
+    """Compact per-leg summary with expiration prefix."""
+    parts: list[str] = []
+    exp_prefix = f"{candidate.expiration.isoformat()} ({candidate.dte}d) "
+    for leg in candidate.legs:
+        action = leg.get("action") or leg.get("side") or "?"
+        opt_type = leg.get("option_type") or leg.get("type") or "?"
+        strike = leg.get("strike")
+        delta = leg.get("delta")
+        oi = leg.get("open_interest")
+        strike_s = f"{float(strike):g}" if strike is not None else "?"
+        delta_s = f"Δ{float(delta):+.2f}" if delta is not None else "Δ?"
+        oi_s = f"OI {int(oi)}" if oi is not None else "OI ?"
+        parts.append(f"{action} {opt_type} {strike_s} {delta_s} {oi_s}")
+    return exp_prefix + " / ".join(parts)
+
+
 def _check_open_interest(candidate: Candidate, min_open_interest: int) -> Optional[Rejection]:
     """Reject if the minimum non-None open interest across legs falls below the floor."""
     ois = [leg.get("open_interest") for leg in candidate.legs if leg.get("open_interest") is not None]
@@ -621,7 +649,7 @@ def _check_open_interest(candidate: Candidate, min_open_interest: int) -> Option
         return Rejection(
             symbol=candidate.symbol,
             reason="low_open_interest",
-            detail=f"min OI {min_oi} below floor {min_open_interest}",
+            detail=f"min OI {min_oi} below floor {min_open_interest} | {_format_legs(candidate)}",
         )
     return None
 
@@ -643,7 +671,7 @@ def _check_spread(candidate: Candidate, max_spread_pct: float) -> Optional[Rejec
         return Rejection(
             symbol=candidate.symbol,
             reason="wide_spread",
-            detail=f"max spread {worst:.3f} above cap {max_spread_pct:.3f}",
+            detail=f"max spread {worst:.3f} above cap {max_spread_pct:.3f} | {_format_legs(candidate)}",
         )
     return None
 

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -49,7 +49,7 @@ DEFAULTS: dict[str, Any] = {
     "bt_concentration_overlap_block_pct": 0.25,
     "bt_min_ivr": 30.0,
     "bt_research_concurrency": 5,
-    "bt_research_timeout_seconds": 45,
+    "bt_research_timeout_seconds": 90,
     "alert_toggles": {
         "position_size": True,
         "bp": True,


### PR DESCRIPTION
## Summary

Three best-trades-pipeline fixes uncovered while running `--best-trades --account 5WW46136` against a live session today. Initial run returned **zero candidates** despite ~150 IVR-eligible symbols; this PR walks the funnel back to a clean three-trade output.

### 1. Monthly-only expiration
`_resolve_expiration` required Friday + day 15-21 to call an expiration "monthly." June 19, 2026 is **Juneteenth** (market closed), so AMD/MSFT/AAPL chains list the monthly on Thu June 18. The resolver silently fell through to the June 5 weekly, where 30-delta OI is single digits on most names → every candidate failed the OI gate.

- New `_is_standard_monthly` helper: day 15-21 + (Friday **or** 3rd-week Thursday when no Friday-in-3rd-week is in the chain).
- Resolver is now monthly-only by default. Weeklies are only picked when the caller passes an explicit `expiration=` to `research()`.

### 2. Lenient MarketData parsing
`tastytrade` SDK 11.x/12.x marks `summary_date` and `prev_close_date` as required on the `MarketData` model, but `/market-data/by-type` omits them for some newly-listed weekly options → Pydantic raises `ValidationError` for the **entire batch**, dropping every option for that symbol.

- Bypass `get_market_data_by_type`; call `session._get(...)` directly.
- `_parse_market_data_item` tries strict `MarketData(**item)`, falls back to a `SimpleNamespace` with the fields we actually use (`symbol`, `bid`, `ask`, `mark`, `mid`, `volume`, `open_interest`).
- Applied in both `agents/options_researcher.py` and `agents/gex.py`.

### 3. Rejection diagnostics
`low_open_interest` and `wide_spread` rejection details now include expiration, DTE, and per-leg `action OPT_TYPE strike Δ±0.NN OI N`, e.g.

```
AMD: min OI 23 below floor 100 | 2026-06-05 (39d) SELL PUT 315 Δ-0.30 OI 23 / BUY PUT 310 Δ-0.27 OI 56
```

Text printer expands per-symbol rejection details when no trades pass — that's how the weekly-vs-monthly issue was diagnosed.

### Misc
- `bt_research_timeout_seconds` default 45 → 90 (already in tree).

## Test plan

- [x] `venv/bin/python main.py --best-trades --account 5WW46136` returns 3 candidates on the 2026-06-18 monthly (INTC, MU, MSFT) with scores 82-85
- [x] `_resolve_expiration` returns `2026-06-18 MONTHLY` for AMD/MSFT/AAPL on 2026-04-27
- [x] No `summary-date` / `prev-close-date` Pydantic warnings during `--best-trades` run
- [ ] Manual sanity-check on `--research <SYMBOL>` (single-symbol path) — uses same researcher, expected to inherit the fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)