### PR TITLE
TCBT-put-selector: cash-secured-put screener (--put-selector)

### DIFF
--- a/agents/options_researcher.py
+++ b/agents/options_researcher.py
@@ -68,6 +68,51 @@ def _parse_market_data_item(item: Dict[str, Any]) -> Any:
             open_interest=_to_decimal(item.get("open-interest")),
         )
 
+def _compute_put_call_skew(rows: List["StrikeRow"]) -> Optional[float]:
+    """Return put/call IV ratio at ~SKEW_REFERENCE_DELTA, or None.
+
+    Picks the put and call whose absolute delta is closest to
+    ``SKEW_REFERENCE_DELTA`` (defaults to 0.25). Returns ``put.iv / call.iv``.
+    Higher values (>1.20 typical) indicate elevated downside fear — premium
+    on the put side is rich relative to the call side, often a sign that
+    crash protection is being bid up. Returns None if either leg lacks IV
+    or no strikes within range exist.
+    """
+    if not rows:
+        return None
+    target = SKEW_REFERENCE_DELTA
+
+    best_put: Optional["StrikeRow"] = None
+    best_call: Optional["StrikeRow"] = None
+    best_put_diff = float("inf")
+    best_call_diff = float("inf")
+
+    for r in rows:
+        if r.delta is None or r.iv is None or r.iv <= 0:
+            continue
+        diff = abs(abs(r.delta) - target)
+        if r.option_type == "PUT":
+            if diff < best_put_diff:
+                best_put_diff = diff
+                best_put = r
+        elif r.option_type == "CALL":
+            if diff < best_call_diff:
+                best_call_diff = diff
+                best_call = r
+
+    if best_put is None or best_call is None:
+        return None
+    if best_call.iv is None or best_call.iv <= 0:
+        return None
+    # Reject when neither leg is anywhere near the reference delta — sparse
+    # OTM chains can otherwise compare a 25Δ put against a 50Δ ATM call,
+    # yielding a meaningless ratio.
+    SKEW_MAX_DELTA_DISTANCE = 0.10
+    if best_put_diff > SKEW_MAX_DELTA_DISTANCE or best_call_diff > SKEW_MAX_DELTA_DISTANCE:
+        return None
+    return float(best_put.iv) / float(best_call.iv)
+
+
 # Module-level constants
 DEFAULT_DTE_TARGET = 45
 DTE_FALLBACK_MIN = 25
@@ -83,6 +128,14 @@ GREEKS_TIMEOUT_SECONDS = 8
 MARKET_DATA_BATCH_SIZE = 20
 MARKET_DATA_MAX_URL_CHARS = 400
 MAX_IDEAS_RETURNED = 20
+
+# Cash-secured-put screener defaults (income-focused; lower delta than wheel).
+CSP_DELTA_MIN = 0.15
+CSP_DELTA_MAX = 0.30
+CSP_MIN_OTM_PCT = 0.03
+CSP_MAX_PER_SYMBOL = 5
+# Reference target delta when picking comparable put/call legs for skew.
+SKEW_REFERENCE_DELTA = 0.25
 
 
 @dataclass
@@ -154,6 +207,8 @@ class OptionsResearcherAgent:
         self,
         symbol: str,
         expiration: Optional[date] = None,
+        *,
+        underlying_price: Optional[float] = None,
     ) -> Dict[str, Any]:
         """
         Research options chain for a symbol and return ranked trade ideas.
@@ -161,6 +216,10 @@ class OptionsResearcherAgent:
         Args:
             symbol: Underlying symbol (e.g., 'AAPL')
             expiration: Optional target expiration date
+            underlying_price: Spot price for CSP screening; when omitted,
+                cash-secured-put ideas are skipped (callers without a watchlist
+                scan can't compute pct_otm). Spread/iron-condor emission is
+                unaffected.
 
         Returns:
             Dict with status, trade ideas, and metadata
@@ -308,6 +367,31 @@ class OptionsResearcherAgent:
             if ic_idea:
                 ideas_list.append(ic_idea)
 
+        # Build Cash-Secured Puts (one per qualifying strike).
+        # Requires a spot reference to compute pct_otm; skipped if missing.
+        if underlying_price is not None and underlying_price > 0:
+            # Pull CSP settings if available; fall back to module-level defaults.
+            try:
+                from utils.settings import settings as _settings
+                csp_delta_min = _settings.get("bt_csp_delta_min")
+                csp_delta_max = _settings.get("bt_csp_delta_max")
+                csp_min_otm = _settings.get("bt_csp_min_otm_pct")
+                csp_cap = _settings.get("bt_csp_max_per_symbol")
+            except Exception:
+                csp_delta_min = csp_delta_max = csp_min_otm = csp_cap = None
+            csp_ideas = self._build_cash_secured_puts(
+                put_rows, symbol, expiration_date, dte, underlying_price,
+                delta_min=csp_delta_min,
+                delta_max=csp_delta_max,
+                min_otm_pct=csp_min_otm,
+                max_per_symbol=csp_cap,
+            )
+            ideas_list.extend(csp_ideas)
+
+        # Compute put/call skew at the screened expiration; surfaced on the
+        # report so callers (trade_ranker) can attach it to SymbolContext.
+        put_call_skew = _compute_put_call_skew(rows)
+
         # Rank and trim
         ranked_ideas = self._rank_and_trim(ideas_list)
 
@@ -322,7 +406,8 @@ class OptionsResearcherAgent:
             rows=rows,
             ideas=ranked_ideas,
             status=status,
-            warnings=warnings
+            warnings=warnings,
+            put_call_skew=put_call_skew,
         )
 
     async def _resolve_expiration(
@@ -843,6 +928,109 @@ class OptionsResearcherAgent:
             legs=put_idea.legs + call_idea.legs,
         )
 
+    def _build_cash_secured_puts(
+        self,
+        rows: List[StrikeRow],
+        symbol: str,
+        expiration: date,
+        dte: int,
+        underlying_price: float,
+        *,
+        delta_min: Optional[float] = None,
+        delta_max: Optional[float] = None,
+        min_otm_pct: Optional[float] = None,
+        max_per_symbol: Optional[int] = None,
+    ) -> List[TradeIdea]:
+        """
+        Emit one TradeIdea per qualifying OTM PUT strike for the cash-secured-put
+        screener. Filters by abs(delta) in [CSP_DELTA_MIN, CSP_DELTA_MAX] and
+        pct_otm >= CSP_MIN_OTM_PCT. trade_ranker scores each independently so
+        we don't pre-rank here; we just trim to CSP_MAX_PER_SYMBOL by mid desc
+        to avoid candidate bloat.
+
+        Sets:
+            width = strike (so credit_pct_of_width = credit/strike, the
+                "yield on capital" metric).
+            max_loss = strike - credit (per share, in points; conservative
+                assignment-to-zero bound — multiply by 100 for dollars in
+                trade_ranker._dollar_max_loss).
+            credit = mid (per share, in points).
+            score = 0.0; trade_ranker._score_csp_candidate fills it in.
+        """
+        if underlying_price <= 0:
+            return []
+
+        d_min = delta_min if delta_min is not None else CSP_DELTA_MIN
+        d_max = delta_max if delta_max is not None else CSP_DELTA_MAX
+        otm_floor = min_otm_pct if min_otm_pct is not None else CSP_MIN_OTM_PCT
+        cap = max_per_symbol if max_per_symbol is not None else CSP_MAX_PER_SYMBOL
+
+        ideas: List[TradeIdea] = []
+        for r in rows:
+            if r.option_type != "PUT":
+                continue
+            if r.delta is None or r.mid is None or r.mid <= 0:
+                continue
+            abs_delta = abs(r.delta)
+            if not (d_min <= abs_delta <= d_max):
+                continue
+            if r.strike >= underlying_price:
+                continue  # ITM — not a CSP entry
+            pct_otm = (underlying_price - r.strike) / underlying_price
+            if pct_otm < otm_floor:
+                continue
+
+            credit = float(r.mid)
+            strike = float(r.strike)
+            max_loss = strike - credit  # per share, in points
+            credit_pct_of_strike = credit / strike if strike > 0 else 0.0
+            pop = 1.0 - abs_delta
+
+            ideas.append(TradeIdea(
+                strategy="CASH_SECURED_PUT",
+                symbol=symbol,
+                expiration=expiration,
+                dte=dte,
+                short_strike=strike,
+                long_strike=0.0,
+                width=strike,
+                credit=credit,
+                max_loss=max_loss,
+                credit_pct_of_width=credit_pct_of_strike,
+                short_delta=float(r.delta),
+                net_delta=-float(r.delta),
+                net_gamma=-(float(r.gamma) if r.gamma is not None else 0.0),
+                net_theta=-(float(r.theta) if r.theta is not None else 0.0),
+                net_vega=-(float(r.vega) if r.vega is not None else 0.0),
+                breakeven=[strike - credit],
+                pop_estimate=pop,
+                score=0.0,
+                score_breakdown={},
+                legs=[
+                    {
+                        "action": "SELL",
+                        "option_type": "PUT",
+                        "strike": strike,
+                        "occ_symbol": r.occ_symbol,
+                        "streamer_symbol": r.streamer_symbol,
+                        "bid": float(r.bid) if r.bid is not None else None,
+                        "ask": float(r.ask) if r.ask is not None else None,
+                        "mid": credit,
+                        "volume": int(r.volume) if r.volume is not None else None,
+                        "open_interest": int(r.open_interest) if r.open_interest is not None else None,
+                        "delta": float(r.delta),
+                        "gamma": float(r.gamma) if r.gamma is not None else None,
+                        "theta": float(r.theta) if r.theta is not None else None,
+                        "vega": float(r.vega) if r.vega is not None else None,
+                        "iv": float(r.iv) if r.iv is not None else None,
+                    },
+                ],
+            ))
+
+        # Trim to top-N by premium so we don't flood the ranker.
+        ideas.sort(key=lambda i: i.credit, reverse=True)
+        return ideas[:cap]
+
     def _score_idea(self, idea_draft: Dict[str, Any]) -> Tuple[float, Dict[str, float]]:
         """
         Score a trade idea using the formula.
@@ -957,6 +1145,7 @@ class OptionsResearcherAgent:
         ideas: List[TradeIdea],
         status: str,
         warnings: List[str],
+        put_call_skew: Optional[float] = None,
     ) -> Dict[str, Any]:
         """
         Build final report dictionary for serialization.
@@ -1044,6 +1233,7 @@ class OptionsResearcherAgent:
             'chain_summary': chain_summary,
             'warnings': warnings,
             'trade_ideas': ideas_list,
+            'put_call_skew': put_call_skew,
         }
 
         return report

--- a/agents/trade_ranker.py
+++ b/agents/trade_ranker.py
@@ -54,6 +54,9 @@ class SymbolContext:
     beta: Optional[float] = None
     liquidity_rank: Optional[float] = None
     next_earnings_date: Optional[date] = None
+    # Put/call IV ratio at ~25Δ; populated post-research, drives the
+    # "elevated downside fear" warning surfaced by the put-selector.
+    put_call_skew: Optional[float] = None
 
 
 @dataclass
@@ -133,12 +136,15 @@ async def generate_candidates(
     max_per_symbol: int = 3,
     concurrency: int = 1,
     timeout_seconds: Optional[float] = None,
+    structure_filter: Optional[str] = None,
 ) -> tuple[list[Candidate], list[Rejection]]:
     """For each SymbolContext, call OptionsResearcherAgent.research; return candidates + rejections.
 
     `concurrency` caps simultaneous research calls (default 1 = sequential).
     `timeout_seconds` applies a per-symbol hard cap; on timeout the symbol becomes a
     research_timeout rejection instead of blocking the run.
+    `structure_filter` (e.g. "CASH_SECURED_PUT") restricts emitted candidates to
+    one structure type; ``None`` admits all structures the researcher emits.
     """
     candidates: list[Candidate] = []
     rejections: list[Rejection] = []
@@ -161,14 +167,27 @@ async def generate_candidates(
     async def research_one(idx: int, ctx: SymbolContext):
         async with semaphore:
             logger.info("[%d/%d] %s", idx, total, ctx.symbol)
+            underlying_price = (
+                float(ctx.current_price) if ctx.current_price is not None else None
+            )
+            # CSP screening requires a spot reference; without it the
+            # researcher can't compute pct_otm and emits no CSP ideas. If the
+            # caller is filtering for CSPs, surface this as a rejection rather
+            # than letting the symbol disappear silently.
+            if structure_filter == "CASH_SECURED_PUT" and underlying_price is None:
+                return ctx, None, Rejection(
+                    symbol=ctx.symbol,
+                    reason="no_spot_for_csp",
+                    detail="underlying spot unavailable; cannot compute pct_otm",
+                )
             try:
                 if timeout_seconds is not None:
                     report = await asyncio.wait_for(
-                        researcher.research(ctx.symbol),
+                        researcher.research(ctx.symbol, underlying_price=underlying_price),
                         timeout=timeout_seconds,
                     )
                 else:
-                    report = await researcher.research(ctx.symbol)
+                    report = await researcher.research(ctx.symbol, underlying_price=underlying_price)
             except asyncio.TimeoutError:
                 logger.warning("[%d/%d] %s: timed out after %ss", idx, total, ctx.symbol, timeout_seconds)
                 return ctx, None, Rejection(
@@ -199,7 +218,11 @@ async def generate_candidates(
             logger.info("%s: %s", ctx.symbol, status)
             rejections.append(Rejection(symbol=ctx.symbol, reason=str(status), detail=detail))
             continue
+        # Attach skew to context so the printer / scoring can reach it.
+        ctx.put_call_skew = report.get("put_call_skew")
         ideas = report.get("trade_ideas") or []
+        if structure_filter is not None:
+            ideas = [i for i in ideas if i.get("strategy") == structure_filter]
         accepted = ideas[:max_per_symbol]
         logger.info("%s: %d ideas", ctx.symbol, len(accepted))
         for idea in accepted:
@@ -330,6 +353,10 @@ def _load_thresholds() -> dict[str, Any]:
         "research_concurrency": settings.get("bt_research_concurrency"),
         "research_timeout_seconds": settings.get("bt_research_timeout_seconds"),
         "per_trade_risk_pct": settings.get("bt_per_trade_risk_pct"),
+        "csp_min_otm_pct": settings.get("bt_csp_min_otm_pct"),
+        "csp_min_annualized_return": settings.get("bt_csp_min_annualized_return"),
+        "csp_skew_warn_threshold": settings.get("bt_csp_skew_warn_threshold"),
+        "csp_max_pct_nlv_per_trade": settings.get("bt_csp_max_pct_nlv_per_trade"),
     }
 
 
@@ -401,6 +428,7 @@ def _candidate_to_dict(
         "credit": float(c.credit),
         "max_loss": float(c.max_loss),
         "short_delta": float(c.short_delta),
+        "pop_estimate": float(c.pop_estimate),
         "breakevens": [float(b) for b in c.breakevens],
         "score": float(c.score),
         "score_breakdown": dict(c.score_breakdown) if c.score_breakdown else {},
@@ -408,6 +436,22 @@ def _candidate_to_dict(
         "legs": [dict(leg) for leg in (c.legs or [])],
         "sector": get_sector(c.symbol),
     }
+
+    # CSP-specific metrics (article's "balanced" dimensions made visible).
+    if c.structure == "CASH_SECURED_PUT":
+        strike = _csp_short_strike(c)
+        if strike > 0:
+            payload["cash_required"] = strike * 100.0
+            if c.dte > 0:
+                payload["annualized_return"] = (c.credit * 365.0 / c.dte) / strike
+                payload["premium_per_day"] = c.credit / c.dte
+            spot = c.context.current_price
+            if spot is not None and float(spot) > 0:
+                payload["pct_otm"] = (float(spot) - strike) / float(spot)
+                payload["spot_price"] = float(spot)
+        skew = c.context.put_call_skew
+        if skew is not None:
+            payload["put_call_skew"] = float(skew)
 
     if account_state and account_state.nlv > 0 and c.max_loss > 0:
         dollar_risk = _dollar_max_loss(c)
@@ -524,8 +568,13 @@ async def run_best_trades(
     output_format: str = "text",
     account_number: Optional[str] = None,
     today: Optional[date] = None,
+    structure_filter: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Run the full Best-Trades pipeline and return a canonical result dict."""
+    """Run the full Best-Trades pipeline and return a canonical result dict.
+
+    ``structure_filter`` (e.g. "CASH_SECURED_PUT") restricts emitted candidates
+    to one structure type. None admits all structures.
+    """
     resolved_watchlists = list(watchlists) if watchlists is not None else list(DEFAULT_WATCHLISTS)
     result: dict[str, Any] = {
         "top": [],
@@ -561,6 +610,7 @@ async def run_best_trades(
         max_per_symbol=thresholds["max_per_symbol"],
         concurrency=thresholds["research_concurrency"],
         timeout_seconds=thresholds["research_timeout_seconds"],
+        structure_filter=structure_filter,
     )
     for r in gen_rejections:
         result["rejected"].append(_rejection_to_dict(r))
@@ -605,6 +655,7 @@ async def run_best_trades(
             max_pct_nlv_per_trade=thresholds["max_pct_nlv_per_trade"],
             bp_cap_for_new=thresholds["bp_cap_for_new"],
             concentration_block_pct=thresholds["concentration_block_pct"],
+            csp_max_pct_nlv_per_trade=thresholds.get("csp_max_pct_nlv_per_trade"),
         )
         for r in account_rejections:
             result["rejected"].append(_rejection_to_dict(r))
@@ -613,12 +664,19 @@ async def run_best_trades(
         if not passing:
             return result
 
-    scored = score_candidates(passing, today=today, account_state=account_state)
+    scored = score_candidates(
+        passing,
+        today=today,
+        account_state=account_state,
+        csp_min_otm_pct=thresholds.get("csp_min_otm_pct"),
+        csp_min_annualized_return=thresholds.get("csp_min_annualized_return"),
+    )
     selected = _select_top_per_symbol(scored, top)
     result["top"] = [
         _candidate_to_dict(c, account_state=account_state, per_trade_risk_pct=thresholds.get("per_trade_risk_pct"))
         for c in selected
     ]
+    result["csp_skew_warn_threshold"] = thresholds.get("csp_skew_warn_threshold")
     logger.info("done: %d top trades selected from %d scored candidates", len(result["top"]), len(scored))
     return result
 
@@ -641,6 +699,7 @@ def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
     if not top_items:
         print("No trades passed all gates today.")
     else:
+        skew_warn_threshold = result.get("csp_skew_warn_threshold", 1.20)
         for idx, item in enumerate(top_items, start=1):
             symbol = item.get("symbol", "?")
             structure = item.get("structure", "?")
@@ -654,11 +713,35 @@ def _print_best_trades_text(result: dict[str, Any], top: int) -> None:
             breakdown = item.get("score_breakdown") or {}
             jid = item.get("_journal_id")
             jid_tag = f"  [journal #{jid}]" if jid else ""
+
             print(f"[{idx}] {symbol} {structure} {expiration} ({dte} DTE){jid_tag}")
+            # Skew warning printed under the symbol line for CSPs so the
+            # association is unambiguous when scrolling.
+            skew = item.get("put_call_skew")
+            if structure == "CASH_SECURED_PUT" and skew is not None and skew >= skew_warn_threshold:
+                print(f"    ⚠ put/call skew {skew:.2f} — elevated downside fear; consider smaller size or vertical")
             legs_line = _format_legs_from_dicts(item.get("legs") or [])
             if legs_line:
                 print(f"    Legs: {legs_line}")
-            print(f"    Credit ${credit * 100:.0f} / Max risk ${max_loss_dollars:.0f} per contract")
+
+            if structure == "CASH_SECURED_PUT":
+                cash_required = item.get("cash_required")
+                annualized = item.get("annualized_return")
+                premium_per_day = item.get("premium_per_day")
+                pct_otm = item.get("pct_otm")
+                pop = item.get("pop_estimate")
+                ann_str = f" / Annualized {annualized * 100:.1f}%" if annualized is not None else ""
+                cash_str = f" / Cash required ${cash_required:,.0f}" if cash_required is not None else ""
+                print(f"    Credit ${credit * 100:.0f}{cash_str}{ann_str}")
+                buf = f"Buffer {pct_otm * 100:.1f}% OTM" if pct_otm is not None else ""
+                pop_str = f"POP {pop * 100:.0f}%" if pop is not None else ""
+                ppd = f"Premium/day ${premium_per_day * 100:.2f}" if premium_per_day is not None else ""
+                line2 = " · ".join([s for s in (buf, pop_str, ppd) if s])
+                if line2:
+                    print(f"    {line2}")
+            else:
+                print(f"    Credit ${credit * 100:.0f} / Max risk ${max_loss_dollars:.0f} per contract")
+
             recommended = item.get("recommended_contracts")
             pct_at_risk = item.get("pct_nlv_at_risk")
             if recommended is not None:
@@ -851,8 +934,15 @@ def apply_account_filters(
     max_pct_nlv_per_trade: float,
     bp_cap_for_new: float,
     concentration_block_pct: float,
+    csp_max_pct_nlv_per_trade: Optional[float] = None,
 ) -> tuple[list[Candidate], list[Rejection]]:
-    """Hard-reject candidates that worsen account state beyond configured caps."""
+    """Hard-reject candidates that worsen account state beyond configured caps.
+
+    CSPs use a separate (more permissive) per-trade size cap because their
+    assignment-to-zero max-loss is the full strike — applying the spread cap
+    of 5% NLV would reject every CSP on small accounts. Pass
+    ``csp_max_pct_nlv_per_trade`` (typically 0.30) to gate CSPs separately.
+    """
     survivors: list[Candidate] = []
     rejections: list[Rejection] = []
 
@@ -872,15 +962,22 @@ def apply_account_filters(
     for c in candidates:
         dollar_risk = _dollar_max_loss(c)
         size_pct = dollar_risk / nlv
+        # CSPs get their own (more permissive) cap — the spread cap is meant
+        # for vertical max-loss, not assignment-to-zero capital risk.
+        cap_for_this = (
+            csp_max_pct_nlv_per_trade
+            if c.structure == "CASH_SECURED_PUT" and csp_max_pct_nlv_per_trade is not None
+            else max_pct_nlv_per_trade
+        )
 
-        if size_pct > max_pct_nlv_per_trade:
+        if size_pct > cap_for_this:
             rejections.append(Rejection(
                 symbol=c.symbol,
                 reason="oversized_vs_nlv",
                 detail=(
                     f"max_loss ${dollar_risk:.0f} = "
                     f"{size_pct * 100:.1f}% NLV above cap "
-                    f"{max_pct_nlv_per_trade * 100:.1f}%"
+                    f"{cap_for_this * 100:.1f}%"
                 ),
             ))
             continue
@@ -942,6 +1039,16 @@ _WEIGHT_VOLATILITY_EDGE: float = 25.0
 _WEIGHT_EVENT_RISK: float = 10.0
 _WEIGHT_STRUCTURE_QUALITY: float = 20.0
 _WEIGHT_ACCOUNT_FIT: float = 10.0
+
+# Cash-Secured-Put scoring weights — five article dimensions plus account_fit.
+# Total is 100 before any concentration penalty (subtractive, shared with
+# spreads). Income < Distance reflects "survival first, gains second".
+_WEIGHT_CSP_INCOME: float = 20.0
+_WEIGHT_CSP_DISTANCE: float = 25.0
+_WEIGHT_CSP_POP: float = 20.0
+_WEIGHT_CSP_VOL_ENV: float = 15.0
+_WEIGHT_CSP_TIME_EFFICIENCY: float = 10.0
+# 90 from CSP-specific dimensions; remaining 10 reuses _WEIGHT_ACCOUNT_FIT.
 
 
 def _score_regime_fit(candidate: Candidate) -> float:
@@ -1017,10 +1124,18 @@ def _score_account_fit(
     candidate: Candidate,
     account_state: Optional[AccountState] = None,
 ) -> float:
-    """Score 0..10 for trade-size fit; placeholder 10.0 when account_state is None or NLV non-positive."""
+    """Score 0..10 for trade-size fit; placeholder 10.0 when account_state is None or NLV non-positive.
+
+    CSPs use a wider linear ramp (10..0 over [10%, 25%] of NLV) because
+    their assignment-to-zero max-loss is fundamentally larger than spread
+    max-loss. Spreads keep the original 10..0 over [2%, 5%] ramp.
+    """
     if account_state is None or account_state.nlv <= 0:
         return _WEIGHT_ACCOUNT_FIT
     pct = _dollar_max_loss(candidate) / account_state.nlv
+    if candidate.structure == "CASH_SECURED_PUT":
+        # 10 at <=10% NLV; 0 at >=25% NLV; linear in between.
+        return max(0.0, min(10.0, 10.0 * (0.25 - pct) / 0.15))
     return max(0.0, min(10.0, 10.0 * (0.05 - pct) / 0.03))
 
 
@@ -1034,6 +1149,97 @@ def _score_concentration_penalty(
     existing = account_state.existing_exposures.get(candidate.symbol, 0.0)
     post_trade_pct = (existing + _dollar_max_loss(candidate)) / account_state.nlv
     return max(0.0, min(10.0, 10.0 * (post_trade_pct - 0.05) / 0.20))
+
+
+def _csp_short_strike(candidate: Candidate) -> float:
+    """Pull the short-put strike off the candidate's single SELL leg."""
+    for leg in candidate.legs or []:
+        if leg.get("action") == "SELL":
+            strike = leg.get("strike")
+            if strike is not None:
+                return float(strike)
+    return 0.0
+
+
+def _csp_annualized_return(candidate: Candidate) -> float:
+    """(credit * 365 / dte) / strike. Yield on cash-secured capital."""
+    strike = _csp_short_strike(candidate)
+    if strike <= 0 or candidate.dte <= 0:
+        return 0.0
+    return (candidate.credit * 365.0 / candidate.dte) / strike
+
+
+def _score_csp_income(candidate: Candidate, min_annualized_return: float) -> float:
+    """0..20 by annualized return, ramping from min_annualized_return up to 0.30 (30%).
+
+    Saturates at the cap when the user-tuned floor exceeds the cap (avoid
+    div-by-zero / negative-range artefacts).
+    """
+    ann = _csp_annualized_return(candidate)
+    if ann <= min_annualized_return:
+        return 0.0
+    span = 0.30 - min_annualized_return
+    if span <= 0:
+        return _WEIGHT_CSP_INCOME
+    factor = min(1.0, (ann - min_annualized_return) / span)
+    return _WEIGHT_CSP_INCOME * factor
+
+
+def _score_csp_distance(candidate: Candidate, min_otm_pct: float) -> float:
+    """0..25 by buffer below spot, ramping from min_otm_pct up to 0.15 (15% OTM)."""
+    spot = candidate.context.current_price
+    if spot is None or float(spot) <= 0:
+        return 0.0
+    strike = _csp_short_strike(candidate)
+    if strike <= 0:
+        return 0.0  # malformed candidate — no SELL leg
+    pct_otm = (float(spot) - strike) / float(spot)
+    if pct_otm < min_otm_pct:
+        return 0.0
+    span = 0.15 - min_otm_pct
+    if span <= 0:
+        return _WEIGHT_CSP_DISTANCE
+    factor = min(1.0, (pct_otm - min_otm_pct) / span)
+    return _WEIGHT_CSP_DISTANCE * factor
+
+
+def _score_csp_pop(candidate: Candidate) -> float:
+    """0..20 by 1 - |delta|, ramping over [0.65, 0.85]."""
+    pop = 1.0 - abs(candidate.short_delta or 0.0)
+    factor = max(0.0, min(1.0, (pop - 0.65) / 0.20))
+    return _WEIGHT_CSP_POP * factor
+
+
+def _score_csp_vol_env(candidate: Candidate) -> float:
+    """0..15 by IVR ramping over [30, 70]; placeholder 7.5 when IVR is None."""
+    ivr = candidate.context.iv_rank
+    if ivr is None:
+        return _WEIGHT_CSP_VOL_ENV * 0.5
+    factor = max(0.0, min(1.0, (ivr - 30.0) / 40.0))
+    return _WEIGHT_CSP_VOL_ENV * factor
+
+
+def _score_csp_time_efficiency(candidate: Candidate) -> float:
+    """0..10 by DTE bucket fit. Peaks 30..45 DTE.
+
+    Sub-21 DTE is penalised harder than >60 DTE — the article calls out gamma
+    risk on short-DTE puts as more dangerous than the slow time decay of
+    longer-dated. Floor 0.10 below 21d, 0.40 above 60d.
+    """
+    dte = candidate.dte
+    if dte <= 0:
+        return 0.0
+    if 30 <= dte <= 45:
+        factor = 1.0
+    elif 21 <= dte < 30:
+        factor = (dte - 21) / 9.0  # ramp 0..1
+    elif 45 < dte <= 60:
+        factor = 1.0 - (dte - 45) / 15.0  # ramp 1..0
+    elif dte < 21:
+        factor = 0.10  # gamma risk
+    else:  # dte > 60
+        factor = 0.40  # slow theta but not blow-up territory
+    return _WEIGHT_CSP_TIME_EFFICIENCY * factor
 
 
 def _format_summary_reason(
@@ -1092,15 +1298,115 @@ def _format_summary_reason(
     return ", ".join(phrases[:4])
 
 
+def _score_csp_candidate(
+    candidate: Candidate,
+    *,
+    today: date,
+    account_state: Optional[AccountState] = None,
+    min_otm_pct: float = 0.03,
+    min_annualized_return: float = 0.10,
+) -> Candidate:
+    """CSP scoring path — five article dimensions plus account_fit + penalty.
+
+    Total score is bounded to [0, 100]. Concentration penalty is shared with
+    spreads (subtractive). Earnings risk is folded into the time_efficiency
+    + distance components rather than its own bucket — CSPs near earnings
+    typically blow through buffer regardless of DTE bucket.
+    """
+    income = _score_csp_income(candidate, min_annualized_return)
+    distance = _score_csp_distance(candidate, min_otm_pct)
+    pop = _score_csp_pop(candidate)
+    vol_env = _score_csp_vol_env(candidate)
+    time_eff = _score_csp_time_efficiency(candidate)
+    account = _score_account_fit(candidate, account_state)
+    penalty = _score_concentration_penalty(candidate, account_state)
+    # Earnings within 7d → drop time_efficiency to floor (matches spread gate intent).
+    if candidate.context.next_earnings_date is not None:
+        days_to_earnings = (candidate.context.next_earnings_date - today).days
+        if 0 <= days_to_earnings <= 7:
+            time_eff = 0.0
+
+    breakdown: dict[str, float] = {
+        "csp_income": income,
+        "csp_distance": distance,
+        "csp_pop": pop,
+        "csp_vol_env": vol_env,
+        "csp_time_efficiency": time_eff,
+        "account_fit": account,
+        "concentration_penalty": penalty,
+    }
+
+    total = income + distance + pop + vol_env + time_eff + account - penalty
+    score = max(0.0, min(100.0, total))
+
+    summary = _format_csp_summary_reason(candidate, breakdown)
+
+    return replace(
+        candidate,
+        score=score,
+        score_breakdown=breakdown,
+        summary_reason=summary,
+    )
+
+
+def _format_csp_summary_reason(candidate: Candidate, breakdown: dict[str, float]) -> str:
+    """One-line plain-English string of the strongest CSP factors."""
+    phrases: list[str] = []
+    ivr = candidate.context.iv_rank
+    if breakdown["csp_vol_env"] / _WEIGHT_CSP_VOL_ENV >= 0.6 and ivr is not None:
+        phrases.append(f"IVR {round(ivr)}")
+
+    spot = candidate.context.current_price
+    if spot is not None and float(spot) > 0:
+        pct_otm = (float(spot) - _csp_short_strike(candidate)) / float(spot)
+        if pct_otm >= 0.05:
+            phrases.append(f"{pct_otm * 100:.1f}% OTM buffer")
+
+    pop = 1.0 - abs(candidate.short_delta or 0.0)
+    if pop >= 0.75:
+        phrases.append(f"POP {pop * 100:.0f}%")
+
+    ann = _csp_annualized_return(candidate)
+    if ann >= 0.12:
+        phrases.append(f"{ann * 100:.1f}% annualized")
+
+    if 30 <= candidate.dte <= 45:
+        phrases.append("prime DTE")
+
+    skew = candidate.context.put_call_skew
+    if skew is not None and skew >= 1.20:
+        phrases.append(f"⚠ skew {skew:.2f}")
+
+    if not phrases:
+        return "weak across CSP factors"
+    return ", ".join(phrases[:5])
+
+
 def score_candidate(
     candidate: Candidate,
     *,
     today: Optional[date] = None,
     account_state: Optional[AccountState] = None,
+    csp_min_otm_pct: Optional[float] = None,
+    csp_min_annualized_return: Optional[float] = None,
 ) -> Candidate:
-    """Return a new Candidate with score, score_breakdown, and summary_reason populated."""
+    """Return a new Candidate with score, score_breakdown, and summary_reason populated.
+
+    Dispatches to the CSP-specific scoring path when the candidate's structure
+    is ``CASH_SECURED_PUT``; spreads/iron-condors keep the original 7-component
+    formula.
+    """
     if today is None:
         today = date.today()
+
+    if candidate.structure == "CASH_SECURED_PUT":
+        return _score_csp_candidate(
+            candidate,
+            today=today,
+            account_state=account_state,
+            min_otm_pct=csp_min_otm_pct if csp_min_otm_pct is not None else 0.03,
+            min_annualized_return=csp_min_annualized_return if csp_min_annualized_return is not None else 0.10,
+        )
 
     regime = _score_regime_fit(candidate)
     liquidity = _score_liquidity(candidate)
@@ -1138,8 +1444,19 @@ def score_candidates(
     *,
     today: Optional[date] = None,
     account_state: Optional[AccountState] = None,
+    csp_min_otm_pct: Optional[float] = None,
+    csp_min_annualized_return: Optional[float] = None,
 ) -> list[Candidate]:
     """Score each candidate; preserve input order; pure (returns new list of new Candidates)."""
     if today is None:
         today = date.today()
-    return [score_candidate(c, today=today, account_state=account_state) for c in candidates]
+    return [
+        score_candidate(
+            c,
+            today=today,
+            account_state=account_state,
+            csp_min_otm_pct=csp_min_otm_pct,
+            csp_min_annualized_return=csp_min_annualized_return,
+        )
+        for c in candidates
+    ]

--- a/main.py
+++ b/main.py
@@ -80,7 +80,8 @@ def setup_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--min-delta", type=float, default=None, help="Minimum absolute short delta (default: 0.15)")
     parser.add_argument("--max-delta", type=float, default=None, help="Maximum absolute short delta (default: 0.45)")
     parser.add_argument("--best-trades", action="store_true", help="Rank best trade ideas across watchlists")
-    parser.add_argument("--journal", action="store_true", help="When used with --best-trades: persist each top pick as a journal recommendation entry")
+    parser.add_argument("--put-selector", action="store_true", help="Cash-secured-put screener: scan watchlists for income-focused short puts ranked on income/buffer/POP/IV/time")
+    parser.add_argument("--journal", action="store_true", help="When used with --best-trades or --put-selector: persist each top pick as a journal recommendation entry")
     parser.add_argument("--coach", action="store_true", help="AI coach: one-shot personalized daily briefing (uses Claude Max via CLAUDE_CODE_OAUTH_TOKEN)")
     parser.add_argument("--chat", action="store_true", help="AI coach: interactive chat REPL")
     parser.add_argument("--serve", action="store_true", help="Run the web dashboard (FastAPI + chat sidebar)")
@@ -287,15 +288,17 @@ async def async_main() -> int:
                 await run_chat(ctx)
             return 0
 
-        if args.best_trades:
+        if args.best_trades or args.put_selector:
             from agents.trade_ranker import run_best_trades, _print_best_trades_text
 
+            structure_filter = "CASH_SECURED_PUT" if args.put_selector else None
             result = await run_best_trades(
                 session,
                 watchlists=args.bt_watchlist,
                 top=args.top,
                 output_format=args.format,
                 account_number=args.account or getattr(client.config, "account_number", None),
+                structure_filter=structure_filter,
             )
 
             if args.journal:

--- a/tests/test_best_trades_cli.py
+++ b/tests/test_best_trades_cli.py
@@ -59,6 +59,22 @@ class TestBestTradesArgparse(unittest.TestCase):
         self.assertEqual(args.watchlist, "Foo")
         self.assertIsNone(args.bt_watchlist)
 
+    def test_help_lists_put_selector_flag(self):
+        help_text = self.parser.format_help()
+        self.assertIn("--put-selector", help_text)
+
+    def test_put_selector_defaults(self):
+        args = self.parser.parse_args(["--put-selector"])
+        self.assertTrue(args.put_selector)
+        self.assertFalse(args.best_trades)
+        self.assertEqual(args.top, 3)
+
+    def test_put_selector_with_journal_and_top(self):
+        args = self.parser.parse_args(["--put-selector", "--top", "5", "--journal"])
+        self.assertTrue(args.put_selector)
+        self.assertTrue(args.journal)
+        self.assertEqual(args.top, 5)
+
 
 class TestRunBestTradesStub(unittest.IsolatedAsyncioTestCase):
     """Smoke tests on run_best_trades that mock scan_watchlists to skip real I/O."""
@@ -110,6 +126,30 @@ class TestRunBestTradesStub(unittest.IsolatedAsyncioTestCase):
         mock_scan.return_value = ([], [])
         result = await run_best_trades(MagicMock(), output_format="json")
         self.assertGreaterEqual(set(result.keys()), {"top", "rejected", "warnings", "watchlists"})
+
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_structure_filter_threaded_through(self, mock_scan, mock_gen):
+        # When run_best_trades receives structure_filter, it must pass through
+        # to generate_candidates so the researcher's CSP ideas survive while
+        # spread ideas are dropped.
+        from agents.trade_ranker import run_best_trades, SymbolContext
+        # iv_rank=99 to clear the IVR pre-filter regardless of user settings.
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
+        mock_gen.return_value = ([], [])
+        await run_best_trades(MagicMock(), structure_filter="CASH_SECURED_PUT")
+        kwargs = mock_gen.await_args.kwargs
+        self.assertEqual(kwargs.get("structure_filter"), "CASH_SECURED_PUT")
+
+    @patch("agents.trade_ranker.generate_candidates", new_callable=AsyncMock)
+    @patch("agents.trade_ranker.scan_watchlists", new_callable=AsyncMock)
+    async def test_structure_filter_none_when_omitted(self, mock_scan, mock_gen):
+        from agents.trade_ranker import run_best_trades, SymbolContext
+        mock_scan.return_value = ([SymbolContext(symbol="AAPL", iv_rank=99.0)], [])
+        mock_gen.return_value = ([], [])
+        await run_best_trades(MagicMock())
+        kwargs = mock_gen.await_args.kwargs
+        self.assertIsNone(kwargs.get("structure_filter"))
 
 
 class TestBestTradesCliOutput(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_put_selector.py
+++ b/tests/test_put_selector.py
@@ -1,0 +1,464 @@
+"""Tests for the cash-secured-put screener: emission, scoring, skew, CLI."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from agents.options_researcher import (
+    OptionsResearcherAgent,
+    StrikeRow,
+    _compute_put_call_skew,
+    CSP_DELTA_MIN,
+    CSP_DELTA_MAX,
+    CSP_MIN_OTM_PCT,
+    CSP_MAX_PER_SYMBOL,
+)
+from agents.trade_ranker import (
+    AccountState,
+    Candidate,
+    SymbolContext,
+    _candidate_to_dict,
+    _csp_annualized_return,
+    _csp_short_strike,
+    _score_csp_candidate,
+    _score_csp_distance,
+    _score_csp_income,
+    _score_csp_pop,
+    _score_csp_time_efficiency,
+    _score_csp_vol_env,
+    score_candidate,
+)
+
+
+def _put_row(strike: float, delta: float, *, mid: float = 1.50, iv: float = 0.30,
+             oi: int = 1000, bid: float = 1.45, ask: float = 1.55) -> StrikeRow:
+    return StrikeRow(
+        streamer_symbol=f".AAPL{strike:.0f}P",
+        occ_symbol=f"AAPL  260619P{int(strike * 1000):08d}",
+        expiration=date(2026, 6, 19),
+        option_type="PUT",
+        strike=strike,
+        bid=bid,
+        ask=ask,
+        mid=mid,
+        volume=500,
+        open_interest=oi,
+        delta=delta,
+        gamma=0.01,
+        theta=-0.05,
+        vega=0.10,
+        iv=iv,
+    )
+
+
+def _call_row(strike: float, delta: float, iv: float = 0.25) -> StrikeRow:
+    return StrikeRow(
+        streamer_symbol=f".AAPL{strike:.0f}C",
+        occ_symbol=f"AAPL  260619C{int(strike * 1000):08d}",
+        expiration=date(2026, 6, 19),
+        option_type="CALL",
+        strike=strike,
+        bid=1.0, ask=1.1, mid=1.05,
+        volume=400, open_interest=800,
+        delta=delta, gamma=0.01, theta=-0.05, vega=0.10, iv=iv,
+    )
+
+
+class TestBuildCashSecuredPuts(unittest.TestCase):
+    """OptionsResearcherAgent._build_cash_secured_puts emission."""
+
+    def setUp(self):
+        self.agent = OptionsResearcherAgent(MagicMock())
+
+    def test_emits_one_idea_per_qualifying_put_strike(self):
+        rows = [
+            _put_row(145.0, -0.20, mid=1.50),
+            _put_row(140.0, -0.15, mid=0.80),
+            _put_row(135.0, -0.10, mid=0.40),  # delta below CSP_DELTA_MIN — drop
+            _put_row(155.0, -0.50, mid=4.50),  # delta above CSP_DELTA_MAX — drop
+        ]
+        ideas = self.agent._build_cash_secured_puts(
+            rows, "AAPL", date(2026, 6, 19), 49, underlying_price=150.0,
+        )
+        self.assertEqual(len(ideas), 2)
+        for i in ideas:
+            self.assertEqual(i.strategy, "CASH_SECURED_PUT")
+            self.assertGreater(i.credit, 0)
+            self.assertEqual(i.width, i.short_strike)  # width=strike for CSPs
+            self.assertEqual(len(i.legs), 1)
+            self.assertEqual(i.legs[0]["action"], "SELL")
+
+    def test_filters_itm_puts(self):
+        rows = [
+            _put_row(155.0, -0.55, mid=6.0),  # ITM — strike >= spot
+            _put_row(145.0, -0.20, mid=1.5),
+        ]
+        ideas = self.agent._build_cash_secured_puts(
+            rows, "AAPL", date(2026, 6, 19), 49, underlying_price=150.0,
+        )
+        # Only the OTM 145 strike qualifies (155 ITM dropped, also delta out of range)
+        self.assertEqual(len(ideas), 1)
+        self.assertEqual(ideas[0].short_strike, 145.0)
+
+    def test_filters_strikes_inside_otm_floor(self):
+        # 149 is only 0.67% OTM — below default 3% floor.
+        rows = [_put_row(149.0, -0.45, mid=2.0), _put_row(140.0, -0.20, mid=1.0)]
+        ideas = self.agent._build_cash_secured_puts(
+            rows, "AAPL", date(2026, 6, 19), 49, underlying_price=150.0,
+        )
+        self.assertEqual(len(ideas), 1)
+        self.assertEqual(ideas[0].short_strike, 140.0)
+
+    def test_skips_when_underlying_price_unavailable_or_zero(self):
+        rows = [_put_row(145.0, -0.20, mid=1.50)]
+        self.assertEqual(self.agent._build_cash_secured_puts(rows, "AAPL", date(2026, 6, 19), 49, 0.0), [])
+        self.assertEqual(self.agent._build_cash_secured_puts(rows, "AAPL", date(2026, 6, 19), 49, -1.0), [])
+
+    def test_skips_rows_missing_delta_or_mid(self):
+        rows = [
+            _put_row(145.0, -0.20, mid=1.50),
+            StrikeRow(streamer_symbol="x", occ_symbol="x", expiration=date(2026, 6, 19),
+                      option_type="PUT", strike=144.0, mid=None, delta=-0.22),
+            StrikeRow(streamer_symbol="x", occ_symbol="x", expiration=date(2026, 6, 19),
+                      option_type="PUT", strike=143.0, mid=1.0, delta=None),
+        ]
+        ideas = self.agent._build_cash_secured_puts(rows, "AAPL", date(2026, 6, 19), 49, 150.0)
+        self.assertEqual(len(ideas), 1)
+
+    def test_caps_at_max_per_symbol_by_premium_desc(self):
+        rows = [_put_row(150.0 - i, -0.20, mid=2.0 - 0.1 * i) for i in range(1, 10)]
+        ideas = self.agent._build_cash_secured_puts(
+            rows, "AAPL", date(2026, 6, 19), 49, 150.0,
+            max_per_symbol=3,
+        )
+        self.assertEqual(len(ideas), 3)
+        # Sorted by premium descending
+        credits = [i.credit for i in ideas]
+        self.assertEqual(credits, sorted(credits, reverse=True))
+
+    def test_max_loss_is_strike_minus_credit(self):
+        rows = [_put_row(145.0, -0.20, mid=1.50)]
+        ideas = self.agent._build_cash_secured_puts(rows, "AAPL", date(2026, 6, 19), 49, 150.0)
+        self.assertAlmostEqual(ideas[0].max_loss, 145.0 - 1.50, places=4)
+
+    def test_credit_pct_of_width_normalized_against_strike(self):
+        rows = [_put_row(145.0, -0.20, mid=1.45)]
+        ideas = self.agent._build_cash_secured_puts(rows, "AAPL", date(2026, 6, 19), 49, 150.0)
+        self.assertAlmostEqual(ideas[0].credit_pct_of_width, 1.45 / 145.0, places=4)
+
+
+class TestComputePutCallSkew(unittest.TestCase):
+    """_compute_put_call_skew picks legs closest to ~25Δ and returns put_iv / call_iv."""
+
+    def test_returns_ratio_at_reference_delta(self):
+        rows = [
+            _put_row(145.0, -0.25, iv=0.35),  # closest to -25Δ
+            _put_row(140.0, -0.15, iv=0.40),
+            _call_row(155.0, 0.25, iv=0.28),  # closest to +25Δ
+            _call_row(160.0, 0.10, iv=0.22),
+        ]
+        skew = _compute_put_call_skew(rows)
+        self.assertIsNotNone(skew)
+        self.assertAlmostEqual(skew, 0.35 / 0.28, places=4)
+
+    def test_returns_none_when_no_puts_or_calls(self):
+        self.assertIsNone(_compute_put_call_skew([]))
+        self.assertIsNone(_compute_put_call_skew([_put_row(145.0, -0.25)]))
+        self.assertIsNone(_compute_put_call_skew([_call_row(155.0, 0.25)]))
+
+    def test_skips_rows_without_iv(self):
+        rows = [
+            StrikeRow(streamer_symbol="p", occ_symbol="p", expiration=date(2026, 6, 19),
+                      option_type="PUT", strike=145, delta=-0.25, iv=None),
+            _call_row(155.0, 0.25, iv=0.28),
+        ]
+        self.assertIsNone(_compute_put_call_skew(rows))
+
+
+def _make_csp_candidate(
+    *,
+    symbol: str = "AAPL",
+    strike: float = 145.0,
+    credit: float = 1.50,
+    delta: float = -0.22,
+    dte: int = 45,
+    spot: float = 150.0,
+    iv_rank: float = 50.0,
+    earnings: date | None = None,
+    skew: float | None = None,
+) -> Candidate:
+    ctx = SymbolContext(
+        symbol=symbol,
+        current_price=Decimal(str(spot)),
+        iv_rank=iv_rank,
+        next_earnings_date=earnings,
+        put_call_skew=skew,
+    )
+    return Candidate(
+        symbol=symbol,
+        structure="CASH_SECURED_PUT",
+        expiration=date(2026, 6, 19),
+        dte=dte,
+        width=strike,
+        credit=credit,
+        max_loss=strike - credit,
+        credit_pct_of_width=credit / strike,
+        short_delta=delta,
+        pop_estimate=1.0 - abs(delta),
+        breakevens=[strike - credit],
+        net_greeks={},
+        legs=[{"action": "SELL", "option_type": "PUT", "strike": strike,
+               "bid": credit - 0.05, "ask": credit + 0.05, "mid": credit,
+               "open_interest": 1000, "delta": delta, "iv": 0.30}],
+        researcher_score=0.0,
+        researcher_score_breakdown={},
+        context=ctx,
+    )
+
+
+class TestCspScoringComponents(unittest.TestCase):
+    """Each scoring helper clamps as expected at boundaries."""
+
+    def test_short_strike_pulled_from_sell_leg(self):
+        c = _make_csp_candidate(strike=140.0)
+        self.assertEqual(_csp_short_strike(c), 140.0)
+
+    def test_annualized_return_formula(self):
+        # 1.50 credit, 45 DTE, strike 145 → (1.50*365/45)/145 = 0.0839...
+        c = _make_csp_candidate(strike=145.0, credit=1.50, dte=45)
+        self.assertAlmostEqual(_csp_annualized_return(c), (1.50 * 365 / 45) / 145.0, places=4)
+
+    def test_income_zero_below_floor(self):
+        c = _make_csp_candidate(strike=200.0, credit=0.40, dte=45)  # tiny annualized
+        self.assertEqual(_score_csp_income(c, min_annualized_return=0.10), 0.0)
+
+    def test_income_caps_at_max(self):
+        c = _make_csp_candidate(strike=50.0, credit=5.0, dte=30)  # huge annualized
+        score = _score_csp_income(c, min_annualized_return=0.10)
+        self.assertAlmostEqual(score, 20.0, places=2)
+
+    def test_distance_zero_inside_floor(self):
+        c = _make_csp_candidate(strike=149.0, spot=150.0)  # 0.67% buffer
+        self.assertEqual(_score_csp_distance(c, min_otm_pct=0.03), 0.0)
+
+    def test_distance_caps_at_max(self):
+        c = _make_csp_candidate(strike=120.0, spot=150.0)  # 20% buffer
+        self.assertAlmostEqual(_score_csp_distance(c, min_otm_pct=0.03), 25.0, places=2)
+
+    def test_pop_clamps_below_threshold(self):
+        c = _make_csp_candidate(delta=-0.40)  # POP 0.60 < 0.65 → 0
+        self.assertEqual(_score_csp_pop(c), 0.0)
+
+    def test_pop_caps_at_max(self):
+        c = _make_csp_candidate(delta=-0.10)  # POP 0.90 > 0.85 → cap 20
+        self.assertAlmostEqual(_score_csp_pop(c), 20.0, places=2)
+
+    def test_vol_env_placeholder_when_ivr_none(self):
+        c = _make_csp_candidate(iv_rank=50.0)
+        c.context.iv_rank = None
+        self.assertAlmostEqual(_score_csp_vol_env(c), 7.5, places=2)
+
+    def test_vol_env_ramps_30_to_70(self):
+        c = _make_csp_candidate(iv_rank=30.0)
+        self.assertAlmostEqual(_score_csp_vol_env(c), 0.0, places=2)
+        c2 = _make_csp_candidate(iv_rank=70.0)
+        self.assertAlmostEqual(_score_csp_vol_env(c2), 15.0, places=2)
+        c3 = _make_csp_candidate(iv_rank=50.0)
+        self.assertAlmostEqual(_score_csp_vol_env(c3), 7.5, places=2)
+
+    def test_time_efficiency_peaks_30_to_45(self):
+        for d in (30, 35, 45):
+            c = _make_csp_candidate(dte=d)
+            self.assertAlmostEqual(_score_csp_time_efficiency(c), 10.0, places=2)
+
+    def test_time_efficiency_ramps_below_30(self):
+        c = _make_csp_candidate(dte=21)
+        self.assertAlmostEqual(_score_csp_time_efficiency(c), 0.0, places=2)
+        c2 = _make_csp_candidate(dte=25)
+        self.assertGreater(_score_csp_time_efficiency(c2), 0.0)
+        self.assertLess(_score_csp_time_efficiency(c2), 10.0)
+
+    def test_time_efficiency_short_dte_penalised_harder_than_long(self):
+        # Sub-21 DTE = gamma risk → floor 0.10; >60 DTE = slow theta → floor 0.40.
+        # Asymmetry matches the article's "short-DTE more dangerous" framing.
+        c_short = _make_csp_candidate(dte=10)
+        c_long = _make_csp_candidate(dte=90)
+        s_short = _score_csp_time_efficiency(c_short)
+        s_long = _score_csp_time_efficiency(c_long)
+        self.assertAlmostEqual(s_short, 1.0, places=2)
+        self.assertAlmostEqual(s_long, 4.0, places=2)
+        self.assertLess(s_short, s_long)
+
+
+class TestCspScoreCandidateDispatch(unittest.TestCase):
+    """score_candidate dispatches to CSP path when structure is CASH_SECURED_PUT."""
+
+    def test_csp_breakdown_keys_differ_from_spread(self):
+        c = _make_csp_candidate()
+        scored = score_candidate(c, today=date(2026, 5, 1))
+        self.assertIn("csp_income", scored.score_breakdown)
+        self.assertIn("csp_distance", scored.score_breakdown)
+        self.assertIn("csp_pop", scored.score_breakdown)
+        self.assertIn("csp_vol_env", scored.score_breakdown)
+        self.assertIn("csp_time_efficiency", scored.score_breakdown)
+        self.assertNotIn("regime_fit", scored.score_breakdown)
+
+    def test_csp_score_clamped_to_0_100(self):
+        c = _make_csp_candidate()
+        scored = score_candidate(c, today=date(2026, 5, 1))
+        self.assertGreaterEqual(scored.score, 0.0)
+        self.assertLessEqual(scored.score, 100.0)
+
+    def test_earnings_within_7d_zeroes_time_efficiency(self):
+        c = _make_csp_candidate(earnings=date(2026, 5, 5))
+        scored = _score_csp_candidate(c, today=date(2026, 5, 1))
+        self.assertEqual(scored.score_breakdown["csp_time_efficiency"], 0.0)
+
+    def test_summary_reason_mentions_skew_when_elevated(self):
+        c = _make_csp_candidate(skew=1.30)
+        scored = score_candidate(c, today=date(2026, 5, 1))
+        self.assertIn("skew", scored.summary_reason.lower())
+
+
+class TestCspCandidateToDict(unittest.TestCase):
+    """_candidate_to_dict emits CSP-specific fields when structure is CASH_SECURED_PUT."""
+
+    def test_emits_cash_required_and_annualized_return(self):
+        c = _make_csp_candidate(strike=145.0, credit=1.50, dte=45)
+        d = _candidate_to_dict(c)
+        self.assertEqual(d["cash_required"], 14500.0)
+        self.assertAlmostEqual(d["annualized_return"], (1.50 * 365 / 45) / 145.0, places=4)
+        self.assertAlmostEqual(d["premium_per_day"], 1.50 / 45, places=4)
+        self.assertAlmostEqual(d["pct_otm"], (150.0 - 145.0) / 150.0, places=4)
+        self.assertEqual(d["spot_price"], 150.0)
+
+    def test_emits_skew_when_present(self):
+        c = _make_csp_candidate(skew=1.26)
+        d = _candidate_to_dict(c)
+        self.assertEqual(d["put_call_skew"], 1.26)
+
+    def test_omits_csp_fields_for_spread_structure(self):
+        c = _make_csp_candidate()
+        c2 = Candidate(
+            symbol="AAPL", structure="BULL_PUT_SPREAD", expiration=c.expiration,
+            dte=c.dte, width=5.0, credit=c.credit, max_loss=3.50, credit_pct_of_width=0.30,
+            short_delta=c.short_delta, pop_estimate=c.pop_estimate, breakevens=[],
+            net_greeks={}, legs=[], researcher_score=0.0, researcher_score_breakdown={},
+            context=c.context,
+        )
+        d = _candidate_to_dict(c2)
+        self.assertNotIn("cash_required", d)
+        self.assertNotIn("annualized_return", d)
+        self.assertNotIn("pct_otm", d)
+
+
+class TestCspAccountFilterUsesSeparateCap(unittest.TestCase):
+    """CSPs route through bt_csp_max_pct_nlv_per_trade; spreads use bt_max_pct_nlv_per_trade."""
+
+    def _state(self, nlv=20000.0):
+        return AccountState(nlv=nlv, bp_usage_pct=0.10, existing_exposures={})
+
+    def test_csp_admitted_above_spread_cap_below_csp_cap(self):
+        # 50 strike CSP, 1.00 credit on $20k NLV: max_loss=$4,900 = 24.5% NLV.
+        # Spread cap (5%) would reject; CSP cap at 50% admits it.
+        from agents.trade_ranker import apply_account_filters
+        c = _make_csp_candidate(strike=50.0, credit=1.00, spot=55.0)
+        survivors, rejections = apply_account_filters(
+            [c], self._state(),
+            max_pct_nlv_per_trade=0.05,
+            bp_cap_for_new=0.99,  # don't trip BP cap; we're isolating size cap behavior
+            concentration_block_pct=0.50,
+            csp_max_pct_nlv_per_trade=0.50,
+        )
+        self.assertEqual(len(survivors), 1)
+        self.assertEqual(rejections, [])
+
+    def test_csp_rejected_above_csp_cap(self):
+        from agents.trade_ranker import apply_account_filters
+        c = _make_csp_candidate(strike=145.0, credit=1.50)  # 71.7% NLV
+        survivors, rejections = apply_account_filters(
+            [c], self._state(),
+            max_pct_nlv_per_trade=0.05,
+            bp_cap_for_new=0.50,
+            concentration_block_pct=0.25,
+            csp_max_pct_nlv_per_trade=0.50,
+        )
+        self.assertEqual(survivors, [])
+        self.assertEqual(rejections[0].reason, "oversized_vs_nlv")
+
+    def test_spread_unaffected_by_csp_cap(self):
+        # Spread max_loss=3.50 points = $350 = 1.75% NLV — passes both caps.
+        from agents.trade_ranker import apply_account_filters
+        c = _make_csp_candidate()
+        c.structure = "BULL_PUT_SPREAD"
+        c.max_loss = 3.50
+        survivors, _ = apply_account_filters(
+            [c], self._state(),
+            max_pct_nlv_per_trade=0.05,
+            bp_cap_for_new=0.50,
+            concentration_block_pct=0.25,
+            csp_max_pct_nlv_per_trade=0.50,
+        )
+        self.assertEqual(len(survivors), 1)
+
+    def test_csp_account_fit_ramp_uses_wider_band(self):
+        # 145-strike CSP on $20k NLV = 71.7% — way above 25% saturation → 0.
+        # 145-strike CSP on $200k NLV = 7.2% → between 10..0 ramp at (25-7.2)/15 ≈ 11.9 → cap 10.
+        from agents.trade_ranker import _score_account_fit
+        c = _make_csp_candidate(strike=145.0, credit=1.50)
+        big_nlv = AccountState(nlv=200_000.0, bp_usage_pct=0.10)
+        small_nlv = AccountState(nlv=20_000.0, bp_usage_pct=0.10)
+        self.assertGreater(_score_account_fit(c, big_nlv), 0.0)
+        self.assertEqual(_score_account_fit(c, small_nlv), 0.0)
+
+
+class TestStructureFilterNoSpotRejection(unittest.IsolatedAsyncioTestCase):
+    """Symbols missing current_price under --put-selector emit no_spot_for_csp rejections."""
+
+    async def test_no_spot_emits_rejection(self):
+        from agents.trade_ranker import generate_candidates, SymbolContext
+        ctx = SymbolContext(symbol="ZZZZ", current_price=None, iv_rank=99.0)
+        researcher = MagicMock()
+        researcher.research = MagicMock()  # should NOT be called
+        candidates, rejections = await generate_candidates(
+            MagicMock(), [ctx], researcher=researcher,
+            structure_filter="CASH_SECURED_PUT",
+        )
+        self.assertEqual(candidates, [])
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0].reason, "no_spot_for_csp")
+        researcher.research.assert_not_called()
+
+
+class TestCspScoringEdgeCases(unittest.TestCase):
+    """User-tuned thresholds shouldn't crash the scorer."""
+
+    def test_income_floor_above_cap_saturates(self):
+        c = _make_csp_candidate(strike=50.0, credit=5.0, dte=30)  # huge ann return
+        # User sets floor = 0.50 (above the 0.30 cap) — should saturate at full weight, not div-by-zero.
+        score = _score_csp_income(c, min_annualized_return=0.50)
+        self.assertGreaterEqual(score, 0.0)
+        self.assertLessEqual(score, 20.0)
+
+    def test_distance_floor_above_cap_saturates(self):
+        c = _make_csp_candidate(strike=120.0, spot=150.0)  # 20% buffer
+        score = _score_csp_distance(c, min_otm_pct=0.20)
+        self.assertGreaterEqual(score, 0.0)
+        self.assertLessEqual(score, 25.0)
+
+
+class TestSkewDistanceGate(unittest.TestCase):
+    def test_returns_none_when_no_leg_near_reference(self):
+        # Only deep-ITM put and deep-OTM call available — too far from 25Δ.
+        rows = [
+            _put_row(180.0, -0.80, iv=0.50),  # 80Δ — 55 from 25Δ
+            _call_row(200.0, 0.05, iv=0.20),  # 5Δ — 20 from 25Δ
+        ]
+        self.assertIsNone(_compute_put_call_skew(rows))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trade_ranker.py
+++ b/tests/test_trade_ranker.py
@@ -501,7 +501,7 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([c.symbol for c in candidates], ["AAPL", "MSFT"])
 
     async def test_research_timeout_emits_rejection(self):
-        async def hang(symbol):
+        async def hang(symbol, **_kw):
             await asyncio.sleep(10)
             return _make_ok_report(symbol=symbol)
         researcher = MagicMock()
@@ -520,7 +520,7 @@ class TestGenerateCandidates(unittest.IsolatedAsyncioTestCase):
         peak = 0
         lock = asyncio.Lock()
 
-        async def slow(symbol):
+        async def slow(symbol, **_kw):
             nonlocal active, peak
             async with lock:
                 active += 1
@@ -1425,6 +1425,10 @@ class TestLoadThresholds(unittest.TestCase):
                 "research_concurrency",
                 "research_timeout_seconds",
                 "per_trade_risk_pct",
+                "csp_min_otm_pct",
+                "csp_min_annualized_return",
+                "csp_skew_warn_threshold",
+                "csp_max_pct_nlv_per_trade",
             },
         )
         expected_calls = [
@@ -1441,6 +1445,10 @@ class TestLoadThresholds(unittest.TestCase):
             "bt_research_concurrency",
             "bt_research_timeout_seconds",
             "bt_per_trade_risk_pct",
+            "bt_csp_min_otm_pct",
+            "bt_csp_min_annualized_return",
+            "bt_csp_skew_warn_threshold",
+            "bt_csp_max_pct_nlv_per_trade",
         ]
         actual_calls = [call.args[0] for call in mock_settings.get.call_args_list]
         self.assertEqual(set(actual_calls), set(expected_calls))

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -19,6 +19,12 @@ NUMERIC_KEYS: frozenset[str] = frozenset({
     "bt_concentration_overlap_block_pct",
     "bt_min_ivr",
     "bt_per_trade_risk_pct",
+    "bt_csp_delta_min",
+    "bt_csp_delta_max",
+    "bt_csp_min_otm_pct",
+    "bt_csp_min_annualized_return",
+    "bt_csp_skew_warn_threshold",
+    "bt_csp_max_pct_nlv_per_trade",
 })
 OPTIONAL_NUMERIC_KEYS: frozenset[str] = frozenset({
     "theta_target",  # may be None
@@ -31,6 +37,7 @@ INTEGER_KEYS: frozenset[str] = frozenset({
     "bt_max_per_symbol",
     "bt_research_concurrency",
     "bt_research_timeout_seconds",
+    "bt_csp_max_per_symbol",
 })
 
 DEFAULTS: dict[str, Any] = {
@@ -52,6 +59,21 @@ DEFAULTS: dict[str, Any] = {
     "bt_min_ivr": 30.0,
     "bt_research_concurrency": 5,
     "bt_research_timeout_seconds": 90,
+    # Cash-secured-put screener (--put-selector). Income profile by default
+    # (lower delta, expire-worthless preferred); raise the delta range for
+    # wheel entries.
+    "bt_csp_delta_min": 0.15,
+    "bt_csp_delta_max": 0.30,
+    "bt_csp_min_otm_pct": 0.03,
+    "bt_csp_min_annualized_return": 0.10,
+    "bt_csp_skew_warn_threshold": 1.20,
+    "bt_csp_max_per_symbol": 5,
+    # CSPs need a more permissive size cap than spreads — assignment-to-zero
+    # max-loss is much larger than spread max-loss, but the user is choosing
+    # to be cash-secured so they're underwriting the full strike. Default 0.30
+    # = 30% of NLV per trade (per contract). Spread cap (bt_max_pct_nlv_per_trade)
+    # stays at 5% for verticals.
+    "bt_csp_max_pct_nlv_per_trade": 0.30,
     "alert_toggles": {
         "position_size": True,
         "bp": True,
@@ -84,6 +106,14 @@ SETTINGS_DESCRIPTIONS: dict[str, str] = {
     "bt_max_per_symbol": "Cap candidate count per symbol from the researcher (default 3).",
     "bt_research_concurrency": "Number of symbols researched in parallel (default 5; raise for speed at the cost of API load).",
     "bt_research_timeout_seconds": "Per-symbol hard timeout in seconds; symbols exceeding this become research_timeout rejections (default 45).",
+    # Cash-secured-put screener (--put-selector)
+    "bt_csp_delta_min": "Minimum |short delta| for cash-secured-put candidates (default 0.15 = ~15Δ).",
+    "bt_csp_delta_max": "Maximum |short delta| for cash-secured-put candidates (default 0.30 = ~30Δ; raise for wheel entries).",
+    "bt_csp_min_otm_pct": "Minimum buffer below spot to qualify a CSP strike (0.03 = 3%).",
+    "bt_csp_min_annualized_return": "Floor for the income score; (credit*365/dte)/strike below this earns 0 (default 0.10 = 10%).",
+    "bt_csp_skew_warn_threshold": "Put/call IV ratio at ~25Δ that triggers the elevated-skew warning (default 1.20).",
+    "bt_csp_max_per_symbol": "Cap on CSP ideas emitted per symbol per scan (default 5; trim by premium desc).",
+    "bt_csp_max_pct_nlv_per_trade": "Per-trade size cap for CSPs as fraction of NLV (assignment-to-zero max-loss / NLV). Default 0.30 = 30% — separate from the spread cap because cash-secured assignment carries the full strike.",
 }
 
 CONFIG_DIR = Path.home() / ".tasty-coach"


### PR DESCRIPTION
## Summary

Replicates the growyourpile.com "Put Selector" tool inside tasty-coach: a watchlist-wide CSP screener parallel to \`--best-trades\`, ranking short puts on **five balanced dimensions** (income, distance from spot, POP, IV environment, time efficiency) and surfacing put/call IV skew at ~25Δ as a hidden-risk warning.

\`\`\`
python main.py --put-selector --top 5
python main.py --put-selector --top 3 --journal
\`\`\`

## Highlights

- **Researcher** emits \`CASH_SECURED_PUT\` ideas one per qualifying OTM strike (delta and OTM-floor configurable). Skew computed at ~25Δ with a max-distance gate to avoid meaningless ratios on sparse OTM chains.
- **CSP scoring path** in \`trade_ranker\` uses five article-tuned weights instead of the spread weights; account-fit ramp widened for CSPs since assignment-to-zero risk is structurally larger; apply_account_filters routes CSPs through a separate \`bt_csp_max_pct_nlv_per_trade\` cap (default 30%) — otherwise every CSP on small accounts would trip the spread cap.
- **\`structure_filter\`** kwarg threaded through \`run_best_trades\`. Symbols missing a spot under \`--put-selector\` emit \`no_spot_for_csp\` rejections instead of silently disappearing.
- **JSON output** adds \`cash_required\`, \`annualized_return\`, \`premium_per_day\`, \`pct_otm\`, \`spot_price\`, \`put_call_skew\`. \`--journal\` writes recommendations with \`strategy=CASH_SECURED_PUT\`.
- **Time-efficiency floors are asymmetric** — sub-21 DTE penalised harder (0.10) than >60 DTE (0.40), matching the article's "short-DTE more dangerous" framing.

## Test plan

- [x] \`unittest discover tests\` — 572 tests, 567 passing. Same 5 pre-existing failures as on main; no regressions.
- [x] 44 new tests cover CSP emission / delta filtering / OTM floor / cap / single-leg shape; skew ratio + distance-gate fallbacks; each CSP scoring component at boundaries with div-by-zero guards; score_candidate dispatch on structure; CSP-specific JSON fields; account-filter cap routing; no_spot_for_csp rejection.
- [ ] Smoke run \`python main.py --put-selector --top 5\` against live account.
- [ ] Smoke run \`python main.py --put-selector --top 3 --journal --format json\` and inspect first pick for cash_required / annualized_return / pct_otm / put_call_skew.

## Independent review findings addressed

A general-purpose review subagent surfaced three must-fixes; all are in this PR:

1. **CSPs would trip the 5% spread cap on small accounts** (\`apply_account_filters\`). Added \`bt_csp_max_pct_nlv_per_trade\` (default 30%) and routed CSPs through it; \`_score_account_fit\` ramp widened for CSPs to 10..0 over [10%, 25%] NLV.
2. **Symbols with no spot silently disappeared under \`--put-selector\`**. \`generate_candidates\` now emits \`no_spot_for_csp\` rejection when \`structure_filter="CASH_SECURED_PUT"\` and \`underlying_price\` is None.
3. **Div-by-zero in CSP scoring when user sets thresholds at/above the cap**. \`_score_csp_income\` and \`_score_csp_distance\` saturate to full weight when the configured floor exceeds the cap.
4. **Skew compared a 25Δ put against a 50Δ ATM call on sparse chains**. \`_compute_put_call_skew\` returns None when neither leg is within 0.10 of the reference delta.

## Out of scope

- Wheel preset (higher delta, fair-value-entry bias).
- Dashboard tile / coach-tool wrapper for \`--put-selector\` (the \`/api/scan/start\` endpoint can land a \`?structure=csp\` query param later; coach can prompt-engineer the structure today).
- Stress-test column ("what if underlying drops 7% in 5 days"). The article mentions but doesn't define.

🤖 Generated with [Claude Code](https://claude.com/claude-code)