### PR TITLE
coach + dashboard: AI briefing/chat + FastAPI web UI

### DIFF
--- a/agents/coach.py
+++ b/agents/coach.py
@@ -1,0 +1,303 @@
+"""AI coach: Claude Agent SDK driving tasty-coach as in-process tools.
+
+Two entry points:
+- ``run_briefing(ctx)`` — single-turn daily briefing (Opus).
+- ``run_chat(ctx)`` — interactive REPL (Sonnet) with persistent context across turns.
+
+Auth: requires ``CLAUDE_CODE_OAUTH_TOKEN`` (Claude Max subscription) OR
+``ANTHROPIC_API_KEY`` (fallback). Subscription path is preferred.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    ResultMessage,
+    TextBlock,
+    ToolUseBlock,
+)
+
+from agents import coach_context, coach_tools
+from agents.coach_context import CoachContext
+
+CHAT_MODEL = "claude-sonnet-4-6"
+# Briefing uses the same fast model as chat by default — Opus is materially
+# slower for marginal added depth. Override via TASTY_COACH_BRIEFING_MODEL env
+# if you want Opus for a particular run.
+BRIEFING_MODEL = os.environ.get("TASTY_COACH_BRIEFING_MODEL", "claude-sonnet-4-6")
+
+PROMPT_PATH = Path(__file__).parent / "prompts" / "coach_system.md"
+
+def _build_briefing_prompt(
+    snapshot: dict[str, Any] | None,
+    best_trades: dict[str, Any] | None = None,
+) -> str:
+    """Build a self-contained briefing prompt.
+
+    When ``snapshot`` and ``best_trades`` are both supplied, the agent has
+    everything it needs and only writes the prose — no tool calls, no waiting.
+    This is the fast path. Falls back gracefully if either is missing.
+    """
+    import json as _json
+    parts = ["Produce my morning trading briefing.\n"]
+
+    if snapshot:
+        compact = {
+            "kpis": snapshot.get("kpis"),
+            "positions": snapshot.get("positions"),
+            "alerts": snapshot.get("alerts"),
+        }
+        parts.append(
+            "Account snapshot (already fetched — do NOT call get_account_status or get_positions):\n"
+            + _json.dumps(compact, default=str)
+            + "\n"
+        )
+
+    if best_trades:
+        compact_bt = {
+            "top": best_trades.get("top"),
+            "rejected_summary": best_trades.get("rejected_summary"),
+            "rejected_count": best_trades.get("rejected_count"),
+            "watchlists": best_trades.get("watchlists"),
+        }
+        parts.append(
+            "Best-trades scan (already fetched — do NOT call run_best_trades):\n"
+            + _json.dumps(compact_bt, default=str)
+            + "\n"
+        )
+
+    parts.append("Steps:")
+    if not snapshot:
+        parts.append("- Call get_account_status and get_positions first.")
+    if not best_trades:
+        parts.append(
+            "- Trade scan unavailable right now (likely market closed / no live data). "
+            "Do NOT call run_best_trades — it will time out. Skip the 'top picks' section "
+            "and tell the user trades will be scanned when the market re-opens."
+        )
+    parts.extend([
+        "- Filter any picks against the account-fit rules in your system prompt (BP fit, no symbol-duplicates, sector overlap warnings, sizing).",
+        "- Output (plain prose, not markdown):",
+        "  - One-sentence summary of account state (NLV, BP%, position count).",
+        "  - Top 1-3 actionable picks with strikes, credit, max loss, recommended contracts, and exit plan (50% profit / 21 DTE) — OR a note that trade scan is unavailable.",
+        "  - Any positions worth reviewing (>21 DTE or near profit target).",
+        "Keep total output under 400 words.",
+    ])
+    return "\n".join(parts)
+
+
+def _silence_shutdown_recursion() -> None:
+    """Swallow Python 3.14 asyncio Task.cancel(msg=msg) recursion noise on shutdown.
+
+    The claude-agent-sdk transport spawns the Claude Code CLI subprocess and
+    layers anyio task groups + read/write loops underneath. When the loop
+    closes, Python 3.14's stricter `Task.cancel(msg=msg)` recursively cancels
+    children deep enough to blow the recursion limit. The briefing/chat has
+    already produced its output by the time these fire, so they're pure
+    teardown noise — drop them at the loop level rather than letting them
+    spam stderr.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+
+    def handler(_loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        # Narrow predicate: only swallow RecursionError originating in the SDK
+        # transport teardown path (claude_agent_sdk / anyio frames). Real
+        # RecursionErrors in tool code or our own logic should still surface.
+        exc = context.get("exception")
+        msg = str(context.get("message", ""))
+        looks_like_sdk_teardown = (
+            "claude_agent_sdk" in msg or "anyio" in msg or "task_group" in msg
+        )
+        if isinstance(exc, RecursionError) and looks_like_sdk_teardown:
+            return
+        if "RecursionError" in msg and looks_like_sdk_teardown:
+            return
+        _loop.default_exception_handler(context)
+
+    loop.set_exception_handler(handler)
+
+
+def _check_auth() -> None:
+    if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
+        return
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        print(
+            "[coach] Using ANTHROPIC_API_KEY (pay-per-token). "
+            "For Max-subscription billing, run `claude setup-token` and set CLAUDE_CODE_OAUTH_TOKEN.",
+            file=sys.stderr,
+        )
+        return
+    print(
+        "ERROR: no Claude credentials found.\n"
+        "  Run `claude setup-token` (Max subscription) and add CLAUDE_CODE_OAUTH_TOKEN to your .env,\n"
+        "  or set ANTHROPIC_API_KEY for pay-per-token.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def _load_system_prompt() -> str:
+    try:
+        return PROMPT_PATH.read_text()
+    except FileNotFoundError:
+        return "You are a tasty-coach options trading assistant."
+
+
+def _build_options(model: str) -> ClaudeAgentOptions:
+    return ClaudeAgentOptions(
+        system_prompt=_load_system_prompt(),
+        model=model,
+        mcp_servers={"tasty_coach": coach_tools.build_mcp_server()},
+        allowed_tools=coach_tools.ALLOWED_TOOLS,
+        permission_mode="bypassPermissions",
+        tools=[],  # disable Claude Code native tools (Bash/Read/Write/etc.)
+    )
+
+
+def _print_text_blocks(blocks: Iterable) -> None:
+    for block in blocks:
+        if isinstance(block, TextBlock):
+            sys.stdout.write(block.text)
+            sys.stdout.flush()
+
+
+_TOOL_LABELS = {
+    "mcp__tasty_coach__get_account_status": "checking account status",
+    "mcp__tasty_coach__get_positions": "loading positions",
+    "mcp__tasty_coach__calculate_risk": "computing portfolio risk",
+    "mcp__tasty_coach__run_best_trades": "scanning watchlists for trades",
+    "mcp__tasty_coach__research_symbol": "researching symbol",
+    "mcp__tasty_coach__review_position": "reviewing position",
+    "mcp__tasty_coach__calculate_gex": "calculating gamma exposure",
+    "mcp__tasty_coach__scan_watchlist": "scanning watchlist IVR",
+    "mcp__tasty_coach__get_history": "fetching account history",
+    "mcp__tasty_coach__record_decision": "saving decision to journal",
+    "mcp__tasty_coach__recall_journal": "recalling prior decisions",
+}
+
+
+def _tool_status_label(name: str, input_args: dict) -> str:
+    base = _TOOL_LABELS.get(name, name.replace("mcp__tasty_coach__", ""))
+    sym = input_args.get("symbol") if isinstance(input_args, dict) else None
+    if sym:
+        return f"{base} ({sym})"
+    return base
+
+
+async def run_briefing(
+    ctx: CoachContext,
+    *,
+    snapshot: dict[str, Any] | None = None,
+    best_trades: dict[str, Any] | None = None,
+) -> None:
+    _check_auth()
+    _silence_shutdown_recursion()
+    coach_context.set_current(ctx)
+    options = _build_options(BRIEFING_MODEL)
+
+    prompt = _build_briefing_prompt(snapshot, best_trades)
+    # Use ClaudeSDKClient (not query()) so __aexit__ runs disconnect() and
+    # drains the Node subprocess deterministically — query()'s async generator
+    # cleanup recurses on Python 3.14 task cancellation.
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query(prompt)
+        async for message in client.receive_response():
+            if isinstance(message, AssistantMessage):
+                _print_text_blocks(message.content)
+            elif isinstance(message, ResultMessage):
+                sys.stdout.write("\n")
+                cost = getattr(message, "total_cost_usd", None)
+                if cost is not None:
+                    print(f"[coach] cost: ${cost:.4f}", file=sys.stderr)
+                break
+
+
+async def stream_briefing(
+    ctx: CoachContext,
+    *,
+    snapshot: dict[str, Any] | None = None,
+    best_trades: dict[str, Any] | None = None,
+):
+    """Yield (kind, text) tuples for SSE consumers.
+
+    Kinds:
+      - 'status': tool-call activity ("scanning watchlists for trades (AMD)")
+      - 'token':  visible response text
+      - 'cost':   final cost line
+    """
+    _check_auth()
+    _silence_shutdown_recursion()
+    coach_context.set_current(ctx)
+    options = _build_options(BRIEFING_MODEL)
+    prompt = _build_briefing_prompt(snapshot, best_trades)
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query(prompt)
+        async for message in client.receive_response():
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        yield ("token", block.text)
+                    elif isinstance(block, ToolUseBlock):
+                        yield ("status", _tool_status_label(block.name, block.input or {}))
+            elif isinstance(message, ResultMessage):
+                cost = getattr(message, "total_cost_usd", None)
+                if cost is not None:
+                    yield ("cost", f"${cost:.4f}")
+                break
+
+
+async def stream_chat_turn(client: ClaudeSDKClient, prompt: str):
+    """Yield (kind, text) tuples for one chat turn against an existing connected client."""
+    await client.query(prompt)
+    async for message in client.receive_response():
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    yield ("token", block.text)
+                elif isinstance(block, ToolUseBlock):
+                    yield ("status", _tool_status_label(block.name, block.input or {}))
+        elif isinstance(message, ResultMessage):
+            return
+
+
+def build_chat_options() -> ClaudeAgentOptions:
+    """Public accessor for chat options (used by the web server to construct ClaudeSDKClient)."""
+    return _build_options(CHAT_MODEL)
+
+
+async def run_chat(ctx: CoachContext) -> None:
+    _check_auth()
+    _silence_shutdown_recursion()
+    coach_context.set_current(ctx)
+    options = _build_options(CHAT_MODEL)
+
+    print("Tasty Coach chat. Type your question (or 'exit' to quit).")
+    async with ClaudeSDKClient(options=options) as client:
+        while True:
+            try:
+                line = input("\n> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return
+            if not line:
+                continue
+            if line.lower() in {"exit", "quit", ":q"}:
+                return
+            await client.query(line)
+            async for message in client.receive_response():
+                if isinstance(message, AssistantMessage):
+                    _print_text_blocks(message.content)
+                elif isinstance(message, ResultMessage):
+                    break
+            sys.stdout.write("\n")

--- a/agents/coach_context.py
+++ b/agents/coach_context.py
@@ -1,0 +1,44 @@
+"""Shared runtime context for the AI coach.
+
+Holds the live TastyTrade session, resolved account, and journal path so the
+SDK tool wrappers (which run as in-process MCP tools and receive only their
+JSON args) can reach back into application state.
+
+Stored in a ``contextvars.ContextVar`` so concurrent web requests (each calling
+``set_current`` with their own context) don't trample each other. Tool callbacks
+run in the same task tree as the request handler, so the var propagates
+correctly without explicit threading.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass
+class CoachContext:
+    session: Any           # tastytrade.Session
+    account: Any           # tastytrade.Account
+    account_number: str
+    journal_path: Path = field(
+        default_factory=lambda: Path.home() / ".tasty-coach" / "journal.jsonl"
+    )
+
+
+_CURRENT: ContextVar[Optional[CoachContext]] = ContextVar("coach_context", default=None)
+
+
+def set_current(ctx: CoachContext) -> None:
+    _CURRENT.set(ctx)
+
+
+def current() -> CoachContext:
+    ctx = _CURRENT.get()
+    if ctx is None:
+        raise RuntimeError(
+            "CoachContext not initialised. Call coach_context.set_current() before invoking tools."
+        )
+    return ctx

--- a/agents/coach_tools.py
+++ b/agents/coach_tools.py
@@ -1,0 +1,308 @@
+"""Tool wrappers exposing existing tasty-coach agents to the Claude Agent SDK.
+
+Each tool is a thin async closure that pulls the live session/account from
+``coach_context.current()``, calls the relevant agent, and returns a compact
+JSON-text payload the LLM can reason over. We deliberately avoid Rich objects
+and trim large dataclasses to small dicts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from claude_agent_sdk import tool, create_sdk_mcp_server
+
+from agents import coach_context
+from agents.gex import GEXAgent
+from agents.history import HistoryAgent
+from agents.manager import RiskManager
+from agents.options_researcher import OptionsResearcherAgent
+from agents.portfolio import PortfolioAgent
+from agents.reviewer import ReviewerAgent
+from agents.scanner import ScannerAgent
+from agents.trade_ranker import run_best_trades
+from utils import journal
+
+logger = logging.getLogger(__name__)
+
+
+def _ok(payload: Any) -> dict:
+    text = payload if isinstance(payload, str) else json.dumps(payload, default=str, indent=2)
+    return {"content": [{"type": "text", "text": text}]}
+
+
+def _err(msg: str) -> dict:
+    return {"content": [{"type": "text", "text": f"ERROR: {msg}"}], "is_error": True}
+
+
+def _serialize_position(p: Any) -> dict:
+    g = lambda k, d=None: getattr(p, k, d)
+    inst = g("instrument_type")
+    inst_str = getattr(inst, "value", str(inst)) if inst is not None else None
+    return {
+        "symbol": g("symbol"),
+        "instrument_type": inst_str,
+        "quantity": str(g("quantity")) if g("quantity") is not None else None,
+        "quantity_direction": getattr(g("quantity_direction"), "value", None) or g("quantity_direction"),
+        "average_open_price": str(g("average_open_price")) if g("average_open_price") is not None else None,
+        "underlying_symbol": g("underlying_symbol"),
+        "expires_at": str(g("expires_at")) if g("expires_at") else None,
+    }
+
+
+@tool(
+    "get_account_status",
+    "Fetch live account status: NLV, buying power, BP usage, cash. Always call this before recommending new trades.",
+    {},
+)
+async def get_account_status(_args: dict) -> dict:
+    ctx = coach_context.current()
+    pf = await PortfolioAgent(ctx.session, ctx.account_number).init()
+    if pf.account is None:
+        return _err("could not resolve account")
+    status = await pf.get_account_status()
+    return _ok(status)
+
+
+@tool(
+    "get_positions",
+    "List current open positions with symbol, quantity, direction, and instrument type.",
+    {},
+)
+async def get_positions(_args: dict) -> dict:
+    ctx = coach_context.current()
+    pf = await PortfolioAgent(ctx.session, ctx.account_number).init()
+    positions = await pf.get_positions()
+    return _ok([_serialize_position(p) for p in positions])
+
+
+@tool(
+    "calculate_risk",
+    "Compute portfolio-level risk: BP usage, NLV, portfolio delta/theta, concentration, alerts.",
+    {},
+)
+async def calculate_risk(_args: dict) -> dict:
+    ctx = coach_context.current()
+    rm = RiskManager(ctx.session, ctx.account_number)
+    risk = await rm.calculate_portfolio_risk()
+    return _ok(risk)
+
+
+@tool(
+    "run_best_trades",
+    "Run the full Best-Trades pipeline: scan watchlists, generate candidates, apply quality gates, return top ranked ideas plus rejection summary.",
+    {"top": int},
+)
+async def run_best_trades_tool(args: dict) -> dict:
+    ctx = coach_context.current()
+    top = int(args.get("top") or 3)
+    result = await run_best_trades(
+        ctx.session,
+        top=top,
+        output_format="json",
+        account_number=ctx.account_number,
+    )
+    # Trim rejection list to a summary count to keep context small.
+    if isinstance(result, dict) and isinstance(result.get("rejected"), list):
+        rej = result["rejected"]
+        summary: dict[str, int] = {}
+        for r in rej:
+            reason = r.get("reason") if isinstance(r, dict) else None
+            if reason:
+                summary[reason] = summary.get(reason, 0) + 1
+        result["rejected_summary"] = summary
+        result["rejected_count"] = len(rej)
+        result.pop("rejected", None)
+    return _ok(result)
+
+
+@tool(
+    "research_symbol",
+    "Research one underlying symbol's options chain and return ranked credit-spread / iron-condor ideas. Use for symbol-specific questions.",
+    {"symbol": str},
+)
+async def research_symbol(args: dict) -> dict:
+    ctx = coach_context.current()
+    symbol = (args.get("symbol") or "").strip().upper()
+    if not symbol:
+        return _err("symbol is required")
+    agent = OptionsResearcherAgent(ctx.session)
+    report = await agent.research(symbol)
+    return _ok(report)
+
+
+@tool(
+    "review_position",
+    "Review one underlying's open positions and produce roll scenarios (down / out / down-and-out).",
+    {"symbol": str},
+)
+async def review_position(args: dict) -> dict:
+    ctx = coach_context.current()
+    symbol = (args.get("symbol") or "").strip().upper()
+    if not symbol:
+        return _err("symbol is required")
+    rev = await ReviewerAgent(ctx.session, ctx.account_number).init()
+    results = await rev.review_positions(underlying_filter=symbol)
+    out = []
+    for r in results:
+        out.append({
+            "underlying": getattr(r, "underlying", None),
+            "summary": getattr(r, "summary", None) or str(r),
+        })
+    return _ok(out)
+
+
+@tool(
+    "calculate_gex",
+    "Compute gamma-exposure profile for an underlying: spot, zero-gamma level, call/put walls, regime signal.",
+    {"symbol": str, "max_dte": int},
+)
+async def calculate_gex_tool(args: dict) -> dict:
+    ctx = coach_context.current()
+    symbol = (args.get("symbol") or "SPY").strip().upper()
+    max_dte = int(args.get("max_dte") or 30)
+    gex = GEXAgent(ctx.session)
+    result = await gex.calculate_gex(symbol=symbol, max_dte=max_dte)
+    payload = {
+        "symbol": getattr(result, "symbol", symbol),
+        "spot_price": getattr(result, "spot_price", None),
+        "total_gex": getattr(result, "total_gex", None),
+        "zero_gamma_level": getattr(result, "zero_gamma_level", None),
+        "regime": gex.analyze_regime(result),
+        "walls": gex.get_gamma_walls(result),
+    }
+    return _ok(payload)
+
+
+@tool(
+    "scan_watchlist",
+    "Scan a TastyTrade watchlist for IVR rank. Returns symbols sorted by IVR descending.",
+    {"watchlist": str},
+)
+async def scan_watchlist(args: dict) -> dict:
+    ctx = coach_context.current()
+    watchlist = args.get("watchlist") or "PMCC Targets"
+    sc = ScannerAgent(ctx.session)
+    symbols = await sc.get_symbols_from_watchlist(watchlist)
+    if not symbols:
+        return _ok({"watchlist": watchlist, "symbols": [], "ivr": []})
+    ivr_data = await sc.scan_ivr(symbols)
+    ranked = sorted(
+        ({"symbol": s, "ivr": getattr(d, "ivr", None)} for s, d in ivr_data.items()),
+        key=lambda x: (x["ivr"] is None, -(x["ivr"] or 0)),
+    )
+    return _ok({"watchlist": watchlist, "symbols": symbols, "ivr": ranked})
+
+
+@tool(
+    "get_history",
+    "Fetch recent account events (fills, closes, rolls, assignments) for the last N days.",
+    {"days": int},
+)
+async def get_history(args: dict) -> dict:
+    ctx = coach_context.current()
+    days = int(args.get("days") or 14)
+    h = await HistoryAgent(ctx.session, ctx.account_number).init()
+    events = await h.get_recent_events(days=days)
+    return _ok(events)
+
+
+@tool(
+    "record_decision",
+    (
+        "Persist a decision or notable observation to the journal so future "
+        "conversations can recall it. Use AFTER recommending a trade, opening/"
+        "closing a position, or making an analytical call worth remembering. "
+        "Set 'kind' to one of: recommendation, trade_open, trade_close, note, "
+        "outcome. Provide a clear 'rationale' in plain English."
+    ),
+    {"kind": str, "rationale": str, "symbol": str, "strategy": str},
+)
+async def record_decision(args: dict) -> dict:
+    kind = (args.get("kind") or "").strip().lower()
+    rationale = (args.get("rationale") or "").strip()
+    if not kind or not rationale:
+        return _err("kind and rationale are required")
+    if kind not in journal.VALID_KINDS:
+        return _err(f"kind must be one of {sorted(journal.VALID_KINDS)}")
+    # Cap rationale to bound journal growth on runaway model loops or prompt
+    # injection — the journal lives at ~/.tasty-coach/journal.jsonl and is
+    # append-only, so unbounded entries can quickly bloat the file.
+    if len(rationale) > 4096:
+        rationale = rationale[:4096] + "…[truncated]"
+    entry = {
+        "kind": kind,
+        "rationale": rationale,
+    }
+    sym = (args.get("symbol") or "").strip().upper()
+    if sym:
+        entry["symbol"] = sym
+    strat = (args.get("strategy") or "").strip()
+    if strat:
+        entry["strategy"] = strat
+    persisted = journal.record(entry)
+    return _ok({"recorded": True, "entry": persisted})
+
+
+@tool(
+    "recall_journal",
+    (
+        "Recall prior decisions, recommendations, and notes from the journal. "
+        "Use when the user asks 'what did I do last week?', 'why did I open X?', "
+        "or any history-grounded question. Filters: days (lookback window), "
+        "symbol (specific underlying), kind (recommendation|trade_open|"
+        "trade_close|note|outcome), limit (default 20)."
+    ),
+    {"days": int, "symbol": str, "kind": str, "limit": int},
+)
+async def recall_journal(args: dict) -> dict:
+    days = args.get("days")
+    symbol = (args.get("symbol") or "").strip() or None
+    kind = (args.get("kind") or "").strip().lower() or None
+    limit = int(args.get("limit") or 20)
+    entries = journal.recall(
+        days=int(days) if days is not None else None,
+        symbol=symbol,
+        kind=kind,
+        limit=limit,
+    )
+    return _ok({"entries": entries, "count": len(entries)})
+
+
+def build_mcp_server():
+    """Build the in-process MCP server that registers all coach tools."""
+    return create_sdk_mcp_server(
+        name="tasty_coach",
+        version="0.2.0",
+        tools=[
+            get_account_status,
+            get_positions,
+            calculate_risk,
+            run_best_trades_tool,
+            research_symbol,
+            review_position,
+            calculate_gex_tool,
+            scan_watchlist,
+            get_history,
+            record_decision,
+            recall_journal,
+        ],
+    )
+
+
+# Names the model is allowed to call (mcp__<server>__<tool>).
+ALLOWED_TOOLS = [
+    "mcp__tasty_coach__get_account_status",
+    "mcp__tasty_coach__get_positions",
+    "mcp__tasty_coach__calculate_risk",
+    "mcp__tasty_coach__run_best_trades",
+    "mcp__tasty_coach__research_symbol",
+    "mcp__tasty_coach__review_position",
+    "mcp__tasty_coach__calculate_gex",
+    "mcp__tasty_coach__scan_watchlist",
+    "mcp__tasty_coach__get_history",
+    "mcp__tasty_coach__record_decision",
+    "mcp__tasty_coach__recall_journal",
+]

--- a/agents/prompts/coach_system.md
+++ b/agents/prompts/coach_system.md
@@ -1,0 +1,52 @@
+# Tasty-Coach AI Coach — System Prompt
+
+You are an options trading coach for the user's TastyTrade account. You read live
+account state via tools, reason against the user's trading rules, and explain
+recommendations in plain English. You never place trades — you advise.
+
+## Your trading rules (non-negotiable)
+
+- **Strategy default**: defined-risk credit spreads (bull put / bear call / iron condor) on liquid equity options.
+- **DTE**: target 45 days to expiration; only standard monthly expirations (3rd Friday, or 3rd-week Thursday when Friday is a holiday).
+- **Short strike**: ~30 delta (range 0.15-0.45 acceptable).
+- **Credit floor**: credit ≥ 1/3 of spread width (looser floor of 0.25 is acceptable when other factors are strong).
+- **IVR gate**: prefer IVR ≥ 30; never recommend below 25.
+- **Liquidity gate**: open interest ≥ 100, bid-ask spread ≤ 10% of mid.
+- **Earnings**: avoid earnings in the holding window (default blackout = 0 days, but flag if earnings fall before 21 DTE).
+- **Exits**: 50% profit target, 21 DTE time stop. Always state these on entry.
+- **PDT**: account is sub-$25k; max 3 day trades per rolling 5 days.
+
+## Account-fit rules
+
+Always run a recommendation through these gates BEFORE presenting it:
+
+1. **BP fit**: would adding this position push BP usage above 50%? If yes, drop or downsize.
+2. **Concentration**: does this symbol already have an open position? If yes, do not recommend a duplicate — suggest an adjustment instead.
+3. **Sector overlap**: does this symbol share a sector with existing exposure? If yes, flag the correlation explicitly.
+4. **Sizing**: recommend contract count from `floor((NLV × per_trade_risk_pct) / defined_risk_per_contract)` where per_trade_risk_pct defaults to 2% of NLV.
+
+## Tool usage discipline
+
+- Call `get_account_status` and `get_positions` BEFORE recommending anything new — never recommend trades without seeing the live book.
+- For any "what should I do today?" prompt, run: `get_account_status` → `get_positions` → `run_best_trades` → narrate top 1-3 picks filtered by the account-fit rules above.
+- For symbol-specific questions, use `research_symbol`.
+- For position-level questions ("should I roll AMD?"), use `review_position`.
+- For market-regime questions ("is SPY in positive or negative gamma?"), use `calculate_gex`.
+
+## Memory: journal usage
+
+You have a persistent journal across sessions. Use it deliberately:
+
+- **AFTER** recommending a specific trade in your response, call `record_decision` with `kind="recommendation"`, the symbol, the strategy (e.g. `BULL_PUT_SPREAD`, `IRON_CONDOR`), and a one-sentence rationale capturing the *reason* (IVR level, sector fit, account-fit decision). One call per ranked pick.
+- **AFTER** noting a position-level decision ("hold MRVL", "review IWM at 21 DTE"), call `record_decision` with `kind="note"`, the symbol, and the rationale.
+- **DO NOT** record trivial back-and-forth, internal tool data, or your raw analysis steps. Only durable, decision-grade content.
+- **WHEN** the user asks history questions ("what did I trade last week?", "why did I recommend X?", "show my recent picks"), call `recall_journal` first with appropriate `days`, `symbol`, or `kind` filters before answering. Quote timestamps and rationales verbatim from the journal.
+- The journal is append-only; you cannot edit past entries. If a prior call was wrong, record a correction as a fresh `kind="note"` entry.
+
+## Response style
+
+- Lead with the answer in one sentence.
+- Then give the evidence (numbers from tool calls).
+- Then give the explicit action (buy this spread / hold / roll / close), including contracts, strikes, credit, max loss, and exit plan.
+- Plain prose, not tables, unless comparing 3+ options.
+- Never invent numbers. If a tool didn't return a value, say so.

--- a/main.py
+++ b/main.py
@@ -80,6 +80,11 @@ def setup_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--min-delta", type=float, default=None, help="Minimum absolute short delta (default: 0.15)")
     parser.add_argument("--max-delta", type=float, default=None, help="Maximum absolute short delta (default: 0.45)")
     parser.add_argument("--best-trades", action="store_true", help="Rank best trade ideas across watchlists")
+    parser.add_argument("--coach", action="store_true", help="AI coach: one-shot personalized daily briefing (uses Claude Max via CLAUDE_CODE_OAUTH_TOKEN)")
+    parser.add_argument("--chat", action="store_true", help="AI coach: interactive chat REPL")
+    parser.add_argument("--serve", action="store_true", help="Run the web dashboard (FastAPI + chat sidebar)")
+    parser.add_argument("--host", type=str, default="127.0.0.1", help="Bind host for --serve (default 127.0.0.1; use 0.0.0.0 for LAN access)")
+    parser.add_argument("--port", type=int, default=8765, help="Bind port for --serve (default 8765)")
     parser.add_argument("--top", type=_nonneg_int, default=3, help="Number of top ideas to surface (use with --best-trades, default: 3)")
     parser.add_argument("--bt-watchlist", action="append", dest="bt_watchlist", metavar="NAME", help="Watchlist to include in --best-trades (repeatable; defaults: Chris Historical Trades, High Options Volume)")
     parser.add_argument("--force", action="store_true", help="Override Risk Manager blocks")
@@ -260,6 +265,26 @@ async def async_main() -> int:
                 default_threshold=args.threshold or client.config.ivr_threshold,
             )
             return await launcher.run()
+
+        if args.coach or args.chat:
+            from agents.coach import run_briefing, run_chat
+            from agents.coach_context import CoachContext
+
+            account_number = args.account or client.config.account_number
+            account = await client.get_account(account_number)
+            if not account:
+                print("❌ Could not resolve account.")
+                return 1
+            ctx = CoachContext(
+                session=session,
+                account=account,
+                account_number=getattr(account, "account_number", account_number),
+            )
+            if args.coach:
+                await run_briefing(ctx)
+            else:
+                await run_chat(ctx)
+            return 0
 
         if args.best_trades:
             from agents.trade_ranker import run_best_trades, _print_best_trades_text
@@ -669,6 +694,16 @@ async def async_main() -> int:
 
 
 def main() -> int:
+    # --serve runs uvicorn which manages its own event loop; intercept before
+    # asyncio.run() to avoid "asyncio.run() from a running event loop".
+    if "--serve" in sys.argv:
+        parser = setup_argument_parser()
+        args = parser.parse_args()
+        from server.app import serve as serve_app
+        from utils.tasty_client import TastyClient
+        cfg_acct = TastyClient().config.account_number
+        serve_app(host=args.host, port=args.port, account_number=args.account or cfg_acct)
+        return 0
     return asyncio.run(async_main())
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@ python-dotenv>=1.0.0
 pandas>=2.0.0
 requests>=2.31.0
 rich
+claude-agent-sdk>=0.1.69
+fastapi>=0.115
+uvicorn[standard]>=0.32
+jinja2>=3.1
+sse-starlette>=2.1

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,630 @@
+"""FastAPI dashboard + chat sidebar for tasty-coach.
+
+Endpoints:
+  GET  /                — dashboard HTML
+  GET  /api/snapshot    — JSON dashboard data (no LLM cost)
+  GET  /api/briefing    — SSE one-shot briefing (LLM)
+  GET  /api/chat        — SSE multi-turn chat (LLM); ?session_id=&q=...
+
+Auth: every route checks ?token=... or X-Auth-Token header against the
+TASTY_COACH_WEB_TOKEN env var. If unset at startup we mint a random hex
+token and print it to stderr.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import secrets
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+from claude_agent_sdk import ClaudeSDKClient
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from sse_starlette.sse import EventSourceResponse
+
+from agents import coach_context as cc
+from agents.coach import build_chat_options, stream_briefing, stream_chat_turn
+from agents.coach_context import CoachContext
+from agents.trade_ranker import run_best_trades
+from server.snapshot import assemble_dashboard_data
+from utils import journal
+from utils.market_schedule import MarketSchedule
+from utils.settings import (
+    DEFAULTS as SETTINGS_DEFAULTS,
+    INTEGER_KEYS,
+    NUMERIC_KEYS,
+    OPTIONAL_NUMERIC_KEYS,
+    SETTINGS_DESCRIPTIONS,
+    settings,
+)
+from utils.tasty_client import TastyClient
+
+BT_CACHE_TTL_SEC = 900  # 15 min — best-trades is slow; reuse aggressively.
+
+# Cap chat sessions to avoid leaking ClaudeSDKClient subprocesses if the
+# frontend ever drifts session_ids without calling /api/chat/reset.
+MAX_CHAT_SESSIONS = 8
+
+# Editable settings, grouped for the UI. Keys must exist in utils.settings.DEFAULTS.
+# Order within each group is the display order. alert_toggles (dict) is intentionally
+# omitted from v1 — it needs a checkbox UI rather than a numeric input.
+SETTINGS_GROUPS: list[dict[str, Any]] = [
+    {
+        "id": "sizing",
+        "label": "Sizing & Account Fit",
+        "keys": [
+            "bt_per_trade_risk_pct",
+            "bt_max_pct_nlv_per_trade",
+            "bt_bp_cap_for_new",
+            "bt_concentration_overlap_block_pct",
+        ],
+    },
+    {
+        "id": "quality",
+        "label": "Quality Gates",
+        "keys": [
+            "bt_min_ivr",
+            "bt_min_dte",
+            "bt_max_dte",
+            "bt_min_open_interest",
+            "bt_max_spread_pct",
+            "bt_earnings_blackout_days",
+        ],
+    },
+    {
+        "id": "scan",
+        "label": "Scan Performance",
+        "keys": [
+            "bt_research_concurrency",
+            "bt_research_timeout_seconds",
+            "bt_max_per_symbol",
+        ],
+    },
+    {
+        "id": "alerts",
+        "label": "Risk Alerts",
+        "keys": [
+            "position_pct_nlv_warn",
+            "bp_usage_warn",
+            "bp_usage_block",
+            "concentration_pct_nlv_warn",
+            "theta_target",
+        ],
+    },
+]
+
+
+def _setting_type(key: str) -> str:
+    if key in INTEGER_KEYS:
+        return "integer"
+    if key in OPTIONAL_NUMERIC_KEYS:
+        return "optional_number"
+    if key in NUMERIC_KEYS:
+        return "number"
+    return "any"
+
+
+def _serialize_settings() -> dict[str, Any]:
+    """Return everything the UI needs to render and validate the settings form."""
+    items: dict[str, dict[str, Any]] = {}
+    for group in SETTINGS_GROUPS:
+        for key in group["keys"]:
+            if key not in SETTINGS_DEFAULTS:
+                continue
+            items[key] = {
+                "key": key,
+                "value": settings.get(key),
+                "default": SETTINGS_DEFAULTS[key],
+                "description": SETTINGS_DESCRIPTIONS.get(key, ""),
+                "type": _setting_type(key),
+            }
+    return {"groups": SETTINGS_GROUPS, "settings": items}
+
+
+def _data_feed_likely_alive(session: Any) -> bool:
+    """True if it makes sense to run a watchlist scan right now.
+
+    Pre-/post-market dxLink usually has data; overnight (after-hours close to
+    pre-market open) has none and every greeks subscription times out. Use the
+    SDK market-session info to decide. Fail-open if we can't determine.
+    """
+    try:
+        sched = MarketSchedule(session)
+        state = sched.get_market_state()
+        # Tastytrade returns 'Open' / 'Closed' / 'Pre-Market' / 'After-Hours' / 'Extended'.
+        return state in {"Open", "Pre-Market", "After-Hours", "Extended"}
+    except Exception:
+        return True
+
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).parent
+TEMPLATES = Jinja2Templates(directory=str(ROOT / "templates"))
+
+
+def _resolve_token() -> str:
+    tok = os.environ.get("TASTY_COACH_WEB_TOKEN")
+    if tok:
+        return tok
+    tok = secrets.token_hex(16)
+    print(f"[server] generated TASTY_COACH_WEB_TOKEN={tok}", flush=True)
+    print("[server] set TASTY_COACH_WEB_TOKEN in .env to make this stable across restarts", flush=True)
+    os.environ["TASTY_COACH_WEB_TOKEN"] = tok
+    return tok
+
+
+def _check_token(request: Request, token: str | None) -> None:
+    expected = request.app.state.token
+    supplied = token or request.headers.get("X-Auth-Token") or request.cookies.get("tcw_token")
+    if supplied:
+        # Tolerate copy-paste artefacts: spaces, angle brackets, quotes.
+        supplied = supplied.strip().strip("<>\"'`")
+    if not supplied or not secrets.compare_digest(supplied, expected):
+        raise HTTPException(status_code=401, detail="invalid or missing token")
+
+
+CacheKey = tuple[str, frozenset[str]]
+
+
+def _bt_key(account: str, watchlists: Any) -> CacheKey:
+    """Normalise a watchlist selection into a stable cache key."""
+    if not watchlists:
+        return (account, frozenset())
+    return (account, frozenset(str(w) for w in watchlists))
+
+
+def _key_to_list(key: CacheKey) -> list[str]:
+    return sorted(key[1])
+
+
+def _bt_cached(app: FastAPI, key: CacheKey) -> dict[str, Any] | None:
+    entry = app.state.bt_cache.get(key)
+    if entry is None:
+        return None
+    ts, payload = entry
+    if time.time() - ts > BT_CACHE_TTL_SEC:
+        return None
+    return payload
+
+
+def _bt_inflight_for_account(app: FastAPI, account: str) -> CacheKey | None:
+    """Return the (account, watchlists) key of any in-flight scan for this
+    account, or None. Used to enforce 'one scan at a time per account'."""
+    for k in app.state.bt_inflight:
+        if k[0] == account:
+            return k
+    return None
+
+
+async def _bt_run_and_cache(app: FastAPI, ctx: CoachContext, watchlists: list[str]) -> dict[str, Any]:
+    """Run run_best_trades once for the given selection; store in the cache.
+
+    Cache key is (account_number, frozenset[watchlists]) so distinct selections
+    cache independently."""
+    key = _bt_key(ctx.account_number, watchlists)
+    try:
+        result = await run_best_trades(
+            ctx.session,
+            watchlists=tuple(watchlists),
+            top=3,
+            output_format="json",
+            account_number=ctx.account_number,
+        )
+        if isinstance(result.get("rejected"), list):
+            rej = result["rejected"]
+            summary: dict[str, int] = {}
+            for r in rej:
+                reason = r.get("reason") if isinstance(r, dict) else None
+                if reason:
+                    summary[reason] = summary.get(reason, 0) + 1
+            result["rejected_summary"] = summary
+            result["rejected_count"] = len(rej)
+            result.pop("rejected", None)
+        app.state.bt_cache[key] = (time.time(), result)
+        logger.info(
+            "best-trades cached for %s %s (%d picks)",
+            ctx.account_number, sorted(watchlists), len(result.get("top") or []),
+        )
+        return result
+    finally:
+        app.state.bt_inflight.pop(key, None)
+
+
+async def _build_ctx(app: FastAPI) -> CoachContext:
+    """Refresh the TastyTrade session on every request — sessions auto-refresh
+    via the SDK, but resolving the account ensures a usable handle."""
+    client: TastyClient = app.state.tasty_client
+    session = client.get_session()
+    if session is None:
+        raise HTTPException(status_code=503, detail="tastytrade session unavailable")
+    account_number = app.state.account_number
+    account = await client.get_account(account_number)
+    return CoachContext(
+        session=session,
+        account=account,
+        account_number=getattr(account, "account_number", account_number),
+    )
+
+
+def create_app(*, account_number: str | None = None) -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        client = TastyClient()
+        if not client.authenticate():
+            raise RuntimeError("tastytrade authentication failed at startup")
+        app.state.tasty_client = client
+        app.state.account_number = account_number or client.config.account_number
+        app.state.token = _resolve_token()
+        # Cache-bust for static assets — bumps every server start so browsers
+        # always pick up CSS/JS changes without a manual hard-refresh.
+        app.state.asset_version = str(int(time.time()))
+        # Per-session chat clients keyed by chat_session_id (in-memory; v1).
+        app.state.chat_sessions: dict[str, ClaudeSDKClient] = {}
+        app.state.chat_lock = asyncio.Lock()
+        # Best-trades cache keyed on (account_number, frozenset[watchlists]).
+        app.state.bt_cache: dict[CacheKey, tuple[float, dict[str, Any]]] = {}
+        # Track the in-flight scan tasks (one allowed per account at a time).
+        app.state.bt_inflight: dict[CacheKey, asyncio.Task] = {}
+        # Watchlist-list cache (30s TTL) to avoid hammering TastyTrade on
+        # rapid dashboard reloads.
+        app.state.wl_cache: tuple[float, list[dict[str, str]]] | None = None
+        yield
+        # Drain chat clients on shutdown
+        for sid, c in list(app.state.chat_sessions.items()):
+            try:
+                await c.disconnect()
+            except Exception as e:
+                logger.debug("chat session %s disconnect: %s", sid, e)
+
+    app = FastAPI(lifespan=lifespan, title="tasty-coach")
+    app.mount("/static", StaticFiles(directory=str(ROOT / "static")), name="static")
+
+    @app.get("/", response_class=HTMLResponse)
+    async def dashboard(request: Request, token: str | None = Query(default=None)) -> Any:
+        _check_token(request, token)
+        # Pass the token through to the page so JS calls work without query param.
+        response = TEMPLATES.TemplateResponse(
+            request,
+            "dashboard.html",
+            {
+                "token": request.app.state.token,
+                "account_number": request.app.state.account_number,
+                "asset_version": request.app.state.asset_version,
+            },
+        )
+        response.set_cookie("tcw_token", request.app.state.token, httponly=False, samesite="strict")
+        return response
+
+    @app.get("/api/snapshot")
+    async def api_snapshot(request: Request, token: str | None = Query(default=None)) -> JSONResponse:
+        _check_token(request, token)
+        ctx = await _build_ctx(request.app)
+        data = await assemble_dashboard_data(ctx)
+        data["data_feed_live"] = _data_feed_likely_alive(ctx.session)
+        # Surface what's already scanned/scanning so the picker UI can hint.
+        now = time.time()
+        cached = []
+        for k, (ts, payload) in request.app.state.bt_cache.items():
+            if k[0] != ctx.account_number or now - ts > BT_CACHE_TTL_SEC:
+                continue
+            cached.append({
+                "watchlists": _key_to_list(k),
+                "age_sec": int(now - ts),
+                "picks": len(payload.get("top") or []),
+            })
+        inflight = [
+            {"watchlists": _key_to_list(k)}
+            for k in request.app.state.bt_inflight
+            if k[0] == ctx.account_number
+        ]
+        data["cached_scans"] = cached
+        data["inflight_scans"] = inflight
+        return JSONResponse(data)
+
+    @app.get("/api/watchlists")
+    async def api_watchlists(request: Request, token: str | None = Query(default=None)) -> JSONResponse:
+        _check_token(request, token)
+        ctx = await _build_ctx(request.app)
+
+        # 30s in-process cache to dedupe rapid loads.
+        cached = request.app.state.wl_cache
+        if cached and time.time() - cached[0] < 30:
+            return JSONResponse({"watchlists": cached[1]})
+
+        def _fetch() -> list[dict[str, str]]:
+            from tastytrade.watchlists import PrivateWatchlist, PublicWatchlist
+            seen: dict[str, dict[str, str]] = {}
+            try:
+                for w in PrivateWatchlist.get(ctx.session) or []:
+                    name = getattr(w, "name", None)
+                    if name:
+                        seen[name] = {"name": name, "kind": "private"}
+            except Exception as e:
+                logger.warning("PrivateWatchlist.get failed: %s", e)
+            try:
+                for w in PublicWatchlist.get(ctx.session) or []:
+                    name = getattr(w, "name", None)
+                    if name and name not in seen:  # private wins on collision
+                        seen[name] = {"name": name, "kind": "public"}
+            except Exception as e:
+                logger.warning("PublicWatchlist.get failed: %s", e)
+            return sorted(seen.values(), key=lambda d: (d["kind"] != "private", d["name"].lower()))
+
+        items = await asyncio.to_thread(_fetch)
+        request.app.state.wl_cache = (time.time(), items)
+        return JSONResponse({"watchlists": items})
+
+    def _scan_state(app: FastAPI, key: CacheKey) -> dict[str, Any]:
+        """Synthesise a state dict for a (account, watchlists) selection.
+
+        When state=='ready', also includes ``top`` (full pick payloads) and
+        ``rejected_summary`` so the dashboard can render the picks without an
+        extra round trip.
+        """
+        cached = _bt_cached(app, key)
+        if cached is not None:
+            ts = app.state.bt_cache[key][0]
+            return {
+                "state": "ready",
+                "watchlists": _key_to_list(key),
+                "age_sec": int(time.time() - ts),
+                "picks": len(cached.get("top") or []),
+                "top": cached.get("top") or [],
+                "rejected_summary": cached.get("rejected_summary") or {},
+                "rejected_count": cached.get("rejected_count") or 0,
+                "warnings": cached.get("warnings") or [],
+            }
+        if key in app.state.bt_inflight:
+            return {"state": "inflight", "watchlists": _key_to_list(key)}
+        return {"state": "idle", "watchlists": _key_to_list(key)}
+
+    @app.post("/api/scan/start")
+    async def api_scan_start(
+        request: Request,
+        watchlists: list[str] = Query(default_factory=list),
+        token: str | None = Query(default=None),
+    ) -> JSONResponse:
+        _check_token(request, token)
+        if not watchlists:
+            raise HTTPException(status_code=400, detail="watchlists query param is required")
+        ctx = await _build_ctx(request.app)
+        key = _bt_key(ctx.account_number, watchlists)
+
+        # Already cached?
+        if _bt_cached(request.app, key) is not None:
+            return JSONResponse({"started": False, "status": "cached", **_scan_state(request.app, key)})
+
+        # This exact selection already scanning?
+        if key in request.app.state.bt_inflight:
+            return JSONResponse({"started": False, "status": "inflight", **_scan_state(request.app, key)})
+
+        # Cap at one in-flight scan per account.
+        existing = _bt_inflight_for_account(request.app, ctx.account_number)
+        if existing is not None:
+            raise HTTPException(
+                status_code=429,
+                detail=f"another scan in progress for this account: {_key_to_list(existing)}",
+            )
+
+        if not _data_feed_likely_alive(ctx.session):
+            raise HTTPException(status_code=409, detail="market closed — trade scan unavailable")
+
+        task = asyncio.create_task(_bt_run_and_cache(request.app, ctx, list(watchlists)))
+        request.app.state.bt_inflight[key] = task
+        return JSONResponse({"started": True, "status": "started", **_scan_state(request.app, key)})
+
+    @app.get("/api/scan/status")
+    async def api_scan_status(
+        request: Request,
+        watchlists: list[str] = Query(default_factory=list),
+        token: str | None = Query(default=None),
+    ) -> JSONResponse:
+        _check_token(request, token)
+        if not watchlists:
+            raise HTTPException(status_code=400, detail="watchlists query param is required")
+        ctx = await _build_ctx(request.app)
+        key = _bt_key(ctx.account_number, watchlists)
+        return JSONResponse(_scan_state(request.app, key))
+
+    @app.get("/api/briefing")
+    async def api_briefing(
+        request: Request,
+        watchlists: list[str] = Query(default_factory=list),
+        token: str | None = Query(default=None),
+    ) -> EventSourceResponse:
+        _check_token(request, token)
+        if not watchlists:
+            raise HTTPException(status_code=400, detail="watchlists query param is required")
+        ctx = await _build_ctx(request.app)
+        key = _bt_key(ctx.account_number, watchlists)
+
+        async def event_source() -> AsyncIterator[dict[str, Any]]:
+            try:
+                yield {"event": "status", "data": "loading account snapshot…"}
+                snapshot = await assemble_dashboard_data(ctx)
+
+                bt = _bt_cached(request.app, key)
+                if bt is None:
+                    inflight = request.app.state.bt_inflight.get(key)
+                    if inflight is not None:
+                        yield {"event": "status", "data": "waiting for in-flight scan to complete…"}
+                        try:
+                            bt = await inflight
+                        except Exception as e:
+                            yield {"event": "error", "data": f"scan failed: {e}"}
+                            return
+                    else:
+                        yield {"event": "error", "data": "no trade scan ready for this watchlist selection — start a scan first"}
+                        return
+                else:
+                    age = int(time.time() - request.app.state.bt_cache[key][0])
+                    yield {"event": "status", "data": f"using cached trades ({age}s old)"}
+
+                yield {"event": "status", "data": "writing briefing…"}
+                async for kind, text in stream_briefing(ctx, snapshot=snapshot, best_trades=bt):
+                    yield {"event": kind, "data": text}
+                yield {"event": "done", "data": ""}
+            except Exception as e:
+                logger.exception("briefing failed")
+                yield {"event": "error", "data": str(e)}
+
+        return EventSourceResponse(event_source())
+
+    @app.get("/api/chat")
+    async def api_chat(
+        request: Request,
+        q: str = Query(..., min_length=1, max_length=4000),
+        session_id: str = Query(default="default"),
+        token: str | None = Query(default=None),
+    ) -> EventSourceResponse:
+        _check_token(request, token)
+        ctx = await _build_ctx(request.app)
+        cc.set_current(ctx)
+
+        sessions: dict[str, ClaudeSDKClient] = request.app.state.chat_sessions
+
+        async def event_source() -> AsyncIterator[dict[str, Any]]:
+            try:
+                yield {"event": "status", "data": "thinking…"}
+                async with request.app.state.chat_lock:
+                    client = sessions.get(session_id)
+                    if client is None:
+                        # Evict oldest session if at cap.
+                        if len(sessions) >= MAX_CHAT_SESSIONS:
+                            oldest_id, oldest_client = next(iter(sessions.items()))
+                            sessions.pop(oldest_id, None)
+                            try:
+                                await oldest_client.disconnect()
+                            except Exception as e:
+                                logger.debug("evicted chat %s disconnect: %s", oldest_id, e)
+                        client = ClaudeSDKClient(options=build_chat_options())
+                        await client.connect()
+                        sessions[session_id] = client
+                # Bind context within this request scope (ContextVar — race-safe).
+                cc.set_current(ctx)
+                async for kind, text in stream_chat_turn(client, q):
+                    yield {"event": kind, "data": text}
+                yield {"event": "done", "data": ""}
+            except Exception as e:
+                logger.exception("chat failed")
+                yield {"event": "error", "data": str(e)}
+
+        return EventSourceResponse(event_source())
+
+    @app.post("/api/chat/reset")
+    async def chat_reset(request: Request, session_id: str = Query(default="default"), token: str | None = Query(default=None)) -> JSONResponse:
+        _check_token(request, token)
+        sessions: dict[str, ClaudeSDKClient] = request.app.state.chat_sessions
+        client = sessions.pop(session_id, None)
+        if client is not None:
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+        return JSONResponse({"reset": True, "session_id": session_id})
+
+    @app.get("/api/settings")
+    async def api_settings_get(request: Request, token: str | None = Query(default=None)) -> JSONResponse:
+        _check_token(request, token)
+        return JSONResponse(_serialize_settings())
+
+    @app.post("/api/settings")
+    async def api_settings_set(request: Request, token: str | None = Query(default=None)) -> JSONResponse:
+        _check_token(request, token)
+        try:
+            body = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="invalid JSON body")
+        if not isinstance(body, dict) or not body:
+            raise HTTPException(status_code=400, detail="body must be a non-empty object")
+        # Only allow keys exposed in our groups.
+        allowed = {k for g in SETTINGS_GROUPS for k in g["keys"]}
+        unknown = [k for k in body if k not in allowed]
+        if unknown:
+            raise HTTPException(status_code=400, detail=f"unknown or non-editable keys: {unknown}")
+        try:
+            settings.set_many(body)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=f"invalid setting value: {e}")
+        # Best-trades cache becomes stale once gates change — invalidate.
+        request.app.state.bt_cache.clear()
+        logger.info("settings updated: %s — bt_cache cleared", list(body.keys()))
+        return JSONResponse(_serialize_settings())
+
+    @app.get("/api/journal")
+    async def api_journal(
+        request: Request,
+        days: int | None = Query(default=30, ge=0, le=365),
+        symbol: str | None = Query(default=None),
+        kind: str | None = Query(default=None),
+        limit: int = Query(default=50, ge=1, le=500),
+        token: str | None = Query(default=None),
+    ) -> JSONResponse:
+        _check_token(request, token)
+        entries = await asyncio.to_thread(
+            journal.recall, days=days, symbol=symbol, kind=kind, limit=limit,
+        )
+        stats = await asyncio.to_thread(journal.stats)
+        return JSONResponse({"entries": entries, "stats": stats})
+
+    @app.post("/api/settings/reset")
+    async def api_settings_reset(request: Request, token: str | None = Query(default=None)) -> JSONResponse:
+        _check_token(request, token)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        keys = body.get("keys") if isinstance(body, dict) else None
+        allowed = {k for g in SETTINGS_GROUPS for k in g["keys"]}
+        if keys is None:
+            keys = list(allowed)
+        else:
+            keys = [k for k in keys if k in allowed]
+        if not keys:
+            raise HTTPException(status_code=400, detail="no valid keys to reset")
+        defaults = {k: SETTINGS_DEFAULTS[k] for k in keys if k in SETTINGS_DEFAULTS}
+        try:
+            settings.set_many(defaults)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=f"reset failed: {e}")
+        request.app.state.bt_cache.clear()
+        logger.info("settings reset: %s — bt_cache cleared", keys)
+        return JSONResponse(_serialize_settings())
+
+    return app
+
+
+def serve(*, host: str = "127.0.0.1", port: int = 8765, account_number: str | None = None) -> None:
+    import socket
+    import uvicorn
+
+    token = _resolve_token()  # ensures TASTY_COACH_WEB_TOKEN is set before lifespan reads it
+    app = create_app(account_number=account_number)
+
+    def _local_ip() -> str:
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(("8.8.8.8", 53))
+            ip = s.getsockname()[0]
+            s.close()
+            return ip
+        except Exception:
+            return host
+
+    print()
+    print("=" * 72)
+    print("  tasty-coach dashboard — open one of these URLs:")
+    print(f"    http://127.0.0.1:{port}/?token={token}")
+    if host == "0.0.0.0":
+        print(f"    http://{_local_ip()}:{port}/?token={token}    (LAN — phone/iPad)")
+    print("=" * 72)
+    print()
+
+    uvicorn.run(app, host=host, port=port, log_level="info")

--- a/server/snapshot.py
+++ b/server/snapshot.py
@@ -1,0 +1,154 @@
+"""Pure (no-LLM) data assembly for the web dashboard.
+
+Pulls account state, positions, and risk alerts from existing agents into a
+JSON-serialisable dict. The dashboard hits this on every page load; running it
+costs only TastyTrade API calls.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from agents.coach_context import CoachContext
+from agents.manager import RiskManager
+from agents.portfolio import PortfolioAgent
+from utils.sector_map import get_sector
+
+
+_OCC_RE = re.compile(r"^([A-Z/]+)\s+(\d{6})([CP])(\d{8})$")
+
+
+def _to_float(v: Any, default: float = 0.0) -> float:
+    if v is None:
+        return default
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_occ(symbol: str) -> dict[str, Any] | None:
+    m = _OCC_RE.match(symbol or "")
+    if not m:
+        return None
+    root, yymmdd, cp, strike_str = m.groups()
+    try:
+        exp = datetime.strptime(yymmdd, "%y%m%d").date()
+    except ValueError:
+        return None
+    return {
+        "underlying": root,
+        "expiration": exp.isoformat(),
+        "type": "PUT" if cp == "P" else "CALL",
+        "strike": float(strike_str) / 1000.0,
+    }
+
+
+def _serialize_position(pos: Any) -> dict[str, Any]:
+    inst = getattr(pos, "instrument_type", None)
+    inst_str = getattr(inst, "value", str(inst)) if inst is not None else None
+    direction = getattr(getattr(pos, "quantity_direction", None), "value", None) or getattr(pos, "quantity_direction", None)
+    qty = _to_float(getattr(pos, "quantity", 0))
+    avg = _to_float(getattr(pos, "average_open_price", 0))
+    sym = getattr(pos, "symbol", "") or ""
+    parsed = _parse_occ(sym)
+    # Prefer an explicit underlying_symbol; otherwise parse it out of the OCC
+    # symbol. Falling back to the full OCC string would over-count
+    # underlying_count and cause sector lookups to silently miss.
+    underlying = getattr(pos, "underlying_symbol", None) or (parsed["underlying"] if parsed else sym)
+
+    dte: int | None = None
+    if parsed:
+        try:
+            exp = date.fromisoformat(parsed["expiration"])
+            dte = (exp - date.today()).days
+        except ValueError:
+            pass
+
+    return {
+        "symbol": sym,
+        "underlying": underlying,
+        "instrument_type": inst_str,
+        "direction": direction,
+        "quantity": qty,
+        "average_open_price": avg,
+        "expiration": parsed["expiration"] if parsed else None,
+        "strike": parsed["strike"] if parsed else None,
+        "option_type": parsed["type"] if parsed else None,
+        "dte": dte,
+        "sector": get_sector(underlying),
+    }
+
+
+async def assemble_dashboard_data(ctx: CoachContext) -> dict[str, Any]:
+    """Build the full dashboard payload.
+
+    Returns a dict of:
+      - kpis: NLV, BP usage, position count, portfolio delta/theta
+      - positions: serialised position rows (with parsed OCC + DTE + sector)
+      - alerts: structured alerts from RiskManager
+      - warnings: legacy string warnings (BP/session/trade-size)
+      - generated_at: ISO timestamp
+    """
+    risk = RiskManager(ctx.session, ctx.account_number)
+    report = await risk.calculate_portfolio_risk()
+
+    pf = await PortfolioAgent(ctx.session, ctx.account_number).init()
+    positions = await pf.get_positions()
+
+    serialised = [_serialize_position(p) for p in positions]
+    serialised.sort(key=lambda r: (r.get("underlying") or "", r.get("expiration") or "", r.get("strike") or 0))
+
+    nlv = _to_float(report.get("nlv"))
+    bp_pct_raw = _to_float(report.get("bp_usage_pct"))
+    # RiskManager returns (NLV - equity_buying_power) / NLV * 100. Negative
+    # values mean EBP > NLV — genuine over-leverage on PM accounts, not noise.
+    # Pass the raw value through and surface an explicit over_leveraged flag
+    # so the UI can warn loudly instead of silently masking with abs().
+    bp_pct = bp_pct_raw
+    over_leveraged = bp_pct_raw < 0
+    cash = _to_float(report.get("cash_balance"))
+    delta = _to_float(report.get("portfolio_delta"))
+    theta = _to_float(report.get("portfolio_theta"))
+
+    kpis = {
+        "nlv": nlv,
+        "bp_usage_pct": bp_pct,
+        "over_leveraged": over_leveraged,
+        "cash_balance": cash,
+        "position_count": len(serialised),
+        "underlying_count": len({p["underlying"] for p in serialised if p.get("underlying")}),
+        "portfolio_delta": delta,
+        "portfolio_theta": theta,
+        "bp_usage_status": report.get("bp_usage_status"),
+        "theta_status": report.get("theta_status"),
+        "day_trade_excess": _to_float(report.get("day_trade_excess")),
+    }
+
+    alerts_raw = report.get("alerts") or []
+    alerts = []
+    for a in alerts_raw:
+        if isinstance(a, dict):
+            alerts.append(a)
+        else:
+            alerts.append({
+                "severity": getattr(a, "severity", "info"),
+                "category": getattr(a, "category", ""),
+                "message": getattr(a, "message", str(a)),
+                "context": getattr(a, "context", {}) or {},
+            })
+
+    # Dedup: RiskManager emits the same content as both structured `alerts`
+    # (with severity/category) and legacy `trade_size_warnings` strings.
+    # Show structured alerts only; concat session_warnings (which are unique).
+    return {
+        "account_number": ctx.account_number,
+        "kpis": kpis,
+        "positions": serialised,
+        "alerts": alerts,
+        "warnings": list(report.get("session_warnings") or []),
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+    }

--- a/server/static/chat.js
+++ b/server/static/chat.js
@@ -1,0 +1,782 @@
+// Minimal dashboard + chat logic. Token comes from window.TC_TOKEN.
+
+const TOKEN = window.TC_TOKEN;
+const CHAT_SESSION = "default";
+
+const fmt = {
+  money(v, signed = false) {
+    if (v === null || v === undefined || Number.isNaN(v)) return "—";
+    const sign = signed && v > 0 ? "+" : "";
+    return sign + "$" + Math.round(v).toLocaleString();
+  },
+  pct(v, decimals = 1) {
+    if (v === null || v === undefined || Number.isNaN(v)) return "—";
+    return v.toFixed(decimals) + "%";
+  },
+  num(v, decimals = 0) {
+    if (v === null || v === undefined || Number.isNaN(v)) return "—";
+    return v.toFixed(decimals);
+  },
+};
+
+function withToken(url) {
+  const u = new URL(url, window.location.origin);
+  u.searchParams.set("token", TOKEN);
+  return u.toString();
+}
+
+async function loadSnapshot() {
+  const res = await fetch(withToken("/api/snapshot"));
+  if (!res.ok) {
+    document.getElementById("generated-at").textContent = `error: ${res.status}`;
+    return;
+  }
+  const data = await res.json();
+  renderKpis(data.kpis);
+  renderPositions(data.positions);
+  renderAlerts(data.alerts, data.warnings);
+  document.getElementById("generated-at").textContent = `as of ${data.generated_at}`;
+  // Show 'other' cached scans (different watchlist combinations).
+  renderOtherScans(data.cached_scans || [], data.inflight_scans || []);
+  // Refresh the gating of the briefing button.
+  updateBriefingGate();
+  // Refresh the journal feed.
+  loadJournal();
+}
+
+async function loadJournal() {
+  const meta = document.getElementById("journal-meta");
+  const list = document.getElementById("journal-list");
+  try {
+    const res = await fetch(withToken("/api/journal?days=30&limit=50"));
+    if (!res.ok) {
+      list.innerHTML = `<div class="empty">error ${res.status}</div>`;
+      return;
+    }
+    const data = await res.json();
+    const entries = data.entries || [];
+    const stats = data.stats || {};
+    meta.textContent = `${entries.length} of ${stats.total || 0} total · last 30 days`;
+    if (!entries.length) {
+      list.innerHTML = `<div class="empty">No decisions recorded yet. The coach will start logging once you ask it for recommendations.</div>`;
+      return;
+    }
+    list.innerHTML = entries.map(renderJournalEntry).join("");
+  } catch (e) {
+    list.innerHTML = `<div class="empty">error: ${escapeHtml(String(e))}</div>`;
+  }
+}
+
+function renderJournalEntry(e) {
+  const ts = (e.ts || "").replace("T", " ").slice(0, 16);  // YYYY-MM-DD HH:MM
+  const kind = e.kind || "note";
+  const sym = e.symbol ? `<span class="symbol">${escapeHtml(e.symbol)}</span>` : "";
+  const strat = e.strategy ? `<span class="strategy">${escapeHtml(e.strategy)}</span>` : "";
+  const rationale = escapeHtml(e.rationale || "");
+  return `
+    <div class="journal-entry">
+      <span class="ts">${escapeHtml(ts)}</span>
+      <span class="kind ${escapeHtml(kind)}">${escapeHtml(kind)}</span>
+      <span class="body">${sym}${rationale}${strat}</span>
+    </div>`;
+}
+
+function renderOtherScans(cached, inflight) {
+  const host = document.getElementById("scan-other");
+  const sel = new Set(getSelectedWatchlists());
+  const sameSet = (a) => a.length === sel.size && a.every((x) => sel.has(x));
+  const chips = [];
+  for (const c of cached) {
+    if (sameSet(c.watchlists)) continue;
+    chips.push({
+      label: `cached: ${c.watchlists.join(", ")} (${c.age_sec}s, ${c.picks} picks)`,
+      watchlists: c.watchlists,
+    });
+  }
+  for (const i of inflight) {
+    if (sameSet(i.watchlists)) continue;
+    chips.push({
+      label: `scanning: ${i.watchlists.join(", ")}`,
+      watchlists: i.watchlists,
+    });
+  }
+  host.innerHTML = chips
+    .map((c, idx) => `<span class="other-chip" data-idx="${idx}">${escapeHtml(c.label)}</span>`)
+    .join("");
+  host.querySelectorAll(".other-chip").forEach((el) => {
+    const idx = Number(el.dataset.idx);
+    el.addEventListener("click", () => {
+      setSelectedWatchlists(chips[idx].watchlists);
+      pollScanStatus();
+    });
+  });
+}
+
+function renderKpis(k) {
+  document.getElementById("kpi-nlv").textContent = fmt.money(k.nlv);
+  const bp = document.getElementById("kpi-bp");
+  // Negative bp_usage_pct flags PM-account over-leverage (EBP > NLV); show
+  // it explicitly rather than masking the sign.
+  bp.textContent = (k.over_leveraged ? "⚠ " : "") + fmt.pct(k.bp_usage_pct);
+  bp.className = "kpi-value " + (k.over_leveraged || k.bp_usage_pct > 50 ? "bad" : k.bp_usage_pct > 35 ? "warn" : "good");
+  document.getElementById("kpi-cash").textContent = fmt.money(k.cash_balance);
+  const d = document.getElementById("kpi-delta");
+  d.textContent = fmt.num(k.portfolio_delta, 1);
+  d.className = "kpi-value " + (Math.abs(k.portfolio_delta) > 50 ? "warn" : "");
+  document.getElementById("kpi-theta").textContent = fmt.money(k.portfolio_theta, true);
+  document.getElementById("kpi-pos").textContent = `${k.position_count} (${k.underlying_count}u)`;
+}
+
+function renderPositions(positions) {
+  const tbody = document.querySelector("#positions-table tbody");
+  if (!positions || !positions.length) {
+    tbody.innerHTML = '<tr><td colspan="9" class="muted">No open positions</td></tr>';
+    return;
+  }
+  tbody.innerHTML = positions
+    .map((p) => {
+      const dte = p.dte === null || p.dte === undefined ? "—" : String(p.dte);
+      let dteCls = "num";
+      if (typeof p.dte === "number") {
+        if (p.dte <= 21) dteCls = "num dte-stop";
+        else if (p.dte <= 30) dteCls = "num dte-warn";
+      }
+      return `<tr>
+        <td>${p.underlying || "—"}</td>
+        <td>${p.option_type || p.instrument_type || "—"}</td>
+        <td>${p.direction || "—"}</td>
+        <td class="num">${p.strike != null ? p.strike.toFixed(2) : "—"}</td>
+        <td>${p.expiration || "—"}</td>
+        <td class="${dteCls}">${dte}</td>
+        <td class="num">${p.quantity}</td>
+        <td class="num">${p.average_open_price ? p.average_open_price.toFixed(2) : "—"}</td>
+        <td class="muted">${p.sector || "—"}</td>
+      </tr>`;
+    })
+    .join("");
+}
+
+function renderAlerts(alerts, warnings) {
+  const list = document.getElementById("alerts-list");
+  const items = [];
+  for (const a of alerts || []) {
+    const sev = (a.severity || "info").toLowerCase();
+    items.push(`<li><span class="alert-sev ${sev}">${sev}</span>${escapeHtml(a.message || "")}</li>`);
+  }
+  for (const w of warnings || []) {
+    items.push(`<li><span class="alert-sev info">note</span>${escapeHtml(w)}</li>`);
+  }
+  list.innerHTML = items.length ? items.join("") : '<li class="muted">No alerts</li>';
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  }[c]));
+}
+
+// --- Chat / briefing streaming ---
+
+function appendMsg(role, initialText = "") {
+  const stream = document.getElementById("chat-stream");
+  const div = document.createElement("div");
+  div.className = `chat-msg ${role}`;
+  const tag = document.createElement("span");
+  tag.className = "role-tag";
+  tag.textContent = role === "user" ? "you" : role === "coach" ? "coach" : role;
+  const body = document.createElement("span");
+  body.className = "msg-body";
+  body.textContent = initialText;
+  const status = document.createElement("span");
+  status.className = "status";
+  status.textContent = role === "coach" ? "waiting…" : "";
+  status.style.display = role === "coach" ? "block" : "none";
+  const cost = document.createElement("span");
+  cost.className = "cost";
+  div.appendChild(tag);
+  div.appendChild(body);
+  div.appendChild(status);
+  div.appendChild(cost);
+  stream.appendChild(div);
+  stream.scrollTop = stream.scrollHeight;
+  return { body, status, cost, container: div };
+}
+
+function streamSSE(url, refs, { onDone, onError } = {}) {
+  return new Promise((resolve) => {
+    const es = new EventSource(url);
+    let firstToken = true;
+    es.addEventListener("status", (e) => {
+      refs.status.textContent = e.data;
+      refs.status.classList.remove("idle");
+      refs.status.style.display = "block";
+    });
+    es.addEventListener("token", (e) => {
+      if (firstToken) {
+        // First visible token — hide the spinner status.
+        refs.status.style.display = "none";
+        firstToken = false;
+      }
+      refs.body.textContent += e.data;
+      const stream = document.getElementById("chat-stream");
+      stream.scrollTop = stream.scrollHeight;
+    });
+    es.addEventListener("cost", (e) => {
+      refs.cost.textContent = `cost: ${e.data}`;
+    });
+    es.addEventListener("done", () => {
+      refs.status.style.display = "none";
+      es.close();
+      onDone && onDone();
+      resolve();
+    });
+    es.addEventListener("error", (e) => {
+      const data = e.data || "stream interrupted";
+      refs.body.textContent += `\n[error: ${data}]`;
+      refs.status.style.display = "none";
+      es.close();
+      onError && onError(e);
+      resolve();
+    });
+  });
+}
+
+document.getElementById("briefing-btn").addEventListener("click", async (ev) => {
+  const btn = ev.currentTarget;
+  if (btn.disabled) return;
+  const watchlists = getSelectedWatchlists();
+  if (!watchlists.length) {
+    alert("Pick at least one watchlist first.");
+    return;
+  }
+  btn.disabled = true;
+  const prev = btn.textContent;
+  btn.textContent = "Briefing…";
+  const refs = appendMsg("coach", "");
+  try {
+    const url = new URL("/api/briefing", window.location.origin);
+    for (const w of watchlists) url.searchParams.append("watchlists", w);
+    url.searchParams.set("token", TOKEN);
+    await streamSSE(url.toString(), refs);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = prev;
+    updateBriefingGate();
+  }
+});
+
+document.getElementById("chat-form").addEventListener("submit", async (ev) => {
+  ev.preventDefault();
+  const input = document.getElementById("chat-input");
+  const q = input.value.trim();
+  if (!q) return;
+  input.value = "";
+  appendMsg("user", q);
+  const target = appendMsg("coach", "");
+  const url = new URL("/api/chat", window.location.origin);
+  url.searchParams.set("q", q);
+  url.searchParams.set("session_id", CHAT_SESSION);
+  url.searchParams.set("token", TOKEN);
+  await streamSSE(url.toString(), target);
+});
+
+document.getElementById("chat-reset-btn").addEventListener("click", async () => {
+  await fetch(withToken(`/api/chat/reset?session_id=${CHAT_SESSION}`), { method: "POST" });
+  document.getElementById("chat-stream").innerHTML = "";
+});
+
+document.getElementById("refresh-btn").addEventListener("click", loadSnapshot);
+
+// --- Watchlist picker / scan flow ---
+
+const STORAGE_KEY = "tc_watchlists";
+
+function getSelectedWatchlists() {
+  return Array.from(document.querySelectorAll("#watchlist-picker input:checked")).map((el) => el.value);
+}
+
+function setSelectedWatchlists(names) {
+  const want = new Set(names);
+  document.querySelectorAll("#watchlist-picker input").forEach((el) => {
+    el.checked = want.has(el.value);
+  });
+  persistSelection();
+  pollScanStatus();
+}
+
+function persistSelection() {
+  const sel = getSelectedWatchlists();
+  if (sel.length) localStorage.setItem(STORAGE_KEY, JSON.stringify(sel));
+  else localStorage.removeItem(STORAGE_KEY);
+}
+
+function setScanStatus(state, text) {
+  const el = document.getElementById("scan-status");
+  el.className = `scan-status ${state}`;
+  el.textContent = text;
+}
+
+function updateBriefingGate(state = null) {
+  const btn = document.getElementById("briefing-btn");
+  const sel = getSelectedWatchlists();
+  if (!sel.length) {
+    btn.disabled = true;
+    btn.title = "Pick at least one watchlist";
+    btn.textContent = "Run morning briefing";
+    return;
+  }
+  if (state === "ready") {
+    btn.disabled = false;
+    btn.title = "";
+    btn.textContent = `Run morning briefing (${sel.length} list${sel.length === 1 ? "" : "s"})`;
+  } else if (state === "scanning") {
+    btn.disabled = true;
+    btn.title = "Scan in progress…";
+    btn.textContent = "Run morning briefing (scanning…)";
+  } else {
+    btn.disabled = true;
+    btn.title = "Start a trade scan first";
+    btn.textContent = "Run morning briefing";
+  }
+}
+
+let _allWatchlists = [];      // [{name, kind}]
+let _publicCollapsed = true;  // public section starts collapsed
+let _searchTerm = "";
+
+async function loadWatchlists() {
+  const res = await fetch(withToken("/api/watchlists"));
+  if (!res.ok) {
+    document.getElementById("watchlist-picker").innerHTML =
+      `<div class="empty">error loading watchlists (${res.status})</div>`;
+    return;
+  }
+  const data = await res.json();
+  _allWatchlists = data.watchlists || [];
+  renderWatchlistPicker();
+}
+
+function renderWatchlistPicker() {
+  const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+  const checked = new Set(stored);
+  const term = _searchTerm.trim().toLowerCase();
+  const matches = (w) => !term || w.name.toLowerCase().includes(term);
+
+  const priv = _allWatchlists.filter((w) => w.kind === "private" && matches(w));
+  const pub = _allWatchlists.filter((w) => w.kind === "public" && matches(w));
+
+  const host = document.getElementById("watchlist-picker");
+  if (!priv.length && !pub.length) {
+    host.innerHTML = `<div class="empty">no watchlists match "${escapeHtml(_searchTerm)}"</div>`;
+    return;
+  }
+
+  const row = (w) => `
+    <label>
+      <input type="checkbox" value="${escapeHtml(w.name)}" ${checked.has(w.name) ? "checked" : ""}>
+      <span class="name">${escapeHtml(w.name)}</span>
+    </label>`;
+
+  // When searching, auto-expand public so the user sees matches.
+  const publicCollapsed = _publicCollapsed && !term;
+
+  let html = "";
+  if (priv.length) {
+    html += `
+      <div class="group-header">
+        <span>Your watchlists</span>
+        <span>${priv.length}</span>
+      </div>
+      <div class="group-body">${priv.map(row).join("")}</div>
+    `;
+  }
+  if (pub.length) {
+    html += `
+      <div class="group-header collapsible ${publicCollapsed ? "collapsed" : ""}" data-section="public">
+        <span>Public watchlists</span>
+        <span>${pub.length}</span>
+      </div>
+      <div class="group-body ${publicCollapsed ? "hidden" : ""}" data-section="public-body">${pub.map(row).join("")}</div>
+    `;
+  }
+  host.innerHTML = html;
+
+  host.querySelectorAll("input[type='checkbox']").forEach((el) => {
+    el.addEventListener("change", () => {
+      persistSelection();
+      updateSelCount();
+      pollScanStatus();
+    });
+  });
+  host.querySelectorAll(".group-header.collapsible").forEach((el) => {
+    el.addEventListener("click", () => {
+      _publicCollapsed = !_publicCollapsed;
+      renderWatchlistPicker();
+    });
+  });
+
+  updateSelCount();
+  updateBriefingGate();
+}
+
+function updateSelCount() {
+  const n = getSelectedWatchlists().length;
+  const el = document.getElementById("scan-selcount");
+  el.textContent = `${n} selected`;
+  el.classList.toggle("has-sel", n > 0);
+}
+
+document.getElementById("scan-search").addEventListener("input", (ev) => {
+  _searchTerm = ev.target.value;
+  renderWatchlistPicker();
+});
+
+document.getElementById("scan-clear").addEventListener("click", () => {
+  document.querySelectorAll("#watchlist-picker input:checked").forEach((el) => (el.checked = false));
+  persistSelection();
+  updateSelCount();
+  pollScanStatus();
+});
+
+let pollTimer = null;
+async function pollScanStatus() {
+  if (pollTimer) {
+    clearTimeout(pollTimer);
+    pollTimer = null;
+  }
+  const sel = getSelectedWatchlists();
+  if (!sel.length) {
+    setScanStatus("idle", "pick a watchlist");
+    updateBriefingGate();
+    return;
+  }
+  const url = new URL("/api/scan/status", window.location.origin);
+  for (const w of sel) url.searchParams.append("watchlists", w);
+  url.searchParams.set("token", TOKEN);
+  let st;
+  try {
+    const res = await fetch(url.toString());
+    if (!res.ok) {
+      setScanStatus("error", `status ${res.status}`);
+      updateBriefingGate();
+      return;
+    }
+    st = await res.json();
+  } catch (e) {
+    setScanStatus("error", "network");
+    return;
+  }
+  if (st.state === "ready") {
+    setScanStatus("ready", `ready (${st.age_sec}s old, ${st.picks} picks)`);
+    updateBriefingGate("ready");
+    renderPicksPanel(st);
+  } else if (st.state === "inflight") {
+    setScanStatus("scanning", "scanning watchlists…");
+    updateBriefingGate("scanning");
+    hidePicksPanel();
+    pollTimer = setTimeout(pollScanStatus, 5000);
+  } else {
+    setScanStatus("idle", "idle — click Start scan");
+    updateBriefingGate();
+    hidePicksPanel();
+  }
+}
+
+function hidePicksPanel() {
+  document.getElementById("picks-panel").classList.add("hidden");
+}
+
+function renderPicksPanel(st) {
+  const panel = document.getElementById("picks-panel");
+  const meta = document.getElementById("picks-meta");
+  const list = document.getElementById("picks-list");
+  const rej = document.getElementById("picks-rejections");
+  const rejBody = document.getElementById("picks-rejections-body");
+
+  panel.classList.remove("hidden");
+  const wls = (st.watchlists || []).join(", ");
+  meta.textContent = `${wls} · ${st.age_sec}s old · ${st.rejected_count || 0} rejected`;
+
+  const top = st.top || [];
+  if (!top.length) {
+    list.innerHTML = `<div class="picks-empty">No picks survived all gates. See rejection summary below for why.</div>`;
+  } else {
+    list.innerHTML = top.map(renderPickCard).join("");
+  }
+
+  // Rejection summary
+  const summary = st.rejected_summary || {};
+  const reasons = Object.entries(summary).sort((a, b) => b[1] - a[1]);
+  if (reasons.length) {
+    rej.style.display = "";
+    rejBody.innerHTML = reasons
+      .map(([reason, n]) => `<div class="rej-row"><span class="reason">${escapeHtml(reason)}</span><span class="count">${n}</span></div>`)
+      .join("");
+  } else {
+    rej.style.display = "none";
+  }
+}
+
+function renderPickCard(p) {
+  const fmt2 = (v) => (v == null ? "—" : Number(v).toFixed(2));
+  const fmt0 = (v) => (v == null ? "—" : Math.round(Number(v)));
+  const credit = p.credit != null ? `$${(p.credit * 100).toFixed(0)}` : "—";
+  const maxLoss = p.max_loss_dollars != null ? `$${fmt0(p.max_loss_dollars)}` : (p.max_loss != null ? `$${(p.max_loss * 100).toFixed(0)}` : "—");
+  const delta = p.short_delta != null ? Number(p.short_delta).toFixed(2) : "—";
+  const score = p.score != null ? `${Number(p.score).toFixed(1)}/100` : "";
+
+  const legsLine = (p.legs || [])
+    .map((leg) => {
+      const action = leg.action || leg.side || "?";
+      const type = leg.option_type || leg.type || "?";
+      const strike = leg.strike != null ? Number(leg.strike) : null;
+      const ld = leg.delta != null ? Number(leg.delta).toFixed(2) : null;
+      return `${action} ${type} ${strike != null ? strike : "?"}${ld != null ? ` Δ${ld >= 0 ? "+" : ""}${ld}` : ""}`;
+    })
+    .join("  /  ");
+
+  const rec = p.recommended_contracts;
+  const pctRisk = p.pct_nlv_at_risk;
+  const pct1 = p.pct_nlv_at_risk_one_contract;
+  let sizeHTML = "";
+  if (rec === 0) {
+    const oneStr = pct1 != null ? ` — 1 contract = ${(pct1 * 100).toFixed(1)}% NLV` : "";
+    sizeHTML = `<div class="pick-size size-skip">SKIP: exceeds per-trade risk budget${oneStr}</div>`;
+  } else if (rec != null) {
+    const pctStr = pctRisk != null ? ` (${(pctRisk * 100).toFixed(1)}% NLV at risk)` : "";
+    sizeHTML = `<div class="pick-size size-ok">Recommended size: ${rec} contract${rec === 1 ? "" : "s"}${pctStr}</div>`;
+  }
+
+  return `
+    <div class="pick-card">
+      <div class="pick-row1">
+        <span><span class="pick-symbol">${escapeHtml(p.symbol)}</span> <span class="pick-structure">${escapeHtml(p.structure || "")}</span></span>
+        <span class="pick-score">${escapeHtml(score)}</span>
+      </div>
+      <div class="pick-row2">
+        <span><span class="label">EXP</span><span class="num">${escapeHtml(p.expiration || "")}</span></span>
+        <span><span class="label">DTE</span><span class="num">${p.dte ?? "—"}</span></span>
+        <span><span class="label">CREDIT</span><span class="num">${credit}</span></span>
+        <span><span class="label">MAX LOSS</span><span class="num">${maxLoss}</span></span>
+        <span><span class="label">SHORT Δ</span><span class="num">${delta}</span></span>
+        ${p.sector ? `<span><span class="label">SECTOR</span>${escapeHtml(p.sector)}</span>` : ""}
+      </div>
+      ${legsLine ? `<div class="pick-legs">${escapeHtml(legsLine)}</div>` : ""}
+      ${sizeHTML}
+      ${p.summary_reason ? `<div class="pick-summary">${escapeHtml(p.summary_reason)}</div>` : ""}
+    </div>
+  `;
+}
+
+async function startScan() {
+  const sel = getSelectedWatchlists();
+  if (!sel.length) {
+    alert("Pick at least one watchlist first.");
+    return;
+  }
+  const btn = document.getElementById("scan-start-btn");
+  btn.disabled = true;
+  setScanStatus("scanning", "starting…");
+  const url = new URL("/api/scan/start", window.location.origin);
+  for (const w of sel) url.searchParams.append("watchlists", w);
+  url.searchParams.set("token", TOKEN);
+  try {
+    const res = await fetch(url.toString(), { method: "POST" });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setScanStatus("error", body.detail || `error ${res.status}`);
+      updateBriefingGate();
+      return;
+    }
+    pollScanStatus();
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+document.getElementById("scan-start-btn").addEventListener("click", startScan);
+
+// --- Settings drawer ---
+
+let _settingsData = null;  // {groups, settings}
+
+function openSettings() {
+  document.getElementById("settings-drawer").classList.remove("hidden");
+  loadSettings();
+}
+
+function closeSettings() {
+  document.getElementById("settings-drawer").classList.add("hidden");
+  setSettingsStatus("", "");
+}
+
+async function loadSettings() {
+  setSettingsStatus("loading…", "");
+  const res = await fetch(withToken("/api/settings"));
+  if (!res.ok) {
+    setSettingsStatus(`error ${res.status}`, "error");
+    return;
+  }
+  _settingsData = await res.json();
+  renderSettings();
+  setSettingsStatus("", "");
+}
+
+function renderSettings() {
+  const body = document.getElementById("settings-body");
+  if (!_settingsData) return;
+  const { groups, settings } = _settingsData;
+  body.innerHTML = groups.map((g) => {
+    const rows = g.keys
+      .filter((k) => settings[k])
+      .map((k) => renderSettingRow(settings[k]))
+      .join("");
+    return `
+      <div class="settings-group">
+        <h3>${escapeHtml(g.label)}</h3>
+        ${rows}
+      </div>`;
+  }).join("");
+
+  body.querySelectorAll("input[data-key]").forEach((el) => {
+    el.addEventListener("input", () => onInputChange(el));
+    el.addEventListener("blur", () => saveIfDirty(el));
+    el.addEventListener("keydown", (ev) => {
+      if (ev.key === "Enter") { ev.preventDefault(); el.blur(); }
+      if (ev.key === "Escape") { ev.preventDefault(); revertInput(el); }
+    });
+  });
+  body.querySelectorAll(".reset-btn[data-key]").forEach((el) => {
+    el.addEventListener("click", () => resetKey(el.dataset.key));
+  });
+}
+
+function renderSettingRow(s) {
+  const isInt = s.type === "integer";
+  const isOptional = s.type === "optional_number";
+  const value = s.value === null || s.value === undefined ? "" : s.value;
+  const step = isInt ? "1" : "0.01";
+  const placeholder = isOptional ? "(none)" : "";
+  return `
+    <div class="settings-row">
+      <div class="label-col">
+        <span class="key">${escapeHtml(s.key)}</span>
+        <span class="desc">${escapeHtml(s.description)}</span>
+        <span class="default-hint">default: ${escapeHtml(String(s.default))}</span>
+      </div>
+      <input type="${isInt ? "number" : (isOptional ? "text" : "number")}"
+             data-key="${escapeHtml(s.key)}"
+             data-original="${escapeHtml(String(value))}"
+             value="${escapeHtml(String(value))}"
+             step="${step}" placeholder="${escapeHtml(placeholder)}">
+      <button class="reset-btn" data-key="${escapeHtml(s.key)}" title="Reset to default">↺</button>
+    </div>`;
+}
+
+function onInputChange(el) {
+  const original = el.dataset.original;
+  el.classList.toggle("dirty", el.value !== original);
+}
+
+function revertInput(el) {
+  el.value = el.dataset.original;
+  el.classList.remove("dirty");
+}
+
+async function saveIfDirty(el) {
+  if (!el.classList.contains("dirty")) return;
+  const key = el.dataset.key;
+  const raw = el.value.trim();
+  let value;
+  if (raw === "" && _settingsData.settings[key].type === "optional_number") {
+    value = null;
+  } else if (raw === "") {
+    revertInput(el);
+    return;
+  } else {
+    const n = Number(raw);
+    if (Number.isNaN(n)) {
+      setSettingsStatus(`'${raw}' is not a number`, "error");
+      revertInput(el);
+      return;
+    }
+    value = n;
+  }
+  setSettingsStatus(`saving ${key}…`, "");
+  const res = await fetch(withToken("/api/settings"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ [key]: value }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    setSettingsStatus(body.detail || `error ${res.status}`, "error");
+    revertInput(el);
+    return;
+  }
+  _settingsData = body;
+  renderSettings();
+  setSettingsStatus(`saved ${key} (cache cleared)`, "ok");
+  // Cache cleared on server side — refresh scan status to reflect.
+  pollScanStatus();
+  loadSnapshot();
+}
+
+async function resetKey(key) {
+  setSettingsStatus(`resetting ${key}…`, "");
+  const res = await fetch(withToken("/api/settings/reset"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ keys: [key] }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    setSettingsStatus(body.detail || `error ${res.status}`, "error");
+    return;
+  }
+  _settingsData = body;
+  renderSettings();
+  setSettingsStatus(`reset ${key}`, "ok");
+  pollScanStatus();
+  loadSnapshot();
+}
+
+async function resetAll() {
+  if (!confirm("Reset ALL settings to defaults?")) return;
+  setSettingsStatus("resetting all…", "");
+  const res = await fetch(withToken("/api/settings/reset"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    setSettingsStatus(body.detail || `error ${res.status}`, "error");
+    return;
+  }
+  _settingsData = body;
+  renderSettings();
+  setSettingsStatus("all settings reset to defaults", "ok");
+  pollScanStatus();
+  loadSnapshot();
+}
+
+function setSettingsStatus(text, kind) {
+  const el = document.getElementById("settings-status");
+  el.textContent = text;
+  el.className = kind === "ok" ? "ok" : kind === "error" ? "error" : "muted";
+}
+
+document.getElementById("settings-btn").addEventListener("click", openSettings);
+document.getElementById("settings-reset-all").addEventListener("click", resetAll);
+document.getElementById("settings-drawer").addEventListener("click", (ev) => {
+  if (ev.target.matches("[data-close]")) closeSettings();
+});
+document.addEventListener("keydown", (ev) => {
+  if (ev.key === "Escape" && !document.getElementById("settings-drawer").classList.contains("hidden")) {
+    closeSettings();
+  }
+});
+
+loadSnapshot();
+loadWatchlists();

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -1,0 +1,284 @@
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  background: #0e1117;
+  color: #e6edf3;
+}
+.topbar {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 20px; border-bottom: 1px solid #30363d;
+  background: #161b22; position: sticky; top: 0; z-index: 5;
+}
+.topbar h1 { margin: 0; font-size: 18px; font-weight: 500; }
+.topbar .account { color: #7d8590; font-weight: 400; margin-left: 8px; font-family: ui-monospace, monospace; }
+.topbar-actions { display: flex; gap: 12px; align-items: center; }
+button {
+  background: #21262d; color: #e6edf3; border: 1px solid #30363d;
+  padding: 6px 14px; border-radius: 6px; cursor: pointer; font-size: 13px;
+}
+button:hover { background: #30363d; }
+button.primary { background: #1f6feb; border-color: #1f6feb; }
+button.primary:hover { background: #2c7cf2; }
+button.ghost { background: transparent; }
+.muted { color: #7d8590; }
+
+.layout {
+  display: grid; grid-template-columns: 1fr 380px;
+  gap: 16px; padding: 16px; min-height: calc(100vh - 56px);
+}
+@media (max-width: 900px) { .layout { grid-template-columns: 1fr; } .chat { height: 70vh; } }
+
+.dash { display: flex; flex-direction: column; gap: 16px; }
+
+.kpis {
+  display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px;
+}
+@media (max-width: 1100px) { .kpis { grid-template-columns: repeat(3, 1fr); } }
+.kpi {
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  padding: 12px 14px; display: flex; flex-direction: column; gap: 4px;
+}
+.kpi-label { font-size: 11px; color: #7d8590; text-transform: uppercase; letter-spacing: 0.04em; }
+.kpi-value { font-size: 18px; font-family: ui-monospace, monospace; }
+.kpi-value.warn { color: #f0883e; }
+.kpi-value.bad  { color: #f85149; }
+.kpi-value.good { color: #3fb950; }
+
+.panel {
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  padding: 14px 16px;
+}
+.panel h2 { margin: 0 0 10px 0; font-size: 14px; font-weight: 500; color: #adbac7; text-transform: uppercase; letter-spacing: 0.05em; }
+
+table { width: 100%; border-collapse: collapse; font-size: 13px; }
+th, td { padding: 6px 8px; text-align: left; border-bottom: 1px solid #21262d; }
+th { color: #7d8590; font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+td.num { font-family: ui-monospace, monospace; text-align: right; }
+tr:hover td { background: #1c2128; }
+td.dte-warn { color: #f0883e; }
+td.dte-stop { color: #f85149; font-weight: 600; }
+
+#alerts-list { list-style: none; padding: 0; margin: 0; }
+#alerts-list li { padding: 6px 0; border-bottom: 1px solid #21262d; font-size: 13px; }
+#alerts-list li:last-child { border-bottom: none; }
+.alert-sev { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 10px; font-weight: 600; text-transform: uppercase; margin-right: 8px; }
+.alert-sev.warning { background: #422006; color: #f0883e; }
+.alert-sev.error   { background: #4d0d10; color: #f85149; }
+.alert-sev.info    { background: #0d3158; color: #58a6ff; }
+
+.scan-panel { display: flex; flex-direction: column; gap: 10px; }
+.scan-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin: 0 0 2px 0;
+}
+.scan-head h2 { margin: 0; }
+.scan-selcount {
+  font-size: 11px; color: #7d8590; padding: 2px 8px; border-radius: 10px;
+  background: #21262d;
+}
+.scan-selcount.has-sel { background: #1f3a6e; color: #58a6ff; }
+
+.scan-toolbar { display: flex; gap: 8px; }
+.scan-toolbar input[type="search"] {
+  flex: 1; background: #0d1117; border: 1px solid #30363d; color: #e6edf3;
+  padding: 6px 10px; border-radius: 6px; font-size: 13px; font-family: inherit;
+  -webkit-appearance: none; appearance: none;
+}
+.scan-toolbar input[type="search"]::-webkit-search-cancel-button { display: none; }
+.scan-toolbar input[type="search"]:focus { outline: none; border-color: #1f6feb; }
+.scan-toolbar button { font-size: 12px; padding: 4px 10px; }
+
+.scan-list {
+  max-height: 280px; overflow-y: auto;
+  border: 1px solid #21262d; border-radius: 6px; background: #0d1117;
+}
+.scan-list .group-header {
+  position: sticky; top: 0; z-index: 1;
+  padding: 6px 12px; font-size: 10px; color: #7d8590;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  background: #161b22; border-bottom: 1px solid #21262d;
+  display: flex; justify-content: space-between; align-items: center;
+}
+.scan-list .group-header.collapsible { cursor: pointer; user-select: none; }
+.scan-list .group-header.collapsible::after {
+  content: "▼"; font-size: 9px; color: #7d8590; transition: transform 0.15s;
+}
+.scan-list .group-header.collapsed::after { transform: rotate(-90deg); }
+.scan-list .group-body { display: flex; flex-direction: column; }
+.scan-list .group-body.hidden { display: none; }
+.scan-list label {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 12px; cursor: pointer; font-size: 13px;
+  border-bottom: 1px solid #161b22; user-select: none;
+}
+.scan-list label:hover { background: #1c2128; }
+.scan-list label:has(input:checked) { background: #1f3a6e; }
+.scan-list label:last-child { border-bottom: none; }
+.scan-list input[type="checkbox"] { accent-color: #1f6feb; margin: 0; flex-shrink: 0; }
+.scan-list .name { flex: 1; }
+.scan-list .empty {
+  padding: 18px 12px; text-align: center; color: #7d8590; font-size: 12px;
+}
+
+.scan-actions { display: flex; align-items: center; gap: 12px; }
+
+.picks-panel.hidden { display: none; }
+.picks-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
+.picks-head h2 { margin: 0; }
+.pick-card {
+  border: 1px solid #21262d; border-radius: 6px; padding: 10px 12px;
+  background: #0d1117; margin-bottom: 8px;
+}
+.pick-card:last-child { margin-bottom: 0; }
+.pick-row1 { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+.pick-symbol { font-size: 16px; font-weight: 600; color: #e6edf3; }
+.pick-structure { font-size: 11px; color: #58a6ff; text-transform: uppercase; letter-spacing: 0.04em; }
+.pick-score { font-size: 12px; color: #3fb950; font-family: ui-monospace, monospace; }
+.pick-row2 { display: flex; gap: 16px; flex-wrap: wrap; font-size: 12px; color: #adbac7; margin-top: 6px; }
+.pick-row2 .label { color: #7d8590; font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; margin-right: 4px; }
+.pick-row2 .num { font-family: ui-monospace, monospace; }
+.pick-legs { font-family: ui-monospace, monospace; font-size: 11px; color: #adbac7; margin-top: 6px; padding: 4px 0; border-top: 1px solid #161b22; }
+.pick-size { margin-top: 6px; font-size: 12px; padding: 4px 8px; border-radius: 4px; }
+.pick-size.size-ok   { background: #0d3818; color: #3fb950; }
+.pick-size.size-skip { background: #422006; color: #f0883e; }
+.pick-summary { margin-top: 4px; font-size: 11px; color: #7d8590; font-style: italic; }
+.picks-empty { padding: 18px 12px; text-align: center; color: #7d8590; font-size: 13px; }
+.picks-rejections { margin-top: 8px; font-size: 12px; color: #7d8590; }
+.picks-rejections summary { cursor: pointer; padding: 6px 0; }
+.picks-rejections summary:hover { color: #adbac7; }
+.picks-rejections .rej-row { display: flex; justify-content: space-between; padding: 2px 0; font-family: ui-monospace, monospace; font-size: 11px; }
+.picks-rejections .rej-row .reason { color: #adbac7; }
+.picks-rejections .rej-row .count  { color: #7d8590; }
+
+/* Recent Decisions journal feed */
+.journal-list { display: flex; flex-direction: column; gap: 4px; max-height: 320px; overflow-y: auto; }
+.journal-list .empty { padding: 14px 8px; text-align: center; color: #7d8590; font-size: 12px; }
+.journal-entry {
+  display: grid; grid-template-columns: auto auto 1fr;
+  gap: 8px; padding: 8px 4px; border-bottom: 1px solid #1c2128; align-items: baseline;
+}
+.journal-entry:last-child { border-bottom: none; }
+.journal-entry .ts { font-family: ui-monospace, monospace; font-size: 11px; color: #7d8590; white-space: nowrap; }
+.journal-entry .kind {
+  font-size: 10px; padding: 1px 6px; border-radius: 4px; text-transform: uppercase;
+  letter-spacing: 0.04em; font-weight: 600; white-space: nowrap;
+}
+.journal-entry .kind.recommendation { background: #0d3158; color: #58a6ff; }
+.journal-entry .kind.trade_open     { background: #0d3818; color: #3fb950; }
+.journal-entry .kind.trade_close    { background: #422006; color: #f0883e; }
+.journal-entry .kind.note           { background: #21262d; color: #adbac7; }
+.journal-entry .kind.outcome        { background: #4d0d10; color: #f85149; }
+.journal-entry .body { font-size: 12px; color: #e6edf3; line-height: 1.4; }
+.journal-entry .body .symbol { font-weight: 600; color: #58a6ff; margin-right: 6px; }
+.journal-entry .body .strategy { font-family: ui-monospace, monospace; font-size: 10px; color: #7d8590; margin-left: 4px; }
+
+/* Settings drawer */
+.drawer { position: fixed; inset: 0; z-index: 100; }
+.drawer.hidden { display: none; }
+.drawer-backdrop {
+  position: absolute; inset: 0; background: rgba(1, 4, 9, 0.6);
+  backdrop-filter: blur(2px);
+}
+.drawer-panel {
+  position: absolute; top: 0; right: 0; bottom: 0;
+  width: min(440px, 100vw); background: #161b22;
+  border-left: 1px solid #30363d; display: flex; flex-direction: column;
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.4);
+  animation: drawer-slide 0.18s ease-out;
+}
+@keyframes drawer-slide { from { transform: translateX(100%); } to { transform: translateX(0); } }
+.drawer-head {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 14px 18px; border-bottom: 1px solid #30363d;
+}
+.drawer-head h2 { margin: 0; font-size: 16px; font-weight: 500; }
+.drawer-body { flex: 1; overflow-y: auto; padding: 14px 18px; }
+.drawer-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 18px; border-top: 1px solid #30363d; gap: 12px;
+}
+
+.settings-group { margin-bottom: 18px; }
+.settings-group h3 {
+  margin: 0 0 8px 0; font-size: 11px; font-weight: 600;
+  color: #7d8590; text-transform: uppercase; letter-spacing: 0.06em;
+  border-bottom: 1px solid #21262d; padding-bottom: 4px;
+}
+.settings-row {
+  display: grid; grid-template-columns: 1fr auto auto;
+  gap: 8px 12px; align-items: center; padding: 8px 0;
+  border-bottom: 1px solid #1c2128;
+}
+.settings-row:last-child { border-bottom: none; }
+.settings-row .label-col { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.settings-row .key { font-size: 12px; color: #e6edf3; font-family: ui-monospace, monospace; word-break: break-word; }
+.settings-row .desc { font-size: 11px; color: #7d8590; line-height: 1.35; }
+.settings-row input[type="number"], .settings-row input[type="text"] {
+  background: #0d1117; border: 1px solid #30363d; color: #e6edf3;
+  padding: 5px 8px; border-radius: 5px; font-size: 13px;
+  font-family: ui-monospace, monospace; width: 92px; text-align: right;
+}
+.settings-row input:focus { outline: none; border-color: #1f6feb; }
+.settings-row input.dirty { border-color: #f0883e; background: #1c1815; }
+.settings-row .reset-btn {
+  background: transparent; border: 1px solid #30363d; color: #7d8590;
+  font-size: 11px; padding: 3px 8px; border-radius: 4px; cursor: pointer;
+}
+.settings-row .reset-btn:hover { color: #adbac7; border-color: #58a6ff; }
+.settings-row .reset-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+.settings-row .default-hint { font-size: 10px; color: #7d8590; }
+
+#settings-status.ok    { color: #3fb950; }
+#settings-status.error { color: #f85149; }
+.scan-status {
+  font-size: 12px; padding: 3px 10px; border-radius: 10px;
+}
+.scan-status.idle     { background: #21262d; color: #7d8590; }
+.scan-status.scanning { background: #422006; color: #f0883e; }
+.scan-status.scanning::before { content: "● "; animation: pulse 1.2s ease-in-out infinite; }
+.scan-status.ready    { background: #0d3818; color: #3fb950; }
+.scan-status.error    { background: #4d0d10; color: #f85149; }
+.scan-other { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.scan-other .other-chip {
+  font-size: 11px; color: #7d8590; padding: 2px 8px; border-radius: 10px;
+  background: #0d1117; border: 1px solid #30363d; cursor: pointer;
+}
+.scan-other .other-chip:hover { color: #58a6ff; border-color: #1f6feb; }
+
+.chat {
+  display: flex; flex-direction: column;
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  height: calc(100vh - 88px); position: sticky; top: 72px;
+}
+.chat-header { padding: 12px 16px; border-bottom: 1px solid #30363d; display: flex; justify-content: space-between; align-items: center; }
+.chat-header h2 { margin: 0; font-size: 14px; font-weight: 500; color: #adbac7; text-transform: uppercase; letter-spacing: 0.05em; }
+.chat-stream {
+  flex: 1; overflow-y: auto; padding: 12px 16px; font-size: 13px;
+  display: flex; flex-direction: column; gap: 12px; line-height: 1.5;
+}
+.chat-msg { white-space: pre-wrap; }
+.chat-msg.user { color: #58a6ff; }
+.chat-msg.coach { color: #e6edf3; }
+.chat-msg.error { color: #f85149; }
+.chat-msg .role-tag { font-size: 10px; color: #7d8590; text-transform: uppercase; letter-spacing: 0.04em; display: block; margin-bottom: 2px; }
+.chat-msg .status {
+  font-size: 11px; color: #7d8590; font-style: italic;
+  display: block; margin-top: 4px;
+}
+.chat-msg .status::before {
+  content: "● "; color: #1f6feb; animation: pulse 1.2s ease-in-out infinite;
+}
+.chat-msg .status.idle::before { animation: none; opacity: 0.5; }
+.chat-msg .cost { font-size: 10px; color: #7d8590; display: block; margin-top: 6px; }
+@keyframes pulse {
+  0%, 100% { opacity: 0.3; }
+  50%      { opacity: 1.0; }
+}
+
+.chat-form { display: flex; gap: 8px; padding: 12px; border-top: 1px solid #30363d; }
+.chat-form input {
+  flex: 1; background: #0d1117; border: 1px solid #30363d; color: #e6edf3;
+  padding: 8px 10px; border-radius: 6px; font-size: 13px; font-family: inherit;
+}
+.chat-form input:focus { outline: none; border-color: #1f6feb; }

--- a/server/templates/dashboard.html
+++ b/server/templates/dashboard.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tasty Coach</title>
+  <link rel="stylesheet" href="/static/style.css?v={{ asset_version }}">
+</head>
+<body>
+  <header class="topbar">
+    <h1>tasty-coach <span class="account">{{ account_number }}</span></h1>
+    <div class="topbar-actions">
+      <span id="generated-at" class="muted"></span>
+      <button id="refresh-btn">Refresh</button>
+      <button id="settings-btn" class="ghost" title="Settings">⚙ Settings</button>
+      <button id="briefing-btn" class="primary">Run morning briefing</button>
+    </div>
+  </header>
+
+  <div id="settings-drawer" class="drawer hidden" aria-hidden="true">
+    <div class="drawer-backdrop" data-close></div>
+    <aside class="drawer-panel" role="dialog" aria-label="Settings">
+      <header class="drawer-head">
+        <h2>Settings</h2>
+        <button class="ghost" data-close title="Close">✕</button>
+      </header>
+      <div id="settings-body" class="drawer-body">
+        <div class="muted">Loading…</div>
+      </div>
+      <footer class="drawer-foot">
+        <button id="settings-reset-all" class="ghost">Reset all to defaults</button>
+        <span id="settings-status" class="muted"></span>
+      </footer>
+    </aside>
+  </div>
+
+  <main class="layout">
+    <section class="dash">
+      <div id="kpis" class="kpis">
+        <div class="kpi"><span class="kpi-label">NLV</span><span class="kpi-value" id="kpi-nlv">—</span></div>
+        <div class="kpi"><span class="kpi-label">BP usage</span><span class="kpi-value" id="kpi-bp">—</span></div>
+        <div class="kpi"><span class="kpi-label">Cash</span><span class="kpi-value" id="kpi-cash">—</span></div>
+        <div class="kpi"><span class="kpi-label">Δ</span><span class="kpi-value" id="kpi-delta">—</span></div>
+        <div class="kpi"><span class="kpi-label">Θ</span><span class="kpi-value" id="kpi-theta">—</span></div>
+        <div class="kpi"><span class="kpi-label">Positions</span><span class="kpi-value" id="kpi-pos">—</span></div>
+      </div>
+
+      <div class="panel scan-panel">
+        <div class="scan-head">
+          <h2>Trade Scan</h2>
+          <span id="scan-selcount" class="scan-selcount">0 selected</span>
+        </div>
+        <div class="scan-toolbar">
+          <input id="scan-search" type="search" placeholder="Search watchlists…" autocomplete="off">
+          <button id="scan-clear" class="ghost" title="Clear selection">Clear</button>
+        </div>
+        <div id="watchlist-picker" class="scan-list">
+          <span class="muted">Loading watchlists…</span>
+        </div>
+        <div class="scan-actions">
+          <button id="scan-start-btn" class="primary">Start scan</button>
+          <span id="scan-status" class="scan-status idle">idle</span>
+        </div>
+        <div id="scan-other" class="scan-other"></div>
+      </div>
+
+      <div id="picks-panel" class="panel picks-panel hidden">
+        <div class="picks-head">
+          <h2>Trade Picks</h2>
+          <span id="picks-meta" class="muted"></span>
+        </div>
+        <div id="picks-list"></div>
+        <details id="picks-rejections" class="picks-rejections">
+          <summary>Rejection summary</summary>
+          <div id="picks-rejections-body"></div>
+        </details>
+      </div>
+
+      <div class="panel">
+        <h2>Positions</h2>
+        <table id="positions-table">
+          <thead>
+            <tr>
+              <th>Underlying</th><th>Type</th><th>Dir</th><th>Strike</th>
+              <th>Exp</th><th>DTE</th><th>Qty</th><th>Avg open</th><th>Sector</th>
+            </tr>
+          </thead>
+          <tbody><tr><td colspan="9" class="muted">Loading…</td></tr></tbody>
+        </table>
+      </div>
+
+      <div class="panel">
+        <h2>Alerts</h2>
+        <ul id="alerts-list"><li class="muted">Loading…</li></ul>
+      </div>
+
+      <div class="panel">
+        <div class="picks-head">
+          <h2>Recent Decisions</h2>
+          <span id="journal-meta" class="muted"></span>
+        </div>
+        <div id="journal-list" class="journal-list">
+          <div class="muted">Loading…</div>
+        </div>
+      </div>
+    </section>
+
+    <aside class="chat">
+      <div class="chat-header">
+        <h2>Coach</h2>
+        <button id="chat-reset-btn" class="ghost">New conversation</button>
+      </div>
+      <div id="chat-stream" class="chat-stream"></div>
+      <form id="chat-form" class="chat-form" autocomplete="off">
+        <input id="chat-input" type="text" placeholder="Ask about your account, positions, or trades…" maxlength="4000">
+        <button type="submit">Send</button>
+      </form>
+    </aside>
+  </main>
+
+  <script>window.TC_TOKEN = {{ token | tojson }};</script>
+  <script src="/static/chat.js?v={{ asset_version }}"></script>
+</body>
+</html>

--- a/tests/test_coach_context.py
+++ b/tests/test_coach_context.py
@@ -1,0 +1,56 @@
+"""Tests for agents.coach_context: ContextVar-based per-request context."""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from agents import coach_context
+from agents.coach_context import CoachContext
+
+
+def _make_ctx(account_number: str) -> CoachContext:
+    return CoachContext(session=object(), account=object(), account_number=account_number)
+
+
+class TestCoachContext(unittest.TestCase):
+    def test_current_raises_when_unset(self):
+        # Run in a fresh task to avoid leaking state from sibling tests.
+        async def run():
+            with self.assertRaises(RuntimeError):
+                coach_context.current()
+        asyncio.run(run())
+
+    def test_set_and_get_in_same_task(self):
+        async def run():
+            ctx = _make_ctx("A")
+            coach_context.set_current(ctx)
+            self.assertIs(coach_context.current(), ctx)
+        asyncio.run(run())
+
+    def test_concurrent_tasks_see_independent_contexts(self):
+        # Regression: the previous implementation used a module-level global,
+        # so two requests racing through set_current would clobber each other.
+        async def task_for(account_number: str, gate: asyncio.Event) -> str:
+            coach_context.set_current(_make_ctx(account_number))
+            # Yield to scheduler so the other task definitely runs between
+            # set_current and current() — exposes the race if any.
+            await asyncio.sleep(0)
+            await gate.wait()
+            return coach_context.current().account_number
+
+        async def run():
+            gate = asyncio.Event()
+            t1 = asyncio.create_task(task_for("ACCT-A", gate))
+            t2 = asyncio.create_task(task_for("ACCT-B", gate))
+            await asyncio.sleep(0.01)
+            gate.set()
+            a, b = await asyncio.gather(t1, t2)
+            self.assertEqual(a, "ACCT-A")
+            self.assertEqual(b, "ACCT-B")
+
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,125 @@
+"""Tests for utils.journal: append-only JSONL coach memory."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from utils import journal
+
+
+class TestJournalRecordAndRecall(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "journal.jsonl"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_record_round_trips_through_recall(self):
+        journal.record(
+            {"kind": "recommendation", "symbol": "AAPL", "rationale": "high IVR"},
+            path=self.path,
+        )
+        entries = journal.recall(path=self.path)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["symbol"], "AAPL")
+        self.assertEqual(entries[0]["kind"], "recommendation")
+        self.assertIn("ts", entries[0])
+
+    def test_record_unknown_kind_coerced_to_note(self):
+        journal.record({"kind": "wat", "rationale": "x"}, path=self.path)
+        entries = journal.recall(path=self.path)
+        self.assertEqual(entries[0]["kind"], "note")
+
+    def test_recall_empty_when_path_missing(self):
+        self.assertEqual(journal.recall(path=self.path / "nope"), [])
+
+    def test_recall_filters_by_kind(self):
+        journal.record({"kind": "note", "rationale": "x"}, path=self.path)
+        journal.record({"kind": "recommendation", "rationale": "y"}, path=self.path)
+        recs = journal.recall(kind="recommendation", path=self.path)
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["rationale"], "y")
+
+    def test_recall_filters_by_symbol_case_insensitive(self):
+        journal.record({"kind": "note", "symbol": "aapl", "rationale": "x"}, path=self.path)
+        journal.record({"kind": "note", "symbol": "MSFT", "rationale": "y"}, path=self.path)
+        out = journal.recall(symbol="AAPL", path=self.path)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["symbol"], "aapl")
+
+    def test_recall_days_filter_drops_old(self):
+        old_ts = (datetime.now() - timedelta(days=30)).isoformat(timespec="seconds")
+        journal.record({"kind": "note", "rationale": "old", "ts": old_ts}, path=self.path)
+        journal.record({"kind": "note", "rationale": "new"}, path=self.path)
+        recent = journal.recall(days=7, path=self.path)
+        self.assertEqual(len(recent), 1)
+        self.assertEqual(recent[0]["rationale"], "new")
+
+    def test_recall_limit_caps_output(self):
+        for i in range(5):
+            journal.record({"kind": "note", "rationale": str(i)}, path=self.path)
+        out = journal.recall(limit=3, path=self.path)
+        self.assertEqual(len(out), 3)
+
+    def test_recall_returns_newest_first(self):
+        ts1 = "2026-01-01T10:00:00"
+        ts2 = "2026-04-01T10:00:00"
+        journal.record({"kind": "note", "rationale": "old", "ts": ts1}, path=self.path)
+        journal.record({"kind": "note", "rationale": "new", "ts": ts2}, path=self.path)
+        out = journal.recall(path=self.path)
+        self.assertEqual(out[0]["rationale"], "new")
+        self.assertEqual(out[1]["rationale"], "old")
+
+    def test_malformed_line_is_skipped_not_raised(self):
+        with self.path.open("w", encoding="utf-8") as f:
+            f.write('{"kind":"note","rationale":"good"}\n')
+            f.write("not json at all\n")
+            f.write('{"kind":"note","rationale":"also good"}\n')
+        out = journal.recall(path=self.path)
+        rationales = sorted(e["rationale"] for e in out)
+        self.assertEqual(rationales, ["also good", "good"])
+
+    def test_stats_counts_by_kind(self):
+        journal.record({"kind": "note", "rationale": "a"}, path=self.path)
+        journal.record({"kind": "recommendation", "rationale": "b"}, path=self.path)
+        journal.record({"kind": "note", "rationale": "c"}, path=self.path)
+        s = journal.stats(path=self.path)
+        self.assertEqual(s["total"], 3)
+        self.assertEqual(s["by_kind"]["note"], 2)
+        self.assertEqual(s["by_kind"]["recommendation"], 1)
+        self.assertIsNotNone(s["last_ts"])
+
+
+class TestJournalConcurrentAppend(unittest.TestCase):
+    """Atomic-append safety: many simultaneous record() calls produce valid JSONL."""
+
+    def test_concurrent_records_all_land_as_valid_lines(self):
+        tmp = tempfile.TemporaryDirectory()
+        try:
+            p = Path(tmp.name) / "journal.jsonl"
+
+            async def driver():
+                await asyncio.gather(*[
+                    asyncio.to_thread(journal.record, {"kind": "note", "rationale": f"r{i}"}, path=p)
+                    for i in range(50)
+                ])
+
+            asyncio.run(driver())
+
+            with p.open("r", encoding="utf-8") as f:
+                lines = [ln for ln in f.read().splitlines() if ln.strip()]
+            self.assertEqual(len(lines), 50)
+            for ln in lines:
+                json.loads(ln)  # must parse
+        finally:
+            tmp.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,116 @@
+"""Tests for server.snapshot.assemble_dashboard_data and helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from server.snapshot import _serialize_position, assemble_dashboard_data
+
+
+def _mock_pos(*, symbol, instrument_type, underlying_symbol=None,
+              quantity=1, direction="Short", avg_open=1.50):
+    p = MagicMock()
+    p.symbol = symbol
+    p.instrument_type = MagicMock()
+    p.instrument_type.value = instrument_type
+    p.underlying_symbol = underlying_symbol
+    p.quantity = quantity
+    p.quantity_direction = MagicMock()
+    p.quantity_direction.value = direction
+    p.average_open_price = avg_open
+    return p
+
+
+class TestSerializePosition(unittest.TestCase):
+    """Underlying fallback should never leak the full OCC string."""
+
+    def test_option_with_underlying_symbol_set(self):
+        p = _mock_pos(symbol="AAPL  260619P00150000", instrument_type="Equity Option",
+                      underlying_symbol="AAPL")
+        out = _serialize_position(p)
+        self.assertEqual(out["underlying"], "AAPL")
+        self.assertEqual(out["strike"], 150.0)
+        self.assertEqual(out["option_type"], "PUT")
+        self.assertEqual(out["expiration"], "2026-06-19")
+        self.assertEqual(out["sector"], "tech_hardware")
+
+    def test_option_without_underlying_symbol_falls_back_to_parsed_root(self):
+        # Regression: prior behaviour would set underlying = full OCC string,
+        # which over-counts unique underlyings and breaks sector lookups.
+        p = _mock_pos(symbol="AAPL  260619P00150000", instrument_type="Equity Option",
+                      underlying_symbol=None)
+        out = _serialize_position(p)
+        self.assertEqual(out["underlying"], "AAPL")
+        self.assertEqual(out["sector"], "tech_hardware")
+
+    def test_equity_position_underlying_is_symbol(self):
+        p = _mock_pos(symbol="AAPL", instrument_type="Equity",
+                      underlying_symbol=None, quantity=100, avg_open=180.5)
+        out = _serialize_position(p)
+        self.assertEqual(out["underlying"], "AAPL")
+        self.assertIsNone(out["strike"])
+        self.assertIsNone(out["expiration"])
+        self.assertEqual(out["sector"], "tech_hardware")
+
+    def test_unparseable_symbol_falls_back_to_symbol(self):
+        p = _mock_pos(symbol="WEIRD SYMBOL", instrument_type="Other",
+                      underlying_symbol=None)
+        out = _serialize_position(p)
+        # No OCC parse, no underlying_symbol → fall back to the symbol itself
+        self.assertEqual(out["underlying"], "WEIRD SYMBOL")
+        self.assertIsNone(out["sector"])
+
+
+class TestAssembleDashboardData(unittest.TestCase):
+    """Shape of the dashboard payload + over_leveraged signal."""
+
+    def _run(self, report, positions):
+        ctx = MagicMock()
+        ctx.session = MagicMock()
+        ctx.account_number = "ACCT"
+
+        with patch("server.snapshot.RiskManager") as mock_rm, \
+             patch("server.snapshot.PortfolioAgent") as mock_pa:
+            mock_rm.return_value.calculate_portfolio_risk = AsyncMock(return_value=report)
+            pa_inst = MagicMock()
+            pa_inst.get_positions = AsyncMock(return_value=positions)
+            mock_pa.return_value.init = AsyncMock(return_value=pa_inst)
+            return asyncio.run(assemble_dashboard_data(ctx))
+
+    def test_payload_has_expected_top_level_keys(self):
+        out = self._run({"nlv": 20000.0, "bp_usage_pct": 25.0}, [])
+        for key in ("account_number", "kpis", "positions", "alerts", "warnings", "generated_at"):
+            self.assertIn(key, out)
+
+    def test_over_leveraged_flag_set_when_bp_negative(self):
+        # PM accounts with EBP > NLV yield negative bp_usage_pct;
+        # the payload must surface this rather than abs() over it.
+        out = self._run({"nlv": 20000.0, "bp_usage_pct": -20.0}, [])
+        self.assertTrue(out["kpis"]["over_leveraged"])
+        self.assertEqual(out["kpis"]["bp_usage_pct"], -20.0)
+
+    def test_over_leveraged_flag_unset_when_bp_positive(self):
+        out = self._run({"nlv": 20000.0, "bp_usage_pct": 30.0}, [])
+        self.assertFalse(out["kpis"]["over_leveraged"])
+        self.assertEqual(out["kpis"]["bp_usage_pct"], 30.0)
+
+    def test_underlying_count_dedups_options_under_root_symbol(self):
+        # Two AAPL option positions plus one MSFT option = 2 underlyings,
+        # not 3. Regression for the OCC-string fallback bug.
+        positions = [
+            _mock_pos(symbol="AAPL  260619P00150000", instrument_type="Equity Option",
+                      underlying_symbol=None),
+            _mock_pos(symbol="AAPL  260619P00145000", instrument_type="Equity Option",
+                      underlying_symbol=None),
+            _mock_pos(symbol="MSFT  260619P00400000", instrument_type="Equity Option",
+                      underlying_symbol=None),
+        ]
+        out = self._run({"nlv": 20000.0, "bp_usage_pct": 10.0}, positions)
+        self.assertEqual(out["kpis"]["position_count"], 3)
+        self.assertEqual(out["kpis"]["underlying_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/journal.py
+++ b/utils/journal.py
@@ -1,0 +1,151 @@
+"""Append-only JSONL journal for the coach's cross-session memory.
+
+Lives at ``~/.tasty-coach/journal.jsonl``. Each line is one JSON object:
+
+    {
+      "ts": "2026-04-29T10:23:45",   # ISO-8601, local time
+      "kind": "recommendation",       # recommendation | trade_open | trade_close
+                                      # | note | outcome
+      "symbol": "EWZ",                # optional underlying
+      "strategy": "IRON_CONDOR",      # optional structure
+      "rationale": "high IVR, ...",   # human-readable
+      "details": {...},               # optional structured payload
+      "outcome": null                  # filled later: won|lost|rolled|early_close
+    }
+
+The coach calls ``record`` after recommending or observing something notable, and
+``recall`` to ground answers about prior decisions. Append-only; no edits.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PATH = Path.home() / ".tasty-coach" / "journal.jsonl"
+
+VALID_KINDS = {
+    "recommendation",
+    "trade_open",
+    "trade_close",
+    "note",
+    "outcome",
+}
+
+
+def _path() -> Path:
+    p = os.environ.get("TASTY_COACH_JOURNAL_PATH")
+    return Path(p) if p else DEFAULT_PATH
+
+
+def _ensure_parent(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+
+def record(entry: dict[str, Any], *, path: Optional[Path] = None) -> dict[str, Any]:
+    """Append one entry. Adds ``ts`` if missing. Returns the persisted entry."""
+    p = path or _path()
+    _ensure_parent(p)
+
+    out = dict(entry)
+    out.setdefault("ts", datetime.now().isoformat(timespec="seconds"))
+    kind = out.get("kind")
+    if kind not in VALID_KINDS:
+        logger.warning("journal: unknown kind %r; coercing to 'note'", kind)
+        out["kind"] = "note"
+
+    # Atomic append: a single os.write call up to PIPE_BUF (4096) is atomic on
+    # POSIX, and JSONL lines are typically <1 KB. Use line buffering to be safe.
+    line = json.dumps(out, default=str, ensure_ascii=False) + "\n"
+    with p.open("a", encoding="utf-8") as f:
+        f.write(line)
+    return out
+
+
+def _iter_entries(path: Path) -> Iterable[dict[str, Any]]:
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError as e:
+                logger.warning("journal: skipping malformed line: %s", e)
+
+
+def recall(
+    *,
+    since: Optional[datetime | str] = None,
+    days: Optional[int] = None,
+    symbol: Optional[str] = None,
+    kind: Optional[str] = None,
+    limit: int = 50,
+    path: Optional[Path] = None,
+) -> list[dict[str, Any]]:
+    """Read journal entries, newest first.
+
+    Filters:
+    - ``since`` / ``days``: keep entries with ``ts >= since`` (or ``now - days``).
+    - ``symbol``: case-insensitive match on the entry's ``symbol`` field.
+    - ``kind``: exact match against ``VALID_KINDS``.
+    - ``limit``: cap on returned entries (newest-first after sorting).
+    """
+    p = path or _path()
+
+    cutoff: Optional[datetime] = None
+    if isinstance(since, datetime):
+        cutoff = since
+    elif isinstance(since, str):
+        try:
+            cutoff = datetime.fromisoformat(since)
+        except ValueError:
+            cutoff = None
+    if cutoff is None and days is not None and days >= 0:
+        cutoff = datetime.now() - timedelta(days=days)
+
+    sym = symbol.upper() if symbol else None
+    out: list[dict[str, Any]] = []
+    for e in _iter_entries(p):
+        if kind and e.get("kind") != kind:
+            continue
+        if sym and (e.get("symbol") or "").upper() != sym:
+            continue
+        if cutoff is not None:
+            ts_raw = e.get("ts")
+            try:
+                ts = datetime.fromisoformat(ts_raw) if ts_raw else None
+            except (TypeError, ValueError):
+                ts = None
+            if ts is None or ts < cutoff:
+                continue
+        out.append(e)
+
+    out.sort(key=lambda e: e.get("ts") or "", reverse=True)
+    if limit and limit > 0:
+        out = out[:limit]
+    return out
+
+
+def stats(*, path: Optional[Path] = None) -> dict[str, Any]:
+    """Lightweight summary used by the dashboard feed header."""
+    p = path or _path()
+    total = 0
+    by_kind: dict[str, int] = {}
+    last_ts: Optional[str] = None
+    for e in _iter_entries(p):
+        total += 1
+        k = e.get("kind") or "unknown"
+        by_kind[k] = by_kind.get(k, 0) + 1
+        ts = e.get("ts")
+        if ts and (last_ts is None or ts > last_ts):
+            last_ts = ts
+    return {"total": total, "by_kind": by_kind, "last_ts": last_ts}


### PR DESCRIPTION
## Summary

- **AI Coach** (`--coach` one-shot briefing, `--chat` REPL) — Claude Agent SDK driving 11 in-process MCP tools that wrap existing agents (Portfolio, Risk, OptionsResearcher, Scanner, GEX, Reviewer, History, run_best_trades) plus journal record/recall.
- **Web dashboard** (`--serve`) — FastAPI with token auth, SSE briefing+chat, settings editor, journal viewer, best-trades scan controller. Per-(account, watchlist-set) cache with 15-min TTL, one in-flight scan per account, chat sessions capped at 8 with LRU eviction.
- **Cross-session journal** — append-only JSONL at `~/.tasty-coach/journal.jsonl` (foundation for TCBT-6/7).
- **CoachContext via ContextVar** — was a module-global, races resolved.
- **server/snapshot.py bug fixes** caught by the independent reviewer:
  - Underlying-symbol fallback no longer leaks the full OCC string into the dashboard (was over-counting unique underlyings + breaking sector lookups).
  - `bp_usage_pct` no longer masks PM-account over-leverage with `abs()`; surfaced as a new `over_leveraged: bool` flag and the UI now flags it explicitly.

## Test plan

- [x] `unittest discover tests` — 519 tests, 513 passing. The 6 failures are the same pre-existing failures present on `main` (test_options_researcher / test_risk_manager / test_resolve_expiration_monthly_45dte / test_bt_research_timeout_seconds_default_forty_five). Verified by checking out `main` directly.
- [x] 22 new tests across `test_journal.py` (record/recall, filters, malformed-line skip, concurrent-append safety), `test_snapshot.py` (regression for the OCC fallback bug + over_leveraged flag), `test_coach_context.py` (ContextVar isolates per-task ctx).
- [x] All new modules import cleanly with the new deps installed.
- [x] `python main.py --help` shows the new flags.
- [ ] Smoke run `python main.py --coach` against live account.
- [ ] Smoke run `python main.py --serve` and exercise dashboard + chat.

## Independent review findings addressed

A general-purpose review subagent surfaced four must-fixes; all are in this PR:

1. `server/snapshot.py:_serialize_position` was falling back to the full OCC option string when `underlying_symbol` was unset → over-counted underlyings, broke sector lookups. Fixed by parsing OCC first and using the parsed root.
2. `bp_usage_pct = abs(bp_pct_raw)` was hiding genuine over-leverage on PM accounts. Pass through raw value + new `over_leveraged` boolean flag; UI shows ⚠ prefix and `bad` styling.
3. `coach_context._CURRENT` was a module global racing across concurrent requests. Migrated to `contextvars.ContextVar`. New regression test exercises two concurrent tasks holding different account numbers.
4. `record_decision` had no length cap on `rationale` — could let runaway model loops bloat `~/.tasty-coach/journal.jsonl`. Now capped at 4 KB.

## Should-fix and known follow-ups (not blocking)

- **Token-via-query-param leaks into uvicorn access logs.** Solo LAN deployment, but worth migrating SSE endpoints to header/cookie-only.
- **Settings POST validation is shallow** — only filters by allowed-key set; per-key bounds checking lives in `set_many` validators. Adding bounded-range validators would harden against hand-crafted PATCHes.
- **bt_cache vs settings clear race** — `clear()` during in-flight scan can re-leak a stale entry on completion; rare in practice but a generation counter would close it cleanly.
- Coach SDK transport-task ContextVar propagation — the var is captured at task creation, so cached chat sessions whose transport was set up under one request's ctx may not see a later request's ctx. Single-account deployment makes this irrelevant today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)