### PR TITLE
TCBT-ux: show legs (strikes + deltas) in best-trades text output

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -382,7 +382,22 @@ def _candidate_to_dict(c: Candidate) -> dict[str, Any]:
         "score": float(c.score),
         "score_breakdown": dict(c.score_breakdown) if c.score_breakdown else {},
         "summary_reason": c.summary_reason or "",
+        "legs": [dict(leg) for leg in (c.legs or [])],
     }
+
+
+def _format_legs_from_dicts(legs: list[dict[str, Any]]) -> str:
+    """Compact per-leg summary for text output: 'SELL PUT 105 Δ-0.30 / BUY PUT 100 Δ-0.18'."""
+    parts: list[str] = []
+    for leg in legs or []:
+        action = leg.get("action") or leg.get("side") or "?"
+        opt_type = leg.get("option_type") or leg.get("type") or "?"
+        strike = leg.get("strike")
+        delta = leg.get("delta")
+        strike_s = f"{float(strike):g}" if strike is not None else "?"
+        delta_s = f"Δ{float(delta):+.2f}" if delta is not None else "Δ?"
+        parts.append(f"{action} {opt_type} {strike_s} {delta_s}")
+    return " / ".join(parts)
 
 
 async def _build_account_state(session: Session, account_number: str) -> AccountState:
@@ -533,6 +548,9 @@ def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
             summary = item.get("summary_reason", "")
             breakdown = item.get("score_breakdown") or {}
             print(f"[{idx}] {symbol} {structure} {expiration} ({dte} DTE)")
+            legs_line = _format_legs_from_dicts(item.get("legs") or [])
+            if legs_line:
+                print(f"    Legs: {legs_line}")
             print(f"    Credit ${credit:.2f} / Max risk ${max_loss:.0f}")
             print(f"    Score: {score:.1f}/100 — {summary}")
             if breakdown:


### PR DESCRIPTION
## Summary

The text printer header showed expiration + DTE but no strikes — operators had to switch to `--format json` to see what the actual trade was. Adds a one-line `Legs:` row under each candidate.

Example:
\`\`\`
[1] SNOW BULL_PUT_SPREAD 2026-06-18 (52 DTE)
    Legs: SELL PUT 125 Δ-0.30 / BUY PUT 120 Δ-0.23
    Credit \$1.72 / Max risk \$3
    ...
\`\`\`

Also adds `legs` to `_candidate_to_dict` so JSON consumers carry the same data (previously the JSON output dropped legs from the top-N entries even though they were on the Candidate object).

## Test plan

- [x] Imports/compile clean
- [ ] `venv/bin/python main.py --best-trades --account 5WW46136` shows a `Legs:` line under each top candidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)