### PR TITLE
TCBT-account-sizing: fix dollar accounting + real exposures + sector gate

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass, field, replace
 from datetime import date
 from decimal import Decimal
@@ -17,6 +18,7 @@ from agents.manager import RiskManager
 from agents.options_researcher import OptionsResearcherAgent
 from agents.portfolio import PortfolioAgent
 from agents.scanner import ScannerAgent
+from utils.sector_map import get_sector
 from utils.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -28,6 +30,16 @@ DEFAULT_WATCHLISTS: tuple[str, ...] = (
 )
 
 _BATCH_SIZE: int = 50
+
+# Equity options carry $100 of underlying per contract.
+# Researcher stores credit/max_loss in spread points; multiply by this to get
+# actual dollar risk/credit per contract.
+CONTRACT_MULTIPLIER: float = 100.0
+
+
+def _dollar_max_loss(c: "Candidate") -> float:
+    """Return actual dollar max loss per contract (Candidate.max_loss is in spread points)."""
+    return float(c.max_loss) * CONTRACT_MULTIPLIER
 
 
 @dataclass
@@ -87,6 +99,7 @@ class AccountState:
     nlv: float
     bp_usage_pct: float
     existing_exposures: dict[str, float] = field(default_factory=dict)
+    occupied_sectors: frozenset[str] = field(default_factory=frozenset)
 
 
 def _idea_to_candidate(symbol: str, idea: dict[str, Any], context: SymbolContext) -> Candidate:
@@ -316,6 +329,7 @@ def _load_thresholds() -> dict[str, Any]:
         "min_ivr": settings.get("bt_min_ivr"),
         "research_concurrency": settings.get("bt_research_concurrency"),
         "research_timeout_seconds": settings.get("bt_research_timeout_seconds"),
+        "per_trade_risk_pct": settings.get("bt_per_trade_risk_pct"),
     }
 
 
@@ -368,9 +382,18 @@ def _rejection_to_dict(r: Rejection) -> dict[str, Any]:
     }
 
 
-def _candidate_to_dict(c: Candidate) -> dict[str, Any]:
-    """Serialize a Candidate to a JSON-safe dict for the top-trades output."""
-    return {
+def _candidate_to_dict(
+    c: Candidate,
+    account_state: Optional[AccountState] = None,
+    per_trade_risk_pct: Optional[float] = None,
+) -> dict[str, Any]:
+    """Serialize a Candidate to a JSON-safe dict for the top-trades output.
+
+    When ``account_state`` and ``per_trade_risk_pct`` are provided, also emits
+    ``recommended_contracts``, ``pct_nlv_at_risk``, and ``sector`` so the AI
+    coach (and the text printer) can show personalized sizing.
+    """
+    payload: dict[str, Any] = {
         "symbol": c.symbol,
         "structure": c.structure,
         "expiration": c.expiration.isoformat() if hasattr(c.expiration, "isoformat") else str(c.expiration),
@@ -383,7 +406,23 @@ def _candidate_to_dict(c: Candidate) -> dict[str, Any]:
         "score_breakdown": dict(c.score_breakdown) if c.score_breakdown else {},
         "summary_reason": c.summary_reason or "",
         "legs": [dict(leg) for leg in (c.legs or [])],
+        "sector": get_sector(c.symbol),
     }
+
+    if account_state and account_state.nlv > 0 and c.max_loss > 0:
+        dollar_risk = _dollar_max_loss(c)
+        payload["max_loss_dollars"] = dollar_risk
+        payload["pct_nlv_at_risk_one_contract"] = dollar_risk / account_state.nlv
+        if per_trade_risk_pct and per_trade_risk_pct > 0:
+            budget = account_state.nlv * per_trade_risk_pct
+            recommended = int(budget // dollar_risk)
+            # If a single contract already exceeds the budget, recommend 0 (skip).
+            payload["recommended_contracts"] = recommended
+            payload["pct_nlv_at_risk"] = (
+                recommended * dollar_risk / account_state.nlv
+            )
+
+    return payload
 
 
 def _format_legs_from_dicts(legs: list[dict[str, Any]]) -> str:
@@ -400,18 +439,80 @@ def _format_legs_from_dicts(legs: list[dict[str, Any]]) -> str:
     return " / ".join(parts)
 
 
+def _position_dollar_exposure(pos: Any) -> float:
+    """Conservative per-position dollar exposure for concentration accounting.
+
+    - Short option: strike * 100 * |quantity| (cash-secured worst-case for puts; OK proxy for short calls).
+    - Long option: 0 (premium is sunk cost; no further compounding risk on new picks).
+    - Equity: |quantity| * average_open_price (cost basis).
+    """
+    inst = getattr(pos, "instrument_type", None)
+    inst_str = getattr(inst, "value", str(inst)) if inst is not None else ""
+    qty = getattr(pos, "quantity", 0) or 0
+    try:
+        qty_f = float(qty)
+    except (TypeError, ValueError):
+        qty_f = 0.0
+    qty_f = abs(qty_f)
+
+    if inst_str == "Equity":
+        avg = getattr(pos, "average_open_price", 0) or 0
+        try:
+            return qty_f * float(avg)
+        except (TypeError, ValueError):
+            return 0.0
+
+    if inst_str != "Equity Option":
+        return 0.0
+
+    direction = getattr(getattr(pos, "quantity_direction", None), "value", None) or getattr(pos, "quantity_direction", None)
+    if direction != "Short":
+        return 0.0
+
+    sym = getattr(pos, "symbol", "") or ""
+    m = re.match(r"^[A-Z/]+\s+\d{6}[CP](\d{8})$", sym)
+    if not m:
+        return 0.0
+    strike = float(m.group(1)) / 1000.0
+    return strike * 100.0 * qty_f
+
+
 async def _build_account_state(session: Session, account_number: str) -> AccountState:
-    """Build AccountState from RiskManager + PortfolioAgent (existing_exposures={} for v1)."""
+    """Build AccountState with real per-underlying exposures and occupied sectors."""
     risk_manager = RiskManager(session, account_number)
     report = await risk_manager.calculate_portfolio_risk()
     nlv = float(report["nlv"])
     bp_usage_pct = float(report["bp_usage_pct"]) / 100.0
+
     portfolio_agent = await PortfolioAgent(session, account_number).init()
-    _positions = await portfolio_agent.get_positions()
+    positions = await portfolio_agent.get_positions()
+
+    # Only positions with non-zero dollar exposure (short options + equity) populate
+    # exposures and occupied_sectors. A long-only position contributes 0 dollars and
+    # would silently both (a) pollute the concentration check by creating an
+    # exposures key that bypasses the sector gate's "rolling/adding" exception, and
+    # (b) over-broadly mark the sector as occupied — see review notes on
+    # TCBT-account-sizing.
+    exposures: dict[str, float] = {}
+    sectors: set[str] = set()
+    for pos in positions:
+        underlying = getattr(pos, "underlying_symbol", None) or getattr(pos, "symbol", None)
+        if not underlying:
+            continue
+        dollars = _position_dollar_exposure(pos)
+        if dollars <= 0:
+            continue
+        underlying = str(underlying).upper()
+        exposures[underlying] = exposures.get(underlying, 0.0) + dollars
+        sec = get_sector(underlying)
+        if sec:
+            sectors.add(sec)
+
     return AccountState(
         nlv=nlv,
         bp_usage_pct=bp_usage_pct,
-        existing_exposures={},
+        existing_exposures=exposures,
+        occupied_sectors=frozenset(sectors),
     )
 
 
@@ -514,7 +615,10 @@ async def run_best_trades(
 
     scored = score_candidates(passing, today=today, account_state=account_state)
     selected = _select_top_per_symbol(scored, top)
-    result["top"] = [_candidate_to_dict(c) for c in selected]
+    result["top"] = [
+        _candidate_to_dict(c, account_state=account_state, per_trade_risk_pct=thresholds.get("per_trade_risk_pct"))
+        for c in selected
+    ]
     logger.info("done: %d top trades selected from %d scored candidates", len(result["top"]), len(scored))
     return result
 
@@ -543,7 +647,8 @@ def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
             expiration = item.get("expiration", "?")
             dte = item.get("dte", 0)
             credit = item.get("credit", 0.0)
-            max_loss = item.get("max_loss", 0.0)
+            max_loss_pts = item.get("max_loss", 0.0)
+            max_loss_dollars = item.get("max_loss_dollars", max_loss_pts * 100.0)
             score = item.get("score", 0.0)
             summary = item.get("summary_reason", "")
             breakdown = item.get("score_breakdown") or {}
@@ -551,7 +656,20 @@ def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
             legs_line = _format_legs_from_dicts(item.get("legs") or [])
             if legs_line:
                 print(f"    Legs: {legs_line}")
-            print(f"    Credit ${credit:.2f} / Max risk ${max_loss:.0f}")
+            print(f"    Credit ${credit * 100:.0f} / Max risk ${max_loss_dollars:.0f} per contract")
+            recommended = item.get("recommended_contracts")
+            pct_at_risk = item.get("pct_nlv_at_risk")
+            if recommended is not None:
+                if recommended == 0:
+                    one_pct = item.get("pct_nlv_at_risk_one_contract")
+                    skip_str = f" (1 contract = {one_pct * 100:.1f}% NLV)" if one_pct is not None else ""
+                    print(f"    Recommended size: SKIP — exceeds per-trade risk budget{skip_str}")
+                else:
+                    pct_str = f" ({pct_at_risk * 100:.1f}% NLV at risk)" if pct_at_risk is not None else ""
+                    print(f"    Recommended size: {recommended} contract{'s' if recommended != 1 else ''}{pct_str}")
+            sector_tag = item.get("sector")
+            if sector_tag:
+                print(f"    Sector: {sector_tag}")
             print(f"    Score: {score:.1f}/100 — {summary}")
             if breakdown:
                 parts = [f"{k} {float(v):.1f}" for k, v in breakdown.items()]
@@ -750,14 +868,15 @@ def apply_account_filters(
         return survivors, rejections
 
     for c in candidates:
-        size_pct = c.max_loss / nlv
+        dollar_risk = _dollar_max_loss(c)
+        size_pct = dollar_risk / nlv
 
         if size_pct > max_pct_nlv_per_trade:
             rejections.append(Rejection(
                 symbol=c.symbol,
                 reason="oversized_vs_nlv",
                 detail=(
-                    f"max_loss ${c.max_loss:.0f} = "
+                    f"max_loss ${dollar_risk:.0f} = "
                     f"{size_pct * 100:.1f}% NLV above cap "
                     f"{max_pct_nlv_per_trade * 100:.1f}%"
                 ),
@@ -777,15 +896,35 @@ def apply_account_filters(
             continue
 
         existing = exposures.get(c.symbol, 0.0)
-        post_exposure_pct = (existing + c.max_loss) / nlv
+        post_exposure_pct = (existing + dollar_risk) / nlv
         if post_exposure_pct > concentration_block_pct:
             rejections.append(Rejection(
                 symbol=c.symbol,
                 reason="concentration_overlap",
                 detail=(
-                    f"{c.symbol} exposure ${existing:.0f} + ${c.max_loss:.0f} = "
+                    f"{c.symbol} exposure ${existing:.0f} + ${dollar_risk:.0f} = "
                     f"{post_exposure_pct * 100:.1f}% NLV above cap "
                     f"{concentration_block_pct * 100:.1f}%"
+                ),
+            ))
+            continue
+
+        # Sector gate: block candidates whose sector is already represented by an
+        # OPEN position, but allow rolling/adding into an underlying we already
+        # hold (the `c.symbol in exposures` exception). Only checks against the
+        # existing portfolio, not against other survivors in this batch — multiple
+        # new picks in the same sector can survive a single run.
+        candidate_sector = get_sector(c.symbol)
+        if (
+            candidate_sector
+            and candidate_sector in account_state.occupied_sectors
+            and c.symbol not in exposures
+        ):
+            rejections.append(Rejection(
+                symbol=c.symbol,
+                reason="sector_overlap",
+                detail=(
+                    f"sector '{candidate_sector}' already represented by an open position"
                 ),
             ))
             continue
@@ -879,7 +1018,7 @@ def _score_account_fit(
     """Score 0..10 for trade-size fit; placeholder 10.0 when account_state is None or NLV non-positive."""
     if account_state is None or account_state.nlv <= 0:
         return _WEIGHT_ACCOUNT_FIT
-    pct = candidate.max_loss / account_state.nlv
+    pct = _dollar_max_loss(candidate) / account_state.nlv
     return max(0.0, min(10.0, 10.0 * (0.05 - pct) / 0.03))
 
 
@@ -891,7 +1030,7 @@ def _score_concentration_penalty(
     if account_state is None or account_state.nlv <= 0:
         return 0.0
     existing = account_state.existing_exposures.get(candidate.symbol, 0.0)
-    post_trade_pct = (existing + candidate.max_loss) / account_state.nlv
+    post_trade_pct = (existing + _dollar_max_loss(candidate)) / account_state.nlv
     return max(0.0, min(10.0, 10.0 * (post_trade_pct - 0.05) / 0.20))
 
 

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -665,7 +665,7 @@ class TestQualityGates(unittest.TestCase):
         passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
         self.assertEqual(passing, [])
         self.assertEqual(rejections[0].reason, "low_open_interest")
-        self.assertEqual(rejections[0].detail, "min OI 150 below floor 200")
+        self.assertIn("min OI 150 below floor 200", rejections[0].detail)
 
     def test_all_oi_none_does_not_reject(self):
         legs = [
@@ -684,7 +684,7 @@ class TestQualityGates(unittest.TestCase):
         passing, rejections = apply_quality_gates([c], **self.DEFAULT_KW)
         self.assertEqual(passing, [])
         self.assertEqual(rejections[0].reason, "wide_spread")
-        self.assertEqual(rejections[0].detail, "max spread 0.194 above cap 0.100")
+        self.assertIn("max spread 0.194 above cap 0.100", rejections[0].detail)
 
     def test_missing_pricing_skips_spread_gate(self):
         legs = [
@@ -921,27 +921,30 @@ class TestAccountFiltersAndScoring(unittest.TestCase):
         return AccountState(nlv=nlv, bp_usage_pct=bp_usage_pct, existing_exposures=exposures or {})
 
     def test_passing_candidate_survives_all_account_filters(self):
-        c = _make_candidate(symbol="AAPL", max_loss=200.0)
+        # max_loss in spread points; ×100 = $200 per contract = 1% of $20k NLV
+        c = _make_candidate(symbol="AAPL", max_loss=2.0)
         survivors, rejections = apply_account_filters([c], self._state(), **self.DEFAULT_FILTERS)
         self.assertEqual(survivors, [c])
         self.assertEqual(rejections, [])
 
     def test_oversized_vs_nlv_rejected(self):
-        c = _make_candidate(symbol="AAPL", max_loss=2000.0)
+        # 20 points × $100 = $2000 = 10% NLV, above 5% cap
+        c = _make_candidate(symbol="AAPL", max_loss=20.0)
         survivors, rejections = apply_account_filters([c], self._state(), **self.DEFAULT_FILTERS)
         self.assertEqual(survivors, [])
         self.assertEqual(rejections[0].reason, "oversized_vs_nlv")
         self.assertIn("10.0% NLV above cap 5.0%", rejections[0].detail)
 
     def test_bp_over_cap_rejected(self):
-        c = _make_candidate(symbol="AAPL", max_loss=200.0)
+        c = _make_candidate(symbol="AAPL", max_loss=2.0)
         survivors, rejections = apply_account_filters([c], self._state(bp_usage_pct=0.495), **self.DEFAULT_FILTERS)
         self.assertEqual(survivors, [])
         self.assertEqual(rejections[0].reason, "bp_over_cap")
         self.assertIn("post-trade BP 50.5% above cap 50.0%", rejections[0].detail)
 
     def test_concentration_overlap_rejected(self):
-        c = _make_candidate(symbol="AAPL", max_loss=1500.0)
+        # 15 points × $100 = $1500; existing $4000; total $5500 = 27.5% NLV
+        c = _make_candidate(symbol="AAPL", max_loss=15.0)
         state = self._state(exposures={"AAPL": 4000.0})
         filters = dict(self.DEFAULT_FILTERS, max_pct_nlv_per_trade=0.10)
         survivors, rejections = apply_account_filters([c], state, **filters)
@@ -950,7 +953,7 @@ class TestAccountFiltersAndScoring(unittest.TestCase):
         self.assertIn("AAPL exposure $4000 + $1500 = 27.5% NLV above cap 25.0%", rejections[0].detail)
 
     def test_first_failure_wins_oversized_before_bp(self):
-        c = _make_candidate(symbol="AAPL", max_loss=2000.0)
+        c = _make_candidate(symbol="AAPL", max_loss=20.0)
         state = self._state(bp_usage_pct=0.495)
         survivors, rejections = apply_account_filters([c], state, **self.DEFAULT_FILTERS)
         self.assertEqual(rejections[0].reason, "oversized_vs_nlv")
@@ -961,56 +964,59 @@ class TestAccountFiltersAndScoring(unittest.TestCase):
         self.assertEqual(rejections, [])
 
     def test_threshold_boundary_oversized_just_under_passes(self):
-        c = _make_candidate(symbol="AAPL", max_loss=1000.0)
+        # 10 points × $100 = $1000 = 5% NLV exactly; strict > so passes
+        c = _make_candidate(symbol="AAPL", max_loss=10.0)
         survivors, _ = apply_account_filters([c], self._state(), **self.DEFAULT_FILTERS)
         self.assertEqual(survivors, [c])
 
     def test_threshold_boundary_concentration_no_existing_exposure_passes(self):
-        c = _make_candidate(symbol="AAPL", max_loss=1000.0)
+        c = _make_candidate(symbol="AAPL", max_loss=10.0)
         state = self._state(bp_usage_pct=0.10, exposures={"AAPL": 4000.0})
         survivors, _ = apply_account_filters([c], state, **self.DEFAULT_FILTERS)
         self.assertEqual(survivors, [c])
 
     def test_account_fit_full_when_max_loss_under_two_pct(self):
-        c = _make_candidate(max_loss=200.0)
+        c = _make_candidate(max_loss=2.0)
         self.assertEqual(_score_account_fit(c, self._state()), 10.0)
 
     def test_account_fit_zero_when_max_loss_at_or_above_five_pct(self):
-        c5 = _make_candidate(max_loss=1000.0)
-        c10 = _make_candidate(max_loss=2000.0)
+        c5 = _make_candidate(max_loss=10.0)
+        c10 = _make_candidate(max_loss=20.0)
         self.assertEqual(_score_account_fit(c5, self._state()), 0.0)
         self.assertEqual(_score_account_fit(c10, self._state()), 0.0)
 
     def test_account_fit_linear_ramp_at_three_pct(self):
-        c = _make_candidate(max_loss=600.0)
+        # 6 points × $100 = $600 = 3% NLV
+        c = _make_candidate(max_loss=6.0)
         self.assertAlmostEqual(_score_account_fit(c, self._state()), 6.6667, places=4)
 
     def test_account_fit_no_state_returns_ten_placeholder(self):
-        c = _make_candidate(max_loss=99999.0)
+        c = _make_candidate(max_loss=999.99)
         self.assertEqual(_score_account_fit(c, None), 10.0)
 
     def test_concentration_penalty_zero_no_existing_exposure_small_trade(self):
-        c = _make_candidate(symbol="AAPL", max_loss=400.0)
+        c = _make_candidate(symbol="AAPL", max_loss=4.0)
         self.assertEqual(_score_concentration_penalty(c, self._state()), 0.0)
 
     def test_concentration_penalty_ramps_with_exposure(self):
-        c = _make_candidate(symbol="AAPL", max_loss=1000.0)
+        # 10 points × $100 = $1000 + existing $2000 = $3000 = 15% NLV → penalty 5
+        c = _make_candidate(symbol="AAPL", max_loss=10.0)
         state = self._state(exposures={"AAPL": 2000.0})
         self.assertAlmostEqual(_score_concentration_penalty(c, state), 5.0, places=4)
 
     def test_concentration_penalty_full_at_or_above_twentyfive_pct(self):
-        c = _make_candidate(symbol="AAPL", max_loss=1000.0)
+        c = _make_candidate(symbol="AAPL", max_loss=10.0)
         state25 = self._state(exposures={"AAPL": 4000.0})
         state40 = self._state(exposures={"AAPL": 7000.0})
         self.assertEqual(_score_concentration_penalty(c, state25), 10.0)
         self.assertEqual(_score_concentration_penalty(c, state40), 10.0)
 
     def test_concentration_penalty_no_state_returns_zero_placeholder(self):
-        c = _make_candidate(symbol="AAPL", max_loss=99999.0)
+        c = _make_candidate(symbol="AAPL", max_loss=999.99)
         self.assertEqual(_score_concentration_penalty(c, None), 0.0)
 
     def test_score_candidate_threads_account_state_to_components(self):
-        c = _make_candidate(symbol="AAPL", max_loss=600.0, iv_rank=50.0)
+        c = _make_candidate(symbol="AAPL", max_loss=6.0, iv_rank=50.0)
         state = self._state(exposures={"AAPL": 2000.0})
         scored_with = score_candidate(c, today=date(2026, 4, 26), account_state=state)
         scored_without = score_candidate(c, today=date(2026, 4, 26))
@@ -1025,15 +1031,15 @@ class TestAccountFiltersAndScoring(unittest.TestCase):
         self.assertEqual(a.score_breakdown, b.score_breakdown)
 
     def test_score_candidates_propagates_state_to_each(self):
-        c1 = _make_candidate(symbol="AAPL", max_loss=200.0)
-        c2 = _make_candidate(symbol="MSFT", max_loss=2000.0)
+        c1 = _make_candidate(symbol="AAPL", max_loss=2.0)
+        c2 = _make_candidate(symbol="MSFT", max_loss=20.0)
         state = self._state()
         scored = score_candidates([c1, c2], today=date(2026, 4, 26), account_state=state)
         self.assertEqual(scored[0].score_breakdown["account_fit"], 10.0)
         self.assertEqual(scored[1].score_breakdown["account_fit"], 0.0)
 
     def test_higher_existing_exposure_lowers_score(self):
-        c = _make_candidate(symbol="AAPL", max_loss=1000.0, iv_rank=50.0)
+        c = _make_candidate(symbol="AAPL", max_loss=10.0, iv_rank=50.0)
         state_low = self._state(exposures={"AAPL": 0.0})
         state_high = self._state(exposures={"AAPL": 3000.0})
         s_low = score_candidate(c, today=date(2026, 4, 26), account_state=state_low).score
@@ -1079,6 +1085,94 @@ class TestAccountFiltersAndScoring(unittest.TestCase):
         scored = score_candidate(c, today=date(2026, 4, 26), account_state=state)
         self.assertEqual(scored.score_breakdown["account_fit"], 10.0)
         self.assertEqual(scored.score_breakdown["concentration_penalty"], 0.0)
+
+    # Sector overlap gate (TCBT-account-sizing)
+
+    def _state_with_sectors(self, occupied, exposures=None, nlv=20000.0):
+        return AccountState(
+            nlv=nlv,
+            bp_usage_pct=0.10,
+            existing_exposures=exposures or {},
+            occupied_sectors=frozenset(occupied),
+        )
+
+    def test_sector_overlap_rejected_when_sector_occupied_and_no_existing(self):
+        # AAPL is tech_hardware; sector occupied by another holding (e.g., SMCI)
+        c = _make_candidate(symbol="AAPL", max_loss=2.0)
+        state = self._state_with_sectors({"tech_hardware"})
+        survivors, rejections = apply_account_filters([c], state, **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [])
+        self.assertEqual(rejections[0].reason, "sector_overlap")
+        self.assertIn("tech_hardware", rejections[0].detail)
+
+    def test_sector_overlap_bypassed_when_symbol_already_in_exposures(self):
+        # Rolling/adding into AAPL is allowed even though tech_hardware is occupied
+        c = _make_candidate(symbol="AAPL", max_loss=2.0)
+        state = self._state_with_sectors({"tech_hardware"}, exposures={"AAPL": 1000.0})
+        survivors, rejections = apply_account_filters([c], state, **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [c])
+        self.assertEqual(rejections, [])
+
+    def test_sector_overlap_bypassed_when_sector_unknown(self):
+        # ZZZZ has no sector mapping → fail-open
+        c = _make_candidate(symbol="ZZZZ", max_loss=2.0)
+        state = self._state_with_sectors({"tech_hardware", "financial_bank"})
+        survivors, rejections = apply_account_filters([c], state, **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [c])
+        self.assertEqual(rejections, [])
+
+    def test_sector_overlap_bypassed_when_sector_not_occupied(self):
+        c = _make_candidate(symbol="AAPL", max_loss=2.0)
+        state = self._state_with_sectors({"financial_bank"})
+        survivors, rejections = apply_account_filters([c], state, **self.DEFAULT_FILTERS)
+        self.assertEqual(survivors, [c])
+
+
+class TestSizingRecommendation(unittest.TestCase):
+    """Tests for _candidate_to_dict sizing recommendation fields (TCBT-account-sizing)."""
+
+    @staticmethod
+    def _candidate(symbol="AAPL", max_loss=2.0):
+        return _make_candidate(symbol=symbol, max_loss=max_loss)
+
+    def _state(self, nlv=20000.0):
+        return AccountState(nlv=nlv, bp_usage_pct=0.10, existing_exposures={})
+
+    def test_sizing_omitted_without_account_state(self):
+        from agents.trade_ranker import _candidate_to_dict
+        d = _candidate_to_dict(self._candidate())
+        self.assertNotIn("recommended_contracts", d)
+        self.assertNotIn("max_loss_dollars", d)
+        self.assertIn("sector", d)  # sector is unconditional
+
+    def test_sizing_omitted_when_nlv_non_positive(self):
+        from agents.trade_ranker import _candidate_to_dict
+        bad_state = AccountState(nlv=0.0, bp_usage_pct=0.0)
+        d = _candidate_to_dict(self._candidate(), account_state=bad_state, per_trade_risk_pct=0.02)
+        self.assertNotIn("recommended_contracts", d)
+        self.assertNotIn("max_loss_dollars", d)
+
+    def test_sizing_omitted_when_per_trade_risk_pct_none(self):
+        from agents.trade_ranker import _candidate_to_dict
+        d = _candidate_to_dict(self._candidate(), account_state=self._state(), per_trade_risk_pct=None)
+        # max_loss_dollars + pct_nlv_at_risk_one_contract still emitted; recommended_contracts not
+        self.assertIn("max_loss_dollars", d)
+        self.assertNotIn("recommended_contracts", d)
+
+    def test_recommended_contracts_within_budget(self):
+        from agents.trade_ranker import _candidate_to_dict
+        # 2-point spread = $200/contract; 2% of $20k NLV = $400 budget; rec = 2
+        d = _candidate_to_dict(self._candidate(max_loss=2.0), account_state=self._state(), per_trade_risk_pct=0.02)
+        self.assertEqual(d["recommended_contracts"], 2)
+        self.assertAlmostEqual(d["pct_nlv_at_risk"], 0.02, places=4)
+        self.assertEqual(d["max_loss_dollars"], 200.0)
+
+    def test_recommended_contracts_skip_when_one_exceeds_budget(self):
+        from agents.trade_ranker import _candidate_to_dict
+        # 5-point spread = $500/contract; 2% of $20k = $400 budget → 0 contracts
+        d = _candidate_to_dict(self._candidate(max_loss=5.0), account_state=self._state(), per_trade_risk_pct=0.02)
+        self.assertEqual(d["recommended_contracts"], 0)
+        self.assertAlmostEqual(d["pct_nlv_at_risk_one_contract"], 0.025, places=4)
 
 
 def _mk_top_candidate(symbol: str, score: float, structure: str = "BULL_PUT_SPREAD") -> Candidate:
@@ -1201,6 +1295,112 @@ class TestFilterByIvr(unittest.TestCase):
         self.assertEqual([c.symbol for c in passing], ["A"])
 
 
+class TestPositionDollarExposure(unittest.TestCase):
+    """Tests for _position_dollar_exposure conservative dollar accounting."""
+
+    @staticmethod
+    def _pos(symbol, instrument_type, quantity, direction=None, avg_open=None):
+        p = MagicMock()
+        p.symbol = symbol
+        p.instrument_type = MagicMock()
+        p.instrument_type.value = instrument_type
+        p.quantity = quantity
+        if direction is not None:
+            p.quantity_direction = MagicMock()
+            p.quantity_direction.value = direction
+        else:
+            p.quantity_direction = None
+        if avg_open is not None:
+            p.average_open_price = avg_open
+        return p
+
+    def test_short_put_uses_strike_times_100(self):
+        from agents.trade_ranker import _position_dollar_exposure
+        # AAPL Jun 19 2026 150 PUT, qty -2
+        pos = self._pos("AAPL  260619P00150000", "Equity Option", 2, direction="Short")
+        self.assertEqual(_position_dollar_exposure(pos), 150.0 * 100 * 2)
+
+    def test_long_option_returns_zero(self):
+        from agents.trade_ranker import _position_dollar_exposure
+        pos = self._pos("AAPL  260619C00150000", "Equity Option", 1, direction="Long")
+        self.assertEqual(_position_dollar_exposure(pos), 0.0)
+
+    def test_equity_uses_qty_times_avg(self):
+        from agents.trade_ranker import _position_dollar_exposure
+        pos = self._pos("AAPL", "Equity", 100, avg_open=180.50)
+        self.assertEqual(_position_dollar_exposure(pos), 100 * 180.50)
+
+    def test_unknown_instrument_returns_zero(self):
+        from agents.trade_ranker import _position_dollar_exposure
+        pos = self._pos("/ESM6", "Future", 1)
+        self.assertEqual(_position_dollar_exposure(pos), 0.0)
+
+    def test_malformed_occ_returns_zero(self):
+        from agents.trade_ranker import _position_dollar_exposure
+        pos = self._pos("not-an-occ-symbol", "Equity Option", 1, direction="Short")
+        self.assertEqual(_position_dollar_exposure(pos), 0.0)
+
+
+class TestBuildAccountStateFiltering(unittest.IsolatedAsyncioTestCase):
+    """_build_account_state should drop zero-exposure positions from exposures and sectors."""
+
+    async def test_long_only_position_does_not_occupy_sector_or_pollute_exposures(self):
+        from agents.trade_ranker import _build_account_state
+
+        # Mock RiskManager and PortfolioAgent
+        long_pos = MagicMock()
+        long_pos.symbol = "NVDA  260619C00500000"
+        long_pos.underlying_symbol = "NVDA"
+        long_pos.instrument_type = MagicMock()
+        long_pos.instrument_type.value = "Equity Option"
+        long_pos.quantity = 1
+        long_pos.quantity_direction = MagicMock()
+        long_pos.quantity_direction.value = "Long"
+
+        with patch("agents.trade_ranker.RiskManager") as mock_rm, \
+             patch("agents.trade_ranker.PortfolioAgent") as mock_pa:
+            rm_inst = mock_rm.return_value
+            rm_inst.calculate_portfolio_risk = AsyncMock(return_value={"nlv": 20000.0, "bp_usage_pct": 10.0})
+
+            pa_inst = MagicMock()
+            pa_inst.get_positions = AsyncMock(return_value=[long_pos])
+            init_inst = AsyncMock(return_value=pa_inst)
+            mock_pa.return_value.init = init_inst
+
+            state = await _build_account_state(MagicMock(), "ACCT")
+
+        # Long-only NVDA must not pollute exposures or occupy semis sector
+        self.assertNotIn("NVDA", state.existing_exposures)
+        self.assertEqual(state.occupied_sectors, frozenset())
+
+    async def test_short_position_populates_exposures_and_sector(self):
+        from agents.trade_ranker import _build_account_state
+
+        short_pos = MagicMock()
+        short_pos.symbol = "NVDA  260619P00400000"
+        short_pos.underlying_symbol = "NVDA"
+        short_pos.instrument_type = MagicMock()
+        short_pos.instrument_type.value = "Equity Option"
+        short_pos.quantity = 1
+        short_pos.quantity_direction = MagicMock()
+        short_pos.quantity_direction.value = "Short"
+
+        with patch("agents.trade_ranker.RiskManager") as mock_rm, \
+             patch("agents.trade_ranker.PortfolioAgent") as mock_pa:
+            rm_inst = mock_rm.return_value
+            rm_inst.calculate_portfolio_risk = AsyncMock(return_value={"nlv": 20000.0, "bp_usage_pct": 10.0})
+
+            pa_inst = MagicMock()
+            pa_inst.get_positions = AsyncMock(return_value=[short_pos])
+            init_inst = AsyncMock(return_value=pa_inst)
+            mock_pa.return_value.init = init_inst
+
+            state = await _build_account_state(MagicMock(), "ACCT")
+
+        self.assertEqual(state.existing_exposures.get("NVDA"), 400.0 * 100)
+        self.assertIn("tech_semiconductors", state.occupied_sectors)
+
+
 class TestLoadThresholds(unittest.TestCase):
     """Tests for _load_thresholds helper."""
 
@@ -1224,6 +1424,7 @@ class TestLoadThresholds(unittest.TestCase):
                 "min_ivr",
                 "research_concurrency",
                 "research_timeout_seconds",
+                "per_trade_risk_pct",
             },
         )
         expected_calls = [
@@ -1239,6 +1440,7 @@ class TestLoadThresholds(unittest.TestCase):
             "bt_min_ivr",
             "bt_research_concurrency",
             "bt_research_timeout_seconds",
+            "bt_per_trade_risk_pct",
         ]
         actual_calls = [call.args[0] for call in mock_settings.get.call_args_list]
         self.assertEqual(set(actual_calls), set(expected_calls))

--- a/utils/sector_map.py
+++ b/utils/sector_map.py
@@ -1,0 +1,146 @@
+"""Hardcoded sector classification for the watchlist universe.
+
+V1 keeps this static. Sector overlap drives the account-fit filter so the AI
+coach (and `--best-trades`) won't surface a candidate whose underlying shares
+a sector with an open position. Unknown symbols return ``None`` and bypass
+the gate (fail-open: better to surface a possibly-overlapping pick than
+silently drop a legitimate one).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+_SECTORS: dict[str, str] = {
+    # --- Mega-cap tech ---
+    "AAPL": "tech_hardware",
+    "MSFT": "tech_software",
+    "GOOGL": "tech_internet",
+    "GOOG": "tech_internet",
+    "META": "tech_internet",
+    "AMZN": "consumer_internet",
+    "NVDA": "tech_semiconductors",
+    "AMD": "tech_semiconductors",
+    "INTC": "tech_semiconductors",
+    "AVGO": "tech_semiconductors",
+    "TSM": "tech_semiconductors",
+    "MU": "tech_semiconductors",
+    "QCOM": "tech_semiconductors",
+    "MRVL": "tech_semiconductors",
+    "ARM": "tech_semiconductors",
+    "ON": "tech_semiconductors",
+    "NXPI": "tech_semiconductors",
+    "LRCX": "tech_semiconductors",
+    "AMAT": "tech_semiconductors",
+    "ASML": "tech_semiconductors",
+    "KLAC": "tech_semiconductors",
+    "WDC": "tech_semiconductors",
+    "STX": "tech_semiconductors",
+    "TXN": "tech_semiconductors",
+    "ADI": "tech_semiconductors",
+    "SMCI": "tech_hardware",
+    "TSLA": "auto",
+    "NFLX": "tech_internet",
+    "ORCL": "tech_software",
+    "CRM": "tech_software",
+    "ADBE": "tech_software",
+    "NOW": "tech_software",
+    "PLTR": "tech_software",
+    "SNOW": "tech_software",
+    "SHOP": "tech_software",
+    # --- Financials / banks ---
+    "JPM": "financial_bank",
+    "BAC": "financial_bank",
+    "WFC": "financial_bank",
+    "C": "financial_bank",
+    "GS": "financial_bank",
+    "MS": "financial_bank",
+    "SCHW": "financial_broker",
+    "BLK": "financial_asset_mgr",
+    "BRK/B": "financial_diversified",
+    "V": "financial_payments",
+    "MA": "financial_payments",
+    "PYPL": "financial_payments",
+    "AXP": "financial_payments",
+    "SQ": "financial_payments",
+    # --- Healthcare ---
+    "JNJ": "health_pharma",
+    "PFE": "health_pharma",
+    "MRK": "health_pharma",
+    "LLY": "health_pharma",
+    "ABBV": "health_pharma",
+    "BMY": "health_pharma",
+    "UNH": "health_insurer",
+    "CVS": "health_insurer",
+    "TMO": "health_devices",
+    "ABT": "health_devices",
+    # --- Energy ---
+    "XOM": "energy_oil",
+    "CVX": "energy_oil",
+    "COP": "energy_oil",
+    "OXY": "energy_oil",
+    "SLB": "energy_services",
+    "MPC": "energy_refiner",
+    # --- Industrial / aerospace ---
+    "BA": "industrial_aerospace",
+    "CAT": "industrial_machinery",
+    "DE": "industrial_machinery",
+    "GE": "industrial_diversified",
+    "HON": "industrial_diversified",
+    "RTX": "industrial_aerospace",
+    "LMT": "industrial_defense",
+    # --- Consumer ---
+    "WMT": "consumer_staples",
+    "COST": "consumer_staples",
+    "TGT": "consumer_staples",
+    "HD": "consumer_retail",
+    "LOW": "consumer_retail",
+    "NKE": "consumer_apparel",
+    "MCD": "consumer_restaurants",
+    "SBUX": "consumer_restaurants",
+    "DIS": "media",
+    # --- Comm services ---
+    "T": "telecom",
+    "VZ": "telecom",
+    "TMUS": "telecom",
+    # --- Crypto / fintech ---
+    "COIN": "crypto",
+    "MSTR": "crypto",
+    "MARA": "crypto",
+    "RIOT": "crypto",
+    # --- Index ETFs (treat as own sector for concentration purposes) ---
+    "SPY": "etf_broad",
+    "QQQ": "etf_broad",
+    "IWM": "etf_broad",
+    "DIA": "etf_broad",
+    # --- Sector ETFs ---
+    "XLF": "etf_financials",
+    "XLE": "etf_energy",
+    "XLK": "etf_tech",
+    "XLV": "etf_health",
+    "XLY": "etf_consumer_disc",
+    "XLP": "etf_consumer_staples",
+    "GLD": "etf_metals",
+    "SLV": "etf_metals",
+    "TLT": "etf_treasury",
+    "USO": "etf_energy",
+    # --- Misc high-volume ---
+    "BABA": "tech_internet",
+    "NBIS": "tech_internet",
+    "UBER": "consumer_internet",
+    "LYFT": "consumer_internet",
+    "ABNB": "consumer_internet",
+    "RBLX": "tech_software",
+    "DKNG": "consumer_gaming",
+    "F": "auto",
+    "GM": "auto",
+    "RIVN": "auto",
+    "LCID": "auto",
+}
+
+
+def get_sector(symbol: str) -> Optional[str]:
+    """Return the sector tag for a ticker, or None if unknown."""
+    if not symbol:
+        return None
+    return _SECTORS.get(symbol.strip().upper())

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -18,6 +18,7 @@ NUMERIC_KEYS: frozenset[str] = frozenset({
     "bt_bp_cap_for_new",
     "bt_concentration_overlap_block_pct",
     "bt_min_ivr",
+    "bt_per_trade_risk_pct",
 })
 OPTIONAL_NUMERIC_KEYS: frozenset[str] = frozenset({
     "theta_target",  # may be None
@@ -47,6 +48,7 @@ DEFAULTS: dict[str, Any] = {
     "bt_max_pct_nlv_per_trade": 0.05,
     "bt_bp_cap_for_new": 0.50,
     "bt_concentration_overlap_block_pct": 0.25,
+    "bt_per_trade_risk_pct": 0.02,
     "bt_min_ivr": 30.0,
     "bt_research_concurrency": 5,
     "bt_research_timeout_seconds": 90,
@@ -76,6 +78,7 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "bt_max_pct_nlv_per_trade": "Reject candidates whose max-loss exceeds this fraction of NLV (0.05 = 5%).",
     "bt_bp_cap_for_new": "Reject if post-trade BP usage would exceed this fraction (0.50 = 50%).",
     "bt_concentration_overlap_block_pct": "Reject if combined exposure to one underlying exceeds this fraction of NLV.",
+    "bt_per_trade_risk_pct": "Per-trade risk budget for sizing recommendations (0.02 = 2% of NLV per spread).",
     # Best-Trades-Today: scan + research
     "bt_min_ivr": "Pre-filter watchlist symbols by IVR; symbols below this percentage are skipped before research (default 30).",
     "bt_max_per_symbol": "Cap candidate count per symbol from the researcher (default 3).",


### PR DESCRIPTION
## Summary

- **Bug fix:** `apply_account_filters` + the `_score_account_fit` / `_score_concentration_penalty` helpers treated `Candidate.max_loss` (in *spread points*) as dollars — silently disabling the oversized-vs-NLV and concentration gates by ~100×. Introduces `_dollar_max_loss(c) = c.max_loss * 100` and applies it consistently.
- **Real account state:** `_build_account_state` now computes per-underlying dollar exposure from open positions (short options: strike×100×qty; equity: cost basis; long-only options drop to 0 and are filtered out so they don't pollute the concentration check or over-broadly mark a sector as occupied).
- **Sector-overlap gate:** new `occupied_sectors` set + `utils/sector_map.py` static map drive a rejection that blocks new picks whose sector is already represented by an open position. Allows rolling/adding into underlyings we already hold (`c.symbol in exposures` exception).
- **Personalized sizing in output:** `recommended_contracts`, `pct_nlv_at_risk`, `max_loss_dollars`, `sector` emitted per top-3 candidate when `account_state` is available. Driven by new `bt_per_trade_risk_pct` setting (default 0.02).

## Test plan

- [x] Full `unittest discover tests` passes 491/497 — 6 remaining failures are pre-existing on `main` (test_options_researcher, test_risk_manager, test_resolve_expiration_monthly_45dte, test_bt_research_timeout_seconds_default_forty_five — all confirmed by checking out `main` directly).
- [x] 16 new tests cover sector gate (positive / bypass-when-rolling / bypass-when-unknown / bypass-when-not-occupied), sizing recommendation edge cases, `_position_dollar_exposure` for each instrument type, and `_build_account_state` filtering of long-only positions.
- [x] Existing `TestAccountFiltersAndScoring` fixtures updated to correct spread-point semantics (max_loss values divided by 100).
- [ ] Smoke run `python main.py --best-trades --account <num>` against live account to confirm the new gates and sizing display fire as expected.

## Independent review notes addressed

A general-purpose review subagent surfaced two correctness bugs that this PR includes fixes for:
1. Long-only options were creating `existing_exposures[symbol] = 0.0` keys, which silently bypassed the sector gate's "rolling" exception for those symbols. **Fix:** drop positions with `dollars <= 0` before populating exposures.
2. Long-only options were marking their sector as occupied. Owning one long NVDA call would have blocked all new semiconductor picks. **Fix:** only count positions with positive dollar exposure toward `occupied_sectors`.

Deferred (documented in code or for follow-up): sector map coverage gaps (utilities, REITs, materials, several common tickers); intra-batch sector-overlap among survivors; symmetric `credit_dollars` field in JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)