### PR TITLE
docs+chore: Best-Trades specs + ignore agent tooling dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ cache/
 .coverage
 .pytest_cache/
 .tox/
+
+# Claude Code / agent tooling artifacts
+.claude/
+.memsearch/

--- a/docs/tasty-coach-best-trades-acceptance-checklist.md
+++ b/docs/tasty-coach-best-trades-acceptance-checklist.md
@@ -1,0 +1,51 @@
+# tasty-coach: Best Trades Today Acceptance Checklist
+
+## User-facing behaviour
+- [ ] User can ask for the best trades from the watchlist in one command
+- [ ] Tool returns the top 3 trades only
+- [ ] Each trade includes a score and a plain-English reason
+- [ ] Rejected symbols/candidates show why they were rejected
+- [ ] Output is fast enough to use daily
+
+## Market quality gates
+- [ ] Earnings/event risk is checked
+- [ ] Liquidity / spread quality is checked
+- [ ] Volatility / expected move context is used
+- [ ] Bad market session conditions are handled
+- [ ] Obvious junk setups are filtered out before ranking
+
+## Account-aware checks
+- [ ] Tool reads current positions
+- [ ] Tool reads NLV, cash, BP usage, delta, theta
+- [ ] Tool checks concentration / overlap risk
+- [ ] Tool down-ranks or blocks trades that add too much exposure
+- [ ] Tool explains when a trade is good in general but bad for this account
+
+## Scoring and explainability
+- [ ] Scores are visible out of 100
+- [ ] Score includes a component breakdown
+- [ ] Rank order is stable and reproducible
+- [ ] Reasons are understandable without reading code
+- [ ] Bad scores are explainable, not mysterious
+
+## Logging and learning
+- [ ] Entry context is logged
+- [ ] Exit context is logged
+- [ ] P/L and hold time are saved
+- [ ] Lesson tags are attached to outcomes
+- [ ] History is stored in a predictable file structure
+- [ ] Future ranking can read past results for pattern learning
+
+## Engineering quality
+- [ ] New command is wired into CLI/help text
+- [ ] Unit tests cover the scanner, gates, scoring, and output
+- [ ] Existing functionality still works
+- [ ] No silent failure when market data is missing
+- [ ] The implementation is modular, not a giant ball of spaghetti
+
+## Definition of done
+- [ ] I can ask for the best trades today
+- [ ] The tool runs the gates automatically
+- [ ] It gives me the top 3 with reasons and scores
+- [ ] It checks my account before recommending anything
+- [ ] It logs what happened so the next run can learn from it

--- a/docs/tasty-coach-best-trades-brief.md
+++ b/docs/tasty-coach-best-trades-brief.md
@@ -1,0 +1,109 @@
+# tasty-coach: Best Trades Today Brief
+
+> Implementation brief for Codex / Claude Code.
+
+## Goal
+Turn tasty-coach into an account-aware trade recommendation tool that scans the watchlist, runs quality gates, scores viable setups, and returns the top 3 trades for today with reasons.
+
+## Outcome
+A user can ask:
+
+> "What are the best 3 trades from my watchlist today?"
+
+…and the tool will:
+1. read the watchlist
+2. inspect market regime
+3. screen each symbol for tradeability
+4. generate candidate structures
+5. run quality gates
+6. score the survivors
+7. check fit against the live account
+8. return the top 3 with an explanation
+
+## Core behaviour
+The tool must be:
+- account-aware
+- rule-based first, not vibes-based
+- transparent about why a trade ranked well or got rejected
+- strict about bad liquidity, event risk, oversized exposure, and bad account fit
+- useful even when the market is messy
+
+## Required outputs
+For each top trade:
+- symbol
+- structure
+- expiry / DTE
+- credit or debit
+- max risk
+- breakeven(s)
+- score out of 100
+- reasons it ranked well
+- account-fit notes
+
+Also show:
+- rejected candidates
+- rejection reasons
+- current account warnings that influenced ranking
+
+## Decision gates
+Hard-filter or heavily penalise trades that have:
+- earnings too close
+- weak liquidity / wide spreads
+- poor open interest / volume
+- excessive size vs NLV
+- correlation or concentration overlap
+- event risk
+- poor theta / BP trade-off
+- bad market session conditions
+- ugly assignment / exercise risk
+
+## Scoring categories
+Use a visible score breakdown, e.g.:
+- market regime fit
+- liquidity quality
+- volatility edge
+- event risk
+- structure quality
+- account fit
+- concentration penalty
+- risk-adjusted reward
+
+## Logging requirement
+The tool must log at entry:
+- market regime
+- VIX / IV / IVR / expected move
+- symbol, structure, expiry, strikes
+- size, credit/debit, max risk
+- delta/theta/BP impact
+- why the trade passed
+
+And at exit:
+- P/L
+- hold time
+- whether the thesis worked
+- what actually killed it
+- lesson tags
+
+## Learning requirement
+The tool should accumulate trade history in a way that later ranking can use:
+- winning patterns
+- losing patterns
+- recurring bad conditions
+- what structures fit the account
+- what gets rejected often and why
+
+This is not a separate AI memory project yet. It is a structured evidence trail for future ranking.
+
+## Suggested shape
+- one trade log entry per trade
+- one lesson/summary file per repeated pattern
+- one index page for navigation
+- optional daily regime log
+
+## Definition of done
+The feature is done when the tool can reliably return a ranked top 3 from the watchlist with:
+- sensible quality gates
+- account-aware filtering
+- plain-English reasons
+- reproducible scoring
+- logging for later learning

--- a/docs/tasty-coach-best-trades-task-breakdown.md
+++ b/docs/tasty-coach-best-trades-task-breakdown.md
@@ -1,0 +1,240 @@
+# tasty-coach: Best Trades Today Task Breakdown
+
+> Bite-sized implementation plan for Codex / Claude Code.
+
+## Task 1: Add the new CLI entry point
+**Objective:** Create a command that triggers the watchlist-wide trade ranking flow.
+
+**Files:**
+- Modify: `main.py`
+- Modify: `utils/launcher_ui.py` if the launcher exposes commands there
+- Test: `tests/test_launcher_ui.py` or a new CLI test file
+
+**Work:**
+- Add a new command name such as `--best-trades` or `--rank-trades`.
+- Wire it to a new ranking function rather than reusing single-symbol review.
+- Make sure it can run without user interaction.
+
+**Verify:**
+- `./venv/bin/python main.py --help`
+- confirm the new command appears
+
+---
+
+## Task 2: Build watchlist scanning
+**Objective:** Read all watchlist symbols and collect the market inputs needed for ranking.
+
+**Files:**
+- Create: `agents/trade_ranker.py` or similar
+- Modify: `agents/options_researcher.py` if it already has useful chain logic
+- Modify: `utils/tasty_client.py` if any missing market-data helpers are needed
+- Test: `tests/test_trade_ranker.py`
+
+**Work:**
+- Load the watchlist symbols.
+- For each symbol, gather:
+  - price
+  - option chain
+  - bid/ask/spread info
+  - IV / IVR / expected move if available
+  - earnings/event proximity
+  - basic trend or regime inputs
+- Return a normalised per-symbol data object.
+
+**Verify:**
+- unit test that a watchlist symbol becomes a candidate data object
+- unit test that a broken symbol does not crash the scan
+
+---
+
+## Task 3: Add candidate generation per symbol
+**Objective:** Turn scanned symbols into valid trade candidates.
+
+**Files:**
+- Create/modify: `agents/trade_ranker.py`
+- Test: `tests/test_trade_ranker.py`
+
+**Work:**
+- Generate candidate structures only when they make sense for the symbol and data.
+- Candidate types may include:
+  - credit spread
+  - iron condor
+  - strangle
+  - other structures already supported by the app
+- Keep candidate generation deterministic and testable.
+
+**Verify:**
+- given sample market data, candidate generation returns expected structures
+- invalid structures are not created
+
+---
+
+## Task 4: Add hard quality gates
+**Objective:** Reject obviously bad trades before scoring.
+
+**Files:**
+- Create/modify: `agents/trade_ranker.py`
+- Test: `tests/test_trade_ranker.py`
+
+**Work:**
+- Implement filters for:
+  - earnings too close
+  - poor liquidity
+  - huge spreads
+  - oversized risk vs NLV
+  - concentration overlap
+  - event risk
+  - broken pricing / market closed conditions
+- Return rejection reasons, not just a boolean.
+
+**Verify:**
+- unit tests for each gate
+- rejected candidates include human-readable reasons
+
+---
+
+## Task 5: Add scoring with explanations
+**Objective:** Score surviving trades and explain the score.
+
+**Files:**
+- Create/modify: `agents/trade_ranker.py`
+- Test: `tests/test_trade_ranker.py`
+
+**Work:**
+- Score candidates out of 100.
+- Include component scores such as:
+  - regime fit
+  - liquidity
+  - volatility edge
+  - event risk
+  - structure quality
+  - account fit
+  - concentration penalty
+- Return score breakdown plus summary text.
+
+**Verify:**
+- unit test score ordering
+- unit test breakdown sums sensibly to total score
+
+---
+
+## Task 6: Make the ranking account-aware
+**Objective:** Compare candidates against the live account before final ranking.
+
+**Files:**
+- Create/modify: `agents/trade_ranker.py`
+- Modify: `agents/manager.py` if account metrics are already computed there
+- Test: `tests/test_trade_ranker.py` and `tests/test_risk_manager.py`
+
+**Work:**
+- Pull account state:
+  - NLV
+  - cash
+  - BP usage
+  - delta
+  - theta
+  - existing concentration
+  - current positions
+- Penalise or reject candidates that add bad overlap or exceed sensible limits.
+
+**Verify:**
+- candidate scores change when account state changes
+- oversized additions are rejected or down-ranked
+
+---
+
+## Task 7: Produce the top 3 output
+**Objective:** Return the final answer in a clear trader-friendly format.
+
+**Files:**
+- Create/modify: `agents/trade_ranker.py`
+- Modify: `main.py`
+- Test: `tests/test_trade_ranker.py`
+
+**Work:**
+- Sort candidates by final score.
+- Return the top 3 only.
+- Show:
+  - trade
+  - score
+  - reasons
+  - account-fit notes
+  - rejection summary for others
+
+**Verify:**
+- output has exactly 3 top candidates when 3 exist
+- output still works with fewer than 3 valid candidates
+
+---
+
+## Task 8: Add entry logging
+**Objective:** Save the market and account context used when a trade is entered.
+
+**Files:**
+- Create: `utils/trade_journal.py` or similar
+- Modify: trade entry flow in the ranking/launcher layer
+- Test: `tests/test_trade_journal.py`
+
+**Work:**
+- Persist a structured record for each entry.
+- Include the metrics needed for later review and learning.
+- Use a format that is easy to inspect and easy to export later.
+
+**Verify:**
+- a trade entry creates a log record
+- the record contains all required fields
+
+---
+
+## Task 9: Add exit logging and lesson tags
+**Objective:** Store what happened after a trade closed.
+
+**Files:**
+- Modify: trade close / history pipeline
+- Create/modify: `utils/trade_journal.py`
+- Test: `tests/test_trade_journal.py`
+
+**Work:**
+- Record exit P/L, hold time, thesis result, and failure mode.
+- Add lesson tags for repeated patterns.
+- Keep this simple and structured.
+
+**Verify:**
+- closing a trade adds an exit record
+- lesson tags appear in the saved record
+
+---
+
+## Task 10: Add a learning index
+**Objective:** Make the logged trades searchable for future ranking.
+
+**Files:**
+- Create: `docs/trade-learning/` or a similar folder
+- Create: index file and per-trade notes if needed
+- Test: basic file existence / generation tests
+
+**Work:**
+- Add a lightweight filing system for entries, exits, and lessons.
+- Keep it simple enough that future ranking code can read it.
+
+**Verify:**
+- entries are written to a predictable path
+- index references the stored notes
+
+---
+
+## Final verification
+Run the full flow end-to-end:
+1. scan watchlist
+2. generate candidates
+3. apply gates
+4. score survivors
+5. account-fit check
+6. print top 3
+7. log the run
+
+Expected result:
+- top 3 appear
+- reasons are visible
+- bad candidates are rejected with explanations
+- logs are written

--- a/docs/tasty-coach-project-scope.md
+++ b/docs/tasty-coach-project-scope.md
@@ -1,0 +1,137 @@
+# tasty-coach Project Scope
+
+## Goal
+Turn tasty-coach into a practical decision-support tool for options traders: fast, clear, and actually useful.
+
+## Current State
+The app already has a lot of the right plumbing. It is *not* starting from zero.
+
+### Already in place
+- CLI entry point with a broad command set
+- Interactive terminal launcher
+- Portfolio health checks
+- Performance reporting (weekly / monthly / yearly)
+- Trade history / order history / transaction history
+- Position review with roll scenario analysis
+- Watchlist IVR scanning
+- Strategy screening for verticals and iron condors
+- Gamma exposure (GEX) analysis
+- Market-quality dashboard (separate from the account dashboard)
+- Local trade DB / grouping / analytics support
+
+### Main gaps
+- No single unified coaching dashboard that ties everything together
+- No proper settings page for user-configurable thresholds and alert preferences
+- No correlation-aware concentration analysis
+- No position-level "what now?" guidance layer
+- No polished event timeline that makes assignments/exercises/rolls obvious at a glance
+
+## Problem
+Right now the app can answer *parts* of the question, but it does not clearly answer:
+- What do I own?
+- What’s the risk?
+- What should I do next?
+
+## MVP
+
+### 1) Portfolio Health Dashboard
+Show a clear top-level summary:
+- Net liq
+- Cash balance
+- Buying power / equity BP
+- Portfolio delta
+- Portfolio theta
+- Win rate
+- Profit factor
+- Avg holding time
+- Total P/L
+- Fees paid
+
+### 2) Position Sizing + Concentration Warnings
+Flag risk that’s too large or too concentrated:
+- any leg above a configurable % of NLV
+- exposure by underlying
+- overlapping risk across correlated positions
+- plain-English warnings
+
+### 3) Position Drilldown
+For each open position, show:
+- strategy type
+- strikes / expiration
+- entry details
+- current P/L
+- P/L as % of NLV
+- delta / theta exposure
+- assignment / exercise risk
+- suggested action: hold / roll / close / defend
+
+### 4) Performance Analytics
+Add views for:
+- monthly P/L
+- weekly P/L
+- yearly performance
+- performance by strategy
+- winners vs losers
+- average win / average loss
+- largest win / largest loss
+
+### 5) Trade History Timeline
+Make history readable and useful:
+- fills
+- closes
+- rolls
+- assignments
+- exercises
+- cancellations
+- major account events
+
+### 6) Risk Alerts
+Surface obvious account-level warnings:
+- oversized positions
+- low theta vs target
+- market closed / liquidity warning
+- assignment / exercise events
+- concentration in one underlying or basket
+
+## Non-Goals
+Do not build:
+- auto-trading
+- broker execution
+- signal generation
+- a full research platform
+
+## AI Layer (added 2026-04-28)
+Originally listed as a non-goal; now in scope. The AI coach is an advisor, not an autotrader:
+- Drives existing rule-based agents as tools via the Anthropic Agent SDK (`claude-agent-sdk`).
+- Subscription billing via `CLAUDE_CODE_OAUTH_TOKEN` (Claude Max). API key is fallback only.
+- Surfaces: `--coach` (one-shot daily briefing), `--chat` (REPL), and a localhost web dashboard with chat sidebar.
+- Account-aware: every recommendation is filtered against live BP, position concentration, sector overlap, and personalized sizing rules.
+- Hard rule: the coach never places trades. User approval still required for execution.
+
+## UX Structure
+- **Dashboard** — account summary, risk score, warnings, top positions, recent events
+- **Positions** — table + filters + drilldown
+- **Performance** — monthly / weekly / yearly + strategy breakdown
+- **History** — chronological feed of trades and events
+- **Settings** — risk thresholds and alert preferences
+
+## Acceptance Criteria
+Done when:
+- a user can understand account health in under 10 seconds
+- oversized positions are flagged automatically
+- performance by strategy is visible
+- assignments / exercises are clearly shown
+- every open position has a quick next-step view
+- the app makes account risk obvious without manual digging
+
+## Phase 2 Ideas
+If MVP lands, add:
+- volatility regime awareness
+- expected move / IV context
+- correlation cluster detection
+- strategy playbooks
+- adjustment guidance
+- scenario simulation
+
+## One-line Summary
+**tasty-coach should help a trader answer three questions fast: what do I own, what’s the risk, and what should I do next?**


### PR DESCRIPTION
## Summary

- Add the four best-trades initiative docs (brief, acceptance checklist, task breakdown, project scope) referenced by project memory.
- `.gitignore` now covers `.claude/` and `.memsearch/` (Claude Code + memsearch session artifacts).

## Test plan

- [x] `git status` clean after commit; ignored dirs no longer show as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)