### PR TITLE
server: stable token + loopback bypass + 30-day cookie

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -149,18 +149,59 @@ ROOT = Path(__file__).parent
 TEMPLATES = Jinja2Templates(directory=str(ROOT / "templates"))
 
 
+TOKEN_FILE = Path.home() / ".tasty-coach" / "web_token"
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60  # 30 days
+
+
 def _resolve_token() -> str:
+    """Return a stable token across restarts.
+
+    Resolution order:
+      1. ``TASTY_COACH_WEB_TOKEN`` env var (highest precedence; lets ops pin it).
+      2. ``~/.tasty-coach/web_token`` file (auto-created on first run).
+      3. Mint a new one and write to (2).
+    """
     tok = os.environ.get("TASTY_COACH_WEB_TOKEN")
     if tok:
         return tok
+    try:
+        if TOKEN_FILE.exists():
+            tok = TOKEN_FILE.read_text().strip()
+            if tok:
+                os.environ["TASTY_COACH_WEB_TOKEN"] = tok
+                return tok
+    except OSError as e:
+        logging.getLogger(__name__).warning("could not read %s: %s", TOKEN_FILE, e)
+
     tok = secrets.token_hex(16)
-    print(f"[server] generated TASTY_COACH_WEB_TOKEN={tok}", flush=True)
-    print("[server] set TASTY_COACH_WEB_TOKEN in .env to make this stable across restarts", flush=True)
+    try:
+        TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+        TOKEN_FILE.write_text(tok)
+        TOKEN_FILE.chmod(0o600)
+        print(f"[server] minted stable web token → {TOKEN_FILE}", flush=True)
+    except OSError as e:
+        print(f"[server] could not persist web token to {TOKEN_FILE} ({e}); using in-memory only", flush=True)
     os.environ["TASTY_COACH_WEB_TOKEN"] = tok
     return tok
 
 
+def _is_loopback(request: Request) -> bool:
+    """True when the request originates from the same machine.
+
+    Solo-LAN deployment: anyone with filesystem access already has TastyTrade
+    creds in .env, so loopback bypass leaks nothing additional. LAN clients
+    (phone/iPad on `--host 0.0.0.0`) still see auth.
+    """
+    client = getattr(request, "client", None)
+    if client is None or client.host is None:
+        return False
+    return client.host in LOOPBACK_HOSTS
+
+
 def _check_token(request: Request, token: str | None) -> None:
+    if _is_loopback(request):
+        return
     expected = request.app.state.token
     supplied = token or request.headers.get("X-Auth-Token") or request.cookies.get("tcw_token")
     if supplied:
@@ -299,7 +340,16 @@ def create_app(*, account_number: str | None = None) -> FastAPI:
                 "asset_version": request.app.state.asset_version,
             },
         )
-        response.set_cookie("tcw_token", request.app.state.token, httponly=False, samesite="strict")
+        # Persistent cookie (30 days) so the browser remembers the token
+        # across sessions. httponly=False because chat.js reads the value
+        # for SSE bootstrap.
+        response.set_cookie(
+            "tcw_token",
+            request.app.state.token,
+            max_age=COOKIE_MAX_AGE_SECONDS,
+            httponly=False,
+            samesite="strict",
+        )
         return response
 
     @app.get("/api/snapshot")
@@ -620,10 +670,11 @@ def serve(*, host: str = "127.0.0.1", port: int = 8765, account_number: str | No
 
     print()
     print("=" * 72)
-    print("  tasty-coach dashboard — open one of these URLs:")
-    print(f"    http://127.0.0.1:{port}/?token={token}")
+    print("  tasty-coach dashboard")
+    print(f"    http://127.0.0.1:{port}/                    (loopback — no token needed)")
     if host == "0.0.0.0":
         print(f"    http://{_local_ip()}:{port}/?token={token}    (LAN — phone/iPad)")
+        print(f"    Token persisted to {TOKEN_FILE} (or pin TASTY_COACH_WEB_TOKEN in .env)")
     print("=" * 72)
     print()
 

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,0 +1,123 @@
+"""Tests for server.app token persistence + loopback bypass + cookie max-age."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException
+
+import server.app as server_app
+
+
+class TestResolveToken(unittest.TestCase):
+    """_resolve_token persists across restarts via ~/.tasty-coach/web_token."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._patches = [
+            patch.object(server_app, "TOKEN_FILE", Path(self.tmp.name) / "web_token"),
+            patch.dict(os.environ, {}, clear=False),
+        ]
+        for p in self._patches:
+            p.start()
+        # Ensure the env var is unset for these tests.
+        os.environ.pop("TASTY_COACH_WEB_TOKEN", None)
+
+    def tearDown(self):
+        for p in reversed(self._patches):
+            p.stop()
+        self.tmp.cleanup()
+        os.environ.pop("TASTY_COACH_WEB_TOKEN", None)
+
+    def test_env_var_takes_precedence(self):
+        os.environ["TASTY_COACH_WEB_TOKEN"] = "from-env"
+        # Pre-populate the file with a different value to prove env wins.
+        server_app.TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+        server_app.TOKEN_FILE.write_text("from-file")
+        self.assertEqual(server_app._resolve_token(), "from-env")
+
+    def test_reads_from_file_when_env_missing(self):
+        server_app.TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+        server_app.TOKEN_FILE.write_text("persisted-token-abc")
+        self.assertEqual(server_app._resolve_token(), "persisted-token-abc")
+        # Subsequent call returns the same value (no rotation).
+        self.assertEqual(server_app._resolve_token(), "persisted-token-abc")
+
+    def test_mints_and_persists_when_no_source(self):
+        self.assertFalse(server_app.TOKEN_FILE.exists())
+        tok = server_app._resolve_token()
+        self.assertTrue(server_app.TOKEN_FILE.exists())
+        self.assertEqual(server_app.TOKEN_FILE.read_text().strip(), tok)
+        # Restart simulation: clear env, re-read; same token.
+        os.environ.pop("TASTY_COACH_WEB_TOKEN", None)
+        self.assertEqual(server_app._resolve_token(), tok)
+
+    def test_minted_token_file_is_user_only(self):
+        server_app._resolve_token()
+        mode = server_app.TOKEN_FILE.stat().st_mode & 0o777
+        self.assertEqual(mode, 0o600)
+
+
+class TestLoopbackBypass(unittest.TestCase):
+    """Requests from 127.0.0.1 / ::1 / localhost skip token auth."""
+
+    def _request(self, host: str | None) -> MagicMock:
+        req = MagicMock()
+        if host is None:
+            req.client = None
+        else:
+            req.client = MagicMock()
+            req.client.host = host
+        req.headers = {}
+        req.cookies = {}
+        req.app.state.token = "secret"
+        return req
+
+    def test_loopback_v4_bypasses_token(self):
+        req = self._request("127.0.0.1")
+        # No token supplied — should NOT raise.
+        server_app._check_token(req, None)
+
+    def test_loopback_v6_bypasses_token(self):
+        req = self._request("::1")
+        server_app._check_token(req, None)
+
+    def test_localhost_string_bypasses_token(self):
+        req = self._request("localhost")
+        server_app._check_token(req, None)
+
+    def test_lan_address_still_requires_token(self):
+        req = self._request("192.168.1.42")
+        with self.assertRaises(HTTPException) as ctx:
+            server_app._check_token(req, None)
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_lan_address_accepts_correct_token(self):
+        req = self._request("192.168.1.42")
+        server_app._check_token(req, "secret")  # must not raise
+
+    def test_lan_address_rejects_wrong_token(self):
+        req = self._request("192.168.1.42")
+        with self.assertRaises(HTTPException):
+            server_app._check_token(req, "wrong")
+
+    def test_no_client_falls_through_to_token_check(self):
+        req = self._request(None)
+        # No client info AND no token → 401 (don't bypass on missing info)
+        with self.assertRaises(HTTPException):
+            server_app._check_token(req, None)
+
+
+class TestCookieMaxAgeConstant(unittest.TestCase):
+    """Cookie persists 30 days (vs. session-only)."""
+
+    def test_max_age_is_thirty_days(self):
+        self.assertEqual(server_app.COOKIE_MAX_AGE_SECONDS, 30 * 24 * 60 * 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three small UX wins for solo dashboard use:

1. **Stable token across restarts** — auto-minted token persisted to \`~/.tasty-coach/web_token\` (chmod 0600). Env var still wins when set.
2. **Loopback bypass** — requests from 127.0.0.1/::1/localhost skip auth entirely. LAN clients still see it.
3. **30-day persistent cookie** — \`tcw_token\` now has \`max_age=30 days\` instead of being session-only.

## Test plan

- [x] \`unittest discover tests\` — 588 tests, 583 passing. Same 5 pre-existing failures only.
- [x] 12 new tests cover token persistence (env > file > mint), loopback bypass (v4/v6/localhost), and LAN auth still required.
- [x] Live boot smoke: \`curl http://127.0.0.1:8767/\` returns 200 without any token; Set-Cookie header includes \`Max-Age=2592000\`.

## Net result

\`python main.py --serve\` then bookmark \`http://127.0.0.1:8765/\` — works forever, no token. LAN access still token-protected with stable token + 30-day device memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)