### PR TITLE
dashboard: --put-selector parity (CSP toggle, fields, skew, settings)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -20,7 +20,7 @@ import secrets
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Optional
 
 from claude_agent_sdk import ClaudeSDKClient
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
@@ -60,6 +60,7 @@ SETTINGS_GROUPS: list[dict[str, Any]] = [
         "id": "sizing",
         "label": "Sizing & Account Fit",
         "keys": [
+            "bt_per_trade_risk_dollars",
             "bt_per_trade_risk_pct",
             "bt_max_pct_nlv_per_trade",
             "bt_bp_cap_for_new",
@@ -76,6 +77,19 @@ SETTINGS_GROUPS: list[dict[str, Any]] = [
             "bt_min_open_interest",
             "bt_max_spread_pct",
             "bt_earnings_blackout_days",
+        ],
+    },
+    {
+        "id": "csp",
+        "label": "Cash-Secured Puts (--put-selector)",
+        "keys": [
+            "bt_csp_delta_min",
+            "bt_csp_delta_max",
+            "bt_csp_min_otm_pct",
+            "bt_csp_min_annualized_return",
+            "bt_csp_skew_warn_threshold",
+            "bt_csp_max_per_symbol",
+            "bt_csp_max_pct_nlv_per_trade",
         ],
     },
     {
@@ -211,18 +225,39 @@ def _check_token(request: Request, token: str | None) -> None:
         raise HTTPException(status_code=401, detail="invalid or missing token")
 
 
-CacheKey = tuple[str, frozenset[str]]
+# Cache key: (account_number, frozenset[watchlists], structure_filter | None).
+# Structure is part of the key so spread vs CSP results cache independently.
+CacheKey = tuple[str, frozenset[str], Optional[str]]
+
+# UI shorthand → canonical structure name passed to run_best_trades.
+_STRUCTURE_ALIASES: dict[str, str] = {
+    "csp": "CASH_SECURED_PUT",
+    "cash_secured_put": "CASH_SECURED_PUT",
+}
 
 
-def _bt_key(account: str, watchlists: Any) -> CacheKey:
-    """Normalise a watchlist selection into a stable cache key."""
-    if not watchlists:
-        return (account, frozenset())
-    return (account, frozenset(str(w) for w in watchlists))
+def _normalize_structure(structure: Optional[str]) -> Optional[str]:
+    """Map UI alias (or None) to the canonical structure_filter value."""
+    if not structure:
+        return None
+    cleaned = structure.strip()
+    if not cleaned:
+        return None
+    return _STRUCTURE_ALIASES.get(cleaned.lower(), cleaned)
+
+
+def _bt_key(account: str, watchlists: Any, structure: Optional[str] = None) -> CacheKey:
+    """Normalise a watchlist + structure selection into a stable cache key."""
+    wl = frozenset(str(w) for w in watchlists) if watchlists else frozenset()
+    return (account, wl, _normalize_structure(structure))
 
 
 def _key_to_list(key: CacheKey) -> list[str]:
     return sorted(key[1])
+
+
+def _key_structure(key: CacheKey) -> Optional[str]:
+    return key[2] if len(key) >= 3 else None
 
 
 def _bt_cached(app: FastAPI, key: CacheKey) -> dict[str, Any] | None:
@@ -244,12 +279,18 @@ def _bt_inflight_for_account(app: FastAPI, account: str) -> CacheKey | None:
     return None
 
 
-async def _bt_run_and_cache(app: FastAPI, ctx: CoachContext, watchlists: list[str]) -> dict[str, Any]:
+async def _bt_run_and_cache(
+    app: FastAPI,
+    ctx: CoachContext,
+    watchlists: list[str],
+    structure: Optional[str] = None,
+) -> dict[str, Any]:
     """Run run_best_trades once for the given selection; store in the cache.
 
-    Cache key is (account_number, frozenset[watchlists]) so distinct selections
-    cache independently."""
-    key = _bt_key(ctx.account_number, watchlists)
+    Cache key is (account_number, frozenset[watchlists], structure) so distinct
+    selections cache independently. ``structure`` is the canonical name
+    (e.g. "CASH_SECURED_PUT") or None for all structures."""
+    key = _bt_key(ctx.account_number, watchlists, structure)
     try:
         result = await run_best_trades(
             ctx.session,
@@ -257,6 +298,7 @@ async def _bt_run_and_cache(app: FastAPI, ctx: CoachContext, watchlists: list[st
             top=3,
             output_format="json",
             account_number=ctx.account_number,
+            structure_filter=structure,
         )
         if isinstance(result.get("rejected"), list):
             rej = result["rejected"]
@@ -270,8 +312,9 @@ async def _bt_run_and_cache(app: FastAPI, ctx: CoachContext, watchlists: list[st
             result.pop("rejected", None)
         app.state.bt_cache[key] = (time.time(), result)
         logger.info(
-            "best-trades cached for %s %s (%d picks)",
-            ctx.account_number, sorted(watchlists), len(result.get("top") or []),
+            "best-trades cached for %s %s (structure=%s, %d picks)",
+            ctx.account_number, sorted(watchlists), structure or "all",
+            len(result.get("top") or []),
         )
         return result
     finally:
@@ -366,11 +409,12 @@ def create_app(*, account_number: str | None = None) -> FastAPI:
                 continue
             cached.append({
                 "watchlists": _key_to_list(k),
+                "structure": _key_structure(k),
                 "age_sec": int(now - ts),
                 "picks": len(payload.get("top") or []),
             })
         inflight = [
-            {"watchlists": _key_to_list(k)}
+            {"watchlists": _key_to_list(k), "structure": _key_structure(k)}
             for k in request.app.state.bt_inflight
             if k[0] == ctx.account_number
         ]
@@ -412,18 +456,20 @@ def create_app(*, account_number: str | None = None) -> FastAPI:
         return JSONResponse({"watchlists": items})
 
     def _scan_state(app: FastAPI, key: CacheKey) -> dict[str, Any]:
-        """Synthesise a state dict for a (account, watchlists) selection.
+        """Synthesise a state dict for a (account, watchlists, structure) selection.
 
         When state=='ready', also includes ``top`` (full pick payloads) and
         ``rejected_summary`` so the dashboard can render the picks without an
         extra round trip.
         """
+        structure = _key_structure(key)
         cached = _bt_cached(app, key)
         if cached is not None:
             ts = app.state.bt_cache[key][0]
             return {
                 "state": "ready",
                 "watchlists": _key_to_list(key),
+                "structure": structure,
                 "age_sec": int(time.time() - ts),
                 "picks": len(cached.get("top") or []),
                 "top": cached.get("top") or [],
@@ -432,20 +478,22 @@ def create_app(*, account_number: str | None = None) -> FastAPI:
                 "warnings": cached.get("warnings") or [],
             }
         if key in app.state.bt_inflight:
-            return {"state": "inflight", "watchlists": _key_to_list(key)}
-        return {"state": "idle", "watchlists": _key_to_list(key)}
+            return {"state": "inflight", "watchlists": _key_to_list(key), "structure": structure}
+        return {"state": "idle", "watchlists": _key_to_list(key), "structure": structure}
 
     @app.post("/api/scan/start")
     async def api_scan_start(
         request: Request,
         watchlists: list[str] = Query(default_factory=list),
+        structure: str | None = Query(default=None),
         token: str | None = Query(default=None),
     ) -> JSONResponse:
         _check_token(request, token)
         if not watchlists:
             raise HTTPException(status_code=400, detail="watchlists query param is required")
+        canonical_structure = _normalize_structure(structure)
         ctx = await _build_ctx(request.app)
-        key = _bt_key(ctx.account_number, watchlists)
+        key = _bt_key(ctx.account_number, watchlists, canonical_structure)
 
         # Already cached?
         if _bt_cached(request.app, key) is not None:
@@ -466,7 +514,9 @@ def create_app(*, account_number: str | None = None) -> FastAPI:
         if not _data_feed_likely_alive(ctx.session):
             raise HTTPException(status_code=409, detail="market closed — trade scan unavailable")
 
-        task = asyncio.create_task(_bt_run_and_cache(request.app, ctx, list(watchlists)))
+        task = asyncio.create_task(
+            _bt_run_and_cache(request.app, ctx, list(watchlists), canonical_structure)
+        )
         request.app.state.bt_inflight[key] = task
         return JSONResponse({"started": True, "status": "started", **_scan_state(request.app, key)})
 
@@ -474,26 +524,30 @@ def create_app(*, account_number: str | None = None) -> FastAPI:
     async def api_scan_status(
         request: Request,
         watchlists: list[str] = Query(default_factory=list),
+        structure: str | None = Query(default=None),
         token: str | None = Query(default=None),
     ) -> JSONResponse:
         _check_token(request, token)
         if not watchlists:
             raise HTTPException(status_code=400, detail="watchlists query param is required")
+        canonical_structure = _normalize_structure(structure)
         ctx = await _build_ctx(request.app)
-        key = _bt_key(ctx.account_number, watchlists)
+        key = _bt_key(ctx.account_number, watchlists, canonical_structure)
         return JSONResponse(_scan_state(request.app, key))
 
     @app.get("/api/briefing")
     async def api_briefing(
         request: Request,
         watchlists: list[str] = Query(default_factory=list),
+        structure: str | None = Query(default=None),
         token: str | None = Query(default=None),
     ) -> EventSourceResponse:
         _check_token(request, token)
         if not watchlists:
             raise HTTPException(status_code=400, detail="watchlists query param is required")
+        canonical_structure = _normalize_structure(structure)
         ctx = await _build_ctx(request.app)
-        key = _bt_key(ctx.account_number, watchlists)
+        key = _bt_key(ctx.account_number, watchlists, canonical_structure)
 
         async def event_source() -> AsyncIterator[dict[str, Any]]:
             try:

--- a/server/static/chat.js
+++ b/server/static/chat.js
@@ -25,6 +25,12 @@ function withToken(url) {
   return u.toString();
 }
 
+function getScanStructure() {
+  // Returns "csp" when the CSP toggle is checked, else null.
+  const el = document.getElementById("scan-csp-toggle");
+  return el && el.checked ? "csp" : null;
+}
+
 async function loadSnapshot() {
   const res = await fetch(withToken("/api/snapshot"));
   if (!res.ok) {
@@ -84,20 +90,29 @@ function renderJournalEntry(e) {
 function renderOtherScans(cached, inflight) {
   const host = document.getElementById("scan-other");
   const sel = new Set(getSelectedWatchlists());
-  const sameSet = (a) => a.length === sel.size && a.every((x) => sel.has(x));
+  const curStruct = getScanStructure();
+  const sameKey = (entry) => {
+    if (entry.watchlists.length !== sel.size) return false;
+    if (!entry.watchlists.every((x) => sel.has(x))) return false;
+    const entryStruct = entry.structure === "CASH_SECURED_PUT" ? "csp" : null;
+    return entryStruct === curStruct;
+  };
+  const labelStruct = (s) => (s === "CASH_SECURED_PUT" ? " · CSP" : "");
   const chips = [];
   for (const c of cached) {
-    if (sameSet(c.watchlists)) continue;
+    if (sameKey(c)) continue;
     chips.push({
-      label: `cached: ${c.watchlists.join(", ")} (${c.age_sec}s, ${c.picks} picks)`,
+      label: `cached: ${c.watchlists.join(", ")}${labelStruct(c.structure)} (${c.age_sec}s, ${c.picks} picks)`,
       watchlists: c.watchlists,
+      structure: c.structure,
     });
   }
   for (const i of inflight) {
-    if (sameSet(i.watchlists)) continue;
+    if (sameKey(i)) continue;
     chips.push({
-      label: `scanning: ${i.watchlists.join(", ")}`,
+      label: `scanning: ${i.watchlists.join(", ")}${labelStruct(i.structure)}`,
       watchlists: i.watchlists,
+      structure: i.structure,
     });
   }
   host.innerHTML = chips
@@ -107,6 +122,9 @@ function renderOtherScans(cached, inflight) {
     const idx = Number(el.dataset.idx);
     el.addEventListener("click", () => {
       setSelectedWatchlists(chips[idx].watchlists);
+      // Switch the CSP toggle to match the chip's structure.
+      const toggle = document.getElementById("scan-csp-toggle");
+      if (toggle) toggle.checked = chips[idx].structure === "CASH_SECURED_PUT";
       pollScanStatus();
     });
   });
@@ -256,6 +274,8 @@ document.getElementById("briefing-btn").addEventListener("click", async (ev) => 
   try {
     const url = new URL("/api/briefing", window.location.origin);
     for (const w of watchlists) url.searchParams.append("watchlists", w);
+    const struct = getScanStructure();
+    if (struct) url.searchParams.set("structure", struct);
     url.searchParams.set("token", TOKEN);
     await streamSSE(url.toString(), refs);
   } finally {
@@ -452,6 +472,8 @@ async function pollScanStatus() {
   }
   const url = new URL("/api/scan/status", window.location.origin);
   for (const w of sel) url.searchParams.append("watchlists", w);
+  const struct = getScanStructure();
+  if (struct) url.searchParams.set("structure", struct);
   url.searchParams.set("token", TOKEN);
   let st;
   try {
@@ -518,12 +540,11 @@ function renderPicksPanel(st) {
 }
 
 function renderPickCard(p) {
-  const fmt2 = (v) => (v == null ? "—" : Number(v).toFixed(2));
   const fmt0 = (v) => (v == null ? "—" : Math.round(Number(v)));
   const credit = p.credit != null ? `$${(p.credit * 100).toFixed(0)}` : "—";
-  const maxLoss = p.max_loss_dollars != null ? `$${fmt0(p.max_loss_dollars)}` : (p.max_loss != null ? `$${(p.max_loss * 100).toFixed(0)}` : "—");
   const delta = p.short_delta != null ? Number(p.short_delta).toFixed(2) : "—";
   const score = p.score != null ? `${Number(p.score).toFixed(1)}/100` : "";
+  const isCSP = p.structure === "CASH_SECURED_PUT";
 
   const legsLine = (p.legs || [])
     .map((leg) => {
@@ -535,16 +556,58 @@ function renderPickCard(p) {
     })
     .join("  /  ");
 
+  // Top-row metric cells: spreads vs CSPs surface different fields.
+  let row2Html = "";
+  if (isCSP) {
+    const cashReq = p.cash_required != null ? `$${fmt0(p.cash_required).toLocaleString()}` : "—";
+    const ann = p.annualized_return != null ? `${(p.annualized_return * 100).toFixed(1)}%` : "—";
+    const buf = p.pct_otm != null ? `${(p.pct_otm * 100).toFixed(1)}%` : "—";
+    const pop = p.pop_estimate != null ? `${(p.pop_estimate * 100).toFixed(0)}%` : "—";
+    const ppd = p.premium_per_day != null ? `$${(p.premium_per_day * 100).toFixed(2)}/d` : "—";
+    row2Html = `
+      <div class="pick-row2">
+        <span><span class="label">EXP</span><span class="num">${escapeHtml(p.expiration || "")}</span></span>
+        <span><span class="label">DTE</span><span class="num">${p.dte ?? "—"}</span></span>
+        <span><span class="label">CREDIT</span><span class="num">${credit}</span></span>
+        <span><span class="label">CASH REQ</span><span class="num">${cashReq}</span></span>
+        <span><span class="label">ANNUALIZED</span><span class="num">${ann}</span></span>
+        <span><span class="label">BUFFER</span><span class="num">${buf} OTM</span></span>
+        <span><span class="label">POP</span><span class="num">${pop}</span></span>
+        <span><span class="label">PREMIUM/DAY</span><span class="num">${ppd}</span></span>
+        <span><span class="label">SHORT Δ</span><span class="num">${delta}</span></span>
+        ${p.sector ? `<span><span class="label">SECTOR</span>${escapeHtml(p.sector)}</span>` : ""}
+      </div>`;
+  } else {
+    const maxLoss = p.max_loss_dollars != null ? `$${fmt0(p.max_loss_dollars)}` : (p.max_loss != null ? `$${(p.max_loss * 100).toFixed(0)}` : "—");
+    row2Html = `
+      <div class="pick-row2">
+        <span><span class="label">EXP</span><span class="num">${escapeHtml(p.expiration || "")}</span></span>
+        <span><span class="label">DTE</span><span class="num">${p.dte ?? "—"}</span></span>
+        <span><span class="label">CREDIT</span><span class="num">${credit}</span></span>
+        <span><span class="label">MAX LOSS</span><span class="num">${maxLoss}</span></span>
+        <span><span class="label">SHORT Δ</span><span class="num">${delta}</span></span>
+        ${p.sector ? `<span><span class="label">SECTOR</span>${escapeHtml(p.sector)}</span>` : ""}
+      </div>`;
+  }
+
   const rec = p.recommended_contracts;
   const pctRisk = p.pct_nlv_at_risk;
   const pct1 = p.pct_nlv_at_risk_one_contract;
+  const budget = p.risk_budget_dollars;
+  const budgetTag = budget != null ? ` [budget $${fmt0(budget)}]` : "";
   let sizeHTML = "";
   if (rec === 0) {
     const oneStr = pct1 != null ? ` — 1 contract = ${(pct1 * 100).toFixed(1)}% NLV` : "";
-    sizeHTML = `<div class="pick-size size-skip">SKIP: exceeds per-trade risk budget${oneStr}</div>`;
+    sizeHTML = `<div class="pick-size size-skip">SKIP: exceeds per-trade risk budget${oneStr}${budgetTag}</div>`;
   } else if (rec != null) {
     const pctStr = pctRisk != null ? ` (${(pctRisk * 100).toFixed(1)}% NLV at risk)` : "";
-    sizeHTML = `<div class="pick-size size-ok">Recommended size: ${rec} contract${rec === 1 ? "" : "s"}${pctStr}</div>`;
+    sizeHTML = `<div class="pick-size size-ok">Recommended size: ${rec} contract${rec === 1 ? "" : "s"}${pctStr}${budgetTag}</div>`;
+  }
+
+  // CSP elevated-skew warning (article's "hidden risk" signal).
+  let skewHTML = "";
+  if (isCSP && p.put_call_skew != null && p.put_call_skew >= 1.20) {
+    skewHTML = `<div class="pick-skew-warn">⚠ put/call skew ${p.put_call_skew.toFixed(2)} — elevated downside fear; consider smaller size or vertical</div>`;
   }
 
   return `
@@ -553,15 +616,9 @@ function renderPickCard(p) {
         <span><span class="pick-symbol">${escapeHtml(p.symbol)}</span> <span class="pick-structure">${escapeHtml(p.structure || "")}</span></span>
         <span class="pick-score">${escapeHtml(score)}</span>
       </div>
-      <div class="pick-row2">
-        <span><span class="label">EXP</span><span class="num">${escapeHtml(p.expiration || "")}</span></span>
-        <span><span class="label">DTE</span><span class="num">${p.dte ?? "—"}</span></span>
-        <span><span class="label">CREDIT</span><span class="num">${credit}</span></span>
-        <span><span class="label">MAX LOSS</span><span class="num">${maxLoss}</span></span>
-        <span><span class="label">SHORT Δ</span><span class="num">${delta}</span></span>
-        ${p.sector ? `<span><span class="label">SECTOR</span>${escapeHtml(p.sector)}</span>` : ""}
-      </div>
+      ${row2Html}
       ${legsLine ? `<div class="pick-legs">${escapeHtml(legsLine)}</div>` : ""}
+      ${skewHTML}
       ${sizeHTML}
       ${p.summary_reason ? `<div class="pick-summary">${escapeHtml(p.summary_reason)}</div>` : ""}
     </div>
@@ -579,6 +636,8 @@ async function startScan() {
   setScanStatus("scanning", "starting…");
   const url = new URL("/api/scan/start", window.location.origin);
   for (const w of sel) url.searchParams.append("watchlists", w);
+  const struct = getScanStructure();
+  if (struct) url.searchParams.set("structure", struct);
   url.searchParams.set("token", TOKEN);
   try {
     const res = await fetch(url.toString(), { method: "POST" });
@@ -595,6 +654,13 @@ async function startScan() {
 }
 
 document.getElementById("scan-start-btn").addEventListener("click", startScan);
+
+// Re-poll status when the CSP toggle flips so the picks panel reflects the
+// cache for the new (account, watchlists, structure) key.
+const cspToggleEl = document.getElementById("scan-csp-toggle");
+if (cspToggleEl) {
+  cspToggleEl.addEventListener("change", () => pollScanStatus());
+}
 
 // --- Settings drawer ---
 

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -121,7 +121,16 @@ td.dte-stop { color: #f85149; font-weight: 600; }
   padding: 18px 12px; text-align: center; color: #7d8590; font-size: 12px;
 }
 
-.scan-actions { display: flex; align-items: center; gap: 12px; }
+.scan-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.scan-mode {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 13px; color: #c9d1d9; cursor: pointer; user-select: none;
+}
+.scan-mode input { accent-color: #1f6feb; }
+.pick-skew-warn {
+  margin-top: 6px; padding: 6px 8px; border-radius: 4px;
+  background: #4d0d10; color: #f0a4a8; font-size: 12px;
+}
 
 .picks-panel.hidden { display: none; }
 .picks-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }

--- a/server/templates/dashboard.html
+++ b/server/templates/dashboard.html
@@ -59,6 +59,9 @@
         </div>
         <div class="scan-actions">
           <button id="scan-start-btn" class="primary">Start scan</button>
+          <label class="scan-mode" title="Cash-secured-put screener (income-focused short puts ranked on income/buffer/POP/IV/time)">
+            <input type="checkbox" id="scan-csp-toggle"> CSPs only
+          </label>
           <span id="scan-status" class="scan-status idle">idle</span>
         </div>
         <div id="scan-other" class="scan-other"></div>

--- a/tests/test_server_scan_structure.py
+++ b/tests/test_server_scan_structure.py
@@ -1,0 +1,95 @@
+"""Tests for the structure query param threading through scan endpoints."""
+
+from __future__ import annotations
+
+import unittest
+
+import server.app as server_app
+
+
+class TestNormalizeStructure(unittest.TestCase):
+    def test_csp_alias_maps_to_canonical(self):
+        self.assertEqual(server_app._normalize_structure("csp"), "CASH_SECURED_PUT")
+        self.assertEqual(server_app._normalize_structure("CSP"), "CASH_SECURED_PUT")
+        self.assertEqual(server_app._normalize_structure(" csp "), "CASH_SECURED_PUT")
+
+    def test_canonical_passes_through(self):
+        self.assertEqual(
+            server_app._normalize_structure("CASH_SECURED_PUT"),
+            "CASH_SECURED_PUT",
+        )
+        self.assertEqual(
+            server_app._normalize_structure("cash_secured_put"),
+            "CASH_SECURED_PUT",
+        )
+
+    def test_none_and_empty_pass_through_as_none(self):
+        self.assertIsNone(server_app._normalize_structure(None))
+        self.assertIsNone(server_app._normalize_structure(""))
+        self.assertIsNone(server_app._normalize_structure("   "))
+
+    def test_unknown_alias_passes_through_unchanged(self):
+        # Unknown structure names go through verbatim — run_best_trades will
+        # reject them downstream rather than the alias mapping silently
+        # converting to None.
+        self.assertEqual(server_app._normalize_structure("unknown"), "unknown")
+
+
+class TestCacheKeyIncludesStructure(unittest.TestCase):
+    """_bt_key produces distinct keys for distinct (watchlists, structure) tuples."""
+
+    def test_same_watchlists_different_structure_different_key(self):
+        k_all = server_app._bt_key("ACCT", ["A", "B"], None)
+        k_csp = server_app._bt_key("ACCT", ["A", "B"], "csp")
+        self.assertNotEqual(k_all, k_csp)
+        self.assertEqual(k_all[2], None)
+        self.assertEqual(k_csp[2], "CASH_SECURED_PUT")
+
+    def test_watchlist_order_irrelevant(self):
+        k1 = server_app._bt_key("ACCT", ["A", "B"], "csp")
+        k2 = server_app._bt_key("ACCT", ["B", "A"], "csp")
+        self.assertEqual(k1, k2)
+
+    def test_structure_alias_normalized_in_key(self):
+        # "csp" and "CASH_SECURED_PUT" must produce the same key so the cache
+        # is hit regardless of caller spelling.
+        k1 = server_app._bt_key("ACCT", ["A"], "csp")
+        k2 = server_app._bt_key("ACCT", ["A"], "CASH_SECURED_PUT")
+        self.assertEqual(k1, k2)
+
+    def test_key_structure_helper_returns_third_element(self):
+        k = server_app._bt_key("ACCT", ["A"], "csp")
+        self.assertEqual(server_app._key_structure(k), "CASH_SECURED_PUT")
+        k_none = server_app._bt_key("ACCT", ["A"], None)
+        self.assertIsNone(server_app._key_structure(k_none))
+
+    def test_key_to_list_unaffected_by_structure(self):
+        k = server_app._bt_key("ACCT", ["B", "A"], "csp")
+        self.assertEqual(server_app._key_to_list(k), ["A", "B"])
+
+
+class TestSettingsGroupsIncludeNewKeys(unittest.TestCase):
+    """The dashboard settings editor must surface bt_per_trade_risk_dollars + bt_csp_*."""
+
+    def test_per_trade_risk_dollars_in_sizing_group(self):
+        sizing = next(g for g in server_app.SETTINGS_GROUPS if g["id"] == "sizing")
+        self.assertIn("bt_per_trade_risk_dollars", sizing["keys"])
+
+    def test_csp_group_present_with_all_keys(self):
+        groups_by_id = {g["id"]: g for g in server_app.SETTINGS_GROUPS}
+        self.assertIn("csp", groups_by_id)
+        csp_keys = set(groups_by_id["csp"]["keys"])
+        expected = {
+            "bt_csp_delta_min",
+            "bt_csp_delta_max",
+            "bt_csp_min_otm_pct",
+            "bt_csp_min_annualized_return",
+            "bt_csp_skew_warn_threshold",
+            "bt_csp_max_per_symbol",
+            "bt_csp_max_pct_nlv_per_trade",
+        }
+        self.assertEqual(csp_keys & expected, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Brings the dashboard up to parity with the CLI \`--put-selector\` and the \`bt_per_trade_risk_dollars\` override. The three gaps from the earlier audit are closed:

1. **CSP toggle** in the scan panel → \`?structure=csp\` plumbed through \`/api/scan/{start,status}\` and \`/api/briefing\`.
2. **CSP-specific pick rendering** (cash required, annualized return, OTM buffer, POP, premium/day) + put/call skew warning when ≥1.20.
3. **New settings keys** in the editor: \`bt_per_trade_risk_dollars\` in the sizing group; new "Cash-Secured Puts" group with all 7 \`bt_csp_*\` keys.

## Cache key change

\`CacheKey\` now includes structure as a third element: spread and CSP scans cache independently per (account, watchlists, structure). \`_normalize_structure\` maps UI aliases (\"csp\") to canonical names (\"CASH_SECURED_PUT\") so the cache hits regardless of spelling.

## Test plan

- [x] \`unittest discover tests\` — 599 tests, 594 passing. Same 5 pre-existing failures only.
- [x] 11 new tests cover alias normalisation, cache-key uniqueness, and settings-group membership.
- [x] Live boot smoke: dashboard HTML includes the toggle; \`/api/settings\` shows the new csp group; \`/api/scan/status?structure=csp\` returns canonical \"CASH_SECURED_PUT\".
- [ ] Manual UI smoke after merge: flip CSP toggle, click "Start scan", verify picks render with the new CSP fields and skew warning when triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)