### PR TITLE
TCBT-6: --journal flag persists best-trades picks as recommendations

### DIFF
--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -652,7 +652,9 @@ def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
             score = item.get("score", 0.0)
             summary = item.get("summary_reason", "")
             breakdown = item.get("score_breakdown") or {}
-            print(f"[{idx}] {symbol} {structure} {expiration} ({dte} DTE)")
+            jid = item.get("_journal_id")
+            jid_tag = f"  [journal #{jid}]" if jid else ""
+            print(f"[{idx}] {symbol} {structure} {expiration} ({dte} DTE){jid_tag}")
             legs_line = _format_legs_from_dicts(item.get("legs") or [])
             if legs_line:
                 print(f"    Legs: {legs_line}")

--- a/main.py
+++ b/main.py
@@ -80,6 +80,7 @@ def setup_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--min-delta", type=float, default=None, help="Minimum absolute short delta (default: 0.15)")
     parser.add_argument("--max-delta", type=float, default=None, help="Maximum absolute short delta (default: 0.45)")
     parser.add_argument("--best-trades", action="store_true", help="Rank best trade ideas across watchlists")
+    parser.add_argument("--journal", action="store_true", help="When used with --best-trades: persist each top pick as a journal recommendation entry")
     parser.add_argument("--coach", action="store_true", help="AI coach: one-shot personalized daily briefing (uses Claude Max via CLAUDE_CODE_OAUTH_TOKEN)")
     parser.add_argument("--chat", action="store_true", help="AI coach: interactive chat REPL")
     parser.add_argument("--serve", action="store_true", help="Run the web dashboard (FastAPI + chat sidebar)")
@@ -297,10 +298,29 @@ async def async_main() -> int:
                 account_number=args.account or getattr(client.config, "account_number", None),
             )
 
+            if args.journal:
+                from utils import journal
+                import uuid as _uuid
+                scan_id = _uuid.uuid4().hex[:8]
+                top = result.get("top") or []
+                journaled_ids: list[str] = []
+                for cand in top:
+                    entry = journal.record_recommendation(
+                        cand,
+                        scan_id=scan_id,
+                    )
+                    cand["_journal_id"] = entry["id"]
+                    journaled_ids.append(entry["id"])
+                result["scan_id"] = scan_id
+                result["journaled_ids"] = journaled_ids
+
             if args.format == "json":
                 print(json.dumps(result, indent=2, default=str))
             else:
                 _print_best_trades_text(result, args.top)
+                if args.journal and result.get("journaled_ids"):
+                    print(f"\n[journal] saved {len(result['journaled_ids'])} recommendation(s) "
+                          f"under scan_id={result['scan_id']}: {', '.join(result['journaled_ids'])}")
 
             return 0
 

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -96,6 +96,100 @@ class TestJournalRecordAndRecall(unittest.TestCase):
         self.assertIsNotNone(s["last_ts"])
 
 
+class TestRecordRecommendation(unittest.TestCase):
+    """journal.record_recommendation builds entries from Best-Trades candidate dicts."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "journal.jsonl"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _candidate(self):
+        return {
+            "symbol": "AAPL",
+            "structure": "BULL_PUT_SPREAD",
+            "expiration": "2026-06-19",
+            "dte": 49,
+            "credit": 1.50,
+            "max_loss": 3.50,
+            "max_loss_dollars": 350.0,
+            "recommended_contracts": 2,
+            "pct_nlv_at_risk": 0.035,
+            "score": 72.5,
+            "summary_reason": "high IVR, ~30Δ short, 49 DTE",
+            "sector": "tech_hardware",
+            "legs": [{"action": "SELL", "strike": 150}, {"action": "BUY", "strike": 145}],
+        }
+
+    def test_record_recommendation_sets_kind_symbol_strategy(self):
+        entry = journal.record_recommendation(self._candidate(), path=self.path)
+        self.assertEqual(entry["kind"], "recommendation")
+        self.assertEqual(entry["symbol"], "AAPL")
+        self.assertEqual(entry["strategy"], "BULL_PUT_SPREAD")
+        self.assertIn("id", entry)
+        self.assertEqual(len(entry["id"]), 8)
+
+    def test_record_recommendation_uses_summary_reason_as_rationale(self):
+        entry = journal.record_recommendation(self._candidate(), path=self.path)
+        self.assertEqual(entry["rationale"], "high IVR, ~30Δ short, 49 DTE")
+
+    def test_record_recommendation_caps_long_rationale(self):
+        cand = self._candidate()
+        cand["summary_reason"] = "x" * 5000
+        entry = journal.record_recommendation(cand, path=self.path)
+        self.assertLessEqual(len(entry["rationale"]), 4096 + len("…[truncated]"))
+        self.assertTrue(entry["rationale"].endswith("…[truncated]"))
+
+    def test_record_recommendation_preserves_full_candidate_in_details(self):
+        cand = self._candidate()
+        entry = journal.record_recommendation(cand, path=self.path)
+        self.assertEqual(entry["details"]["candidate"]["max_loss_dollars"], 350.0)
+        self.assertEqual(entry["details"]["candidate"]["legs"][0]["strike"], 150)
+
+    def test_record_recommendation_optional_account_snapshot(self):
+        snap = {"nlv": 20000.0, "bp_usage_pct": 30.0, "over_leveraged": False}
+        entry = journal.record_recommendation(self._candidate(), account_snapshot=snap, path=self.path)
+        self.assertEqual(entry["details"]["account"]["nlv"], 20000.0)
+
+    def test_record_recommendation_optional_scan_id_links_batch(self):
+        scan_id = "abcd1234"
+        e1 = journal.record_recommendation(self._candidate(), scan_id=scan_id, path=self.path)
+        cand2 = dict(self._candidate(), symbol="MSFT")
+        e2 = journal.record_recommendation(cand2, scan_id=scan_id, path=self.path)
+        self.assertEqual(e1["details"]["scan_id"], "abcd1234")
+        self.assertEqual(e2["details"]["scan_id"], "abcd1234")
+        self.assertNotEqual(e1["id"], e2["id"])
+
+    def test_record_recommendation_round_trips_through_recall(self):
+        journal.record_recommendation(self._candidate(), path=self.path)
+        out = journal.recall(kind="recommendation", path=self.path)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["details"]["candidate"]["symbol"], "AAPL")
+
+
+class TestJournalEntryId(unittest.TestCase):
+    def test_record_assigns_id_when_missing(self):
+        tmp = tempfile.TemporaryDirectory()
+        try:
+            p = Path(tmp.name) / "journal.jsonl"
+            entry = journal.record({"kind": "note", "rationale": "x"}, path=p)
+            self.assertIn("id", entry)
+            self.assertEqual(len(entry["id"]), 8)
+        finally:
+            tmp.cleanup()
+
+    def test_record_preserves_caller_supplied_id(self):
+        tmp = tempfile.TemporaryDirectory()
+        try:
+            p = Path(tmp.name) / "journal.jsonl"
+            entry = journal.record({"kind": "note", "rationale": "x", "id": "deadbeef"}, path=p)
+            self.assertEqual(entry["id"], "deadbeef")
+        finally:
+            tmp.cleanup()
+
+
 class TestJournalConcurrentAppend(unittest.TestCase):
     """Atomic-append safety: many simultaneous record() calls produce valid JSONL."""
 

--- a/utils/journal.py
+++ b/utils/journal.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterable, Optional
@@ -48,13 +49,20 @@ def _ensure_parent(p: Path) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
 
 
+def _new_entry_id() -> str:
+    """Short, locally-unique entry id used to link follow-up records (e.g. TCBT-7
+    `--mark-outcome` promotes a `recommendation` to `trade_open` via this id)."""
+    return uuid.uuid4().hex[:8]
+
+
 def record(entry: dict[str, Any], *, path: Optional[Path] = None) -> dict[str, Any]:
-    """Append one entry. Adds ``ts`` if missing. Returns the persisted entry."""
+    """Append one entry. Adds ``ts`` and ``id`` if missing. Returns the persisted entry."""
     p = path or _path()
     _ensure_parent(p)
 
     out = dict(entry)
     out.setdefault("ts", datetime.now().isoformat(timespec="seconds"))
+    out.setdefault("id", _new_entry_id())
     kind = out.get("kind")
     if kind not in VALID_KINDS:
         logger.warning("journal: unknown kind %r; coercing to 'note'", kind)
@@ -66,6 +74,49 @@ def record(entry: dict[str, Any], *, path: Optional[Path] = None) -> dict[str, A
     with p.open("a", encoding="utf-8") as f:
         f.write(line)
     return out
+
+
+def record_recommendation(
+    candidate: dict[str, Any],
+    *,
+    account_snapshot: Optional[dict[str, Any]] = None,
+    scan_id: Optional[str] = None,
+    path: Optional[Path] = None,
+) -> dict[str, Any]:
+    """Persist one top-pick from a Best-Trades scan as a ``recommendation`` entry.
+
+    ``candidate`` is the JSON-shape dict produced by
+    ``agents.trade_ranker._candidate_to_dict`` — it already carries symbol,
+    structure, expiration, score, score_breakdown, summary_reason, and (when
+    account-aware) recommended_contracts + max_loss_dollars. We snapshot it
+    verbatim under ``details`` so a later ``trade_open`` outcome can compare
+    against the originally-recommended structure.
+
+    ``account_snapshot`` (optional) is the dict returned by
+    ``server.snapshot.assemble_dashboard_data`` or any subset of NLV/BP at the
+    time of the recommendation — captured so we can reason about position
+    sizing relative to account state when the trade later closes.
+
+    ``scan_id`` is a free-form identifier linking multiple recommendations
+    from the same Best-Trades run.
+    """
+    rationale = candidate.get("summary_reason") or ""
+    if len(rationale) > 4096:
+        rationale = rationale[:4096] + "…[truncated]"
+    entry: dict[str, Any] = {
+        "kind": "recommendation",
+        "symbol": candidate.get("symbol"),
+        "strategy": candidate.get("structure"),
+        "rationale": rationale,
+        "details": {
+            "candidate": candidate,
+        },
+    }
+    if account_snapshot is not None:
+        entry["details"]["account"] = account_snapshot
+    if scan_id is not None:
+        entry["details"]["scan_id"] = scan_id
+    return record(entry, path=path)
 
 
 def _iter_entries(path: Path) -> Iterable[dict[str, Any]]:


### PR DESCRIPTION
## Summary

Closes the loop between Best-Trades output and the journal. After running with \`--best-trades --journal\`, each top pick is persisted as a \`recommendation\` entry in \`~/.tasty-coach/journal.jsonl\` with a fresh 8-char id and a shared \`scan_id\` linking the siblings of one run.

This is the foundation for TCBT-7 (\`--mark-outcome\` promoting a recommendation to \`trade_open\` via its id) and TCBT-11 (learning-index markdown export).

## Highlights

- \`utils/journal.py.record()\` now assigns a uuid4-based 8-hex id when missing; caller-supplied ids preserved.
- \`utils/journal.py.record_recommendation(candidate, *, account_snapshot, scan_id)\` builds a recommendation entry from the JSON candidate dict the ranker already emits — the full candidate (including legs / score breakdown / sizing) lands under \`details.candidate\` so a future close-out can compare against the original structure.
- \`main.py --journal\` flag wires the call site. JSON output gains \`scan_id\` + \`journaled_ids\`; the text printer shows \`[journal #abc12]\` next to each pick.

## Test plan

- [x] \`unittest discover tests\` — 528 tests, 522 passing. Same 6 pre-existing failures only.
- [x] 9 new tests cover record_recommendation (kind/symbol/strategy, rationale truncation, candidate preserved in details, account_snapshot + scan_id, recall round-trip) and record() id assignment + caller-supplied id preservation.
- [x] \`python main.py --help\` shows the new \`--journal\` flag.
- [ ] Smoke run \`python main.py --best-trades --top 3 --journal\` against live account to verify the journal file gains 3 entries.

## Smoke-test notes from the parent session

The dollar-accounting + sector-gate fix shipped in #35 is firing as expected on real positions: account filters rejected 53 of 81 candidates that would have passed under the old buggy code path. The dashboard correctly surfaces \`over_leveraged: true\` for the PM account where \`bp_usage_pct = -54.3\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)